### PR TITLE
Stop disabling scrolling on about page

### DIFF
--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -533,7 +533,6 @@ html, body {
 
 /* Restore body defaults for content pages that contain an <article> in <main id="content"> */
 body:has(main#content > article) {
-  height: auto;       /* Allow body to grow with content. */
   overflow-y: auto;   /* Enable vertical scrolling. */
   padding: 0;         /* Ensure body has no padding, so header can be full-width. */
 }


### PR DESCRIPTION
Not 100% sure this is the best fix, but currently the about page doesn't scroll vertically at all, and that's definitely not right. This can't be a problem with this theme generally (someone would have noticed before now) so something else weird is going on. Removing this line fixes it, but might break stuff elsewhere?