### PR TITLE
Adds gmaps and osm links to page titles

### DIFF
--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -1,7 +1,14 @@
 {{ define "main" }}
 <article>
     <header id="post-header">
-        <h1>{{ .Title }}</h1>
+        <h1>{{ .Title }}
+                {{ if .Params.lat }}
+                    &nbsp;
+                    <a href="http://maps.google.com/maps?z=12&t=m&q=loc:{{ .Params.lat }}+{{ .Params.lng }}" target="_blank" class="external-link" title="Google Maps"> <i class="fa-solid fa-map"></i></a>
+                    &nbsp;
+                    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=12/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i></a>
+                {{ end }}
+        </h1>
             <div>
             {{- if isset .Params "date" -}}
                 {{ if eq .Lastmod .Date }}


### PR DESCRIPTION
If a lat/lng is in the location front matter, then we add a link to google maps and openstreetmap to the title:

<img width="443" alt="image" src="https://github.com/user-attachments/assets/f24fc626-7c5b-4fcb-ad26-744e4316c5cc" />
