### PR TITLE
Add external link icon

### DIFF
--- a/content/daytrip/eu/gb/cole-museum-of-zoology.md
+++ b/content/daytrip/eu/gb/cole-museum-of-zoology.md
@@ -6,6 +6,7 @@ lng: '-0.944628'
 location: University of Reading - Whiteknights Campus, Pepper Lane, Earley, Reading,
   Wokingham, England, RG2 7DN, United Kingdom
 title: Cole Museum of Zoology
+external_url: https://collections.reading.ac.uk/cole-museum/
 ---
 
 

--- a/content/daytrip/eu/gb/witches-crag.md
+++ b/content/daytrip/eu/gb/witches-crag.md
@@ -5,6 +5,7 @@ lat: '56.151860561962785'
 lng: '-3.882293701171875'
 location: Hillfoots Road, Blairlogie, Stirling, Alba / Scotland, FK9 5PJ, United Kingdom
 title: Witches Crag
+external_url: https://www.visitscotland.com/info/accommodation/witches-craig-caravan-camping-park-p206221
 ---
 
 

--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -2,6 +2,10 @@
 <article>
     <header id="post-header">
         <h1>{{ .Title }}
+            {{ if .Params.external_url }}
+                &nbsp;
+                <a href="{{ .Params.external_url }}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+            {{ end }}
                 {{ if .Params.lat }}
                     &nbsp;
                     <a href="http://maps.google.com/maps?z=12&t=m&q=loc:{{ .Params.lat }}+{{ .Params.lng }}" target="_blank" class="external-link" title="Google Maps"> <i class="fa-solid fa-map"></i></a>


### PR DESCRIPTION
If sites have `external_url` set, then we add a link to the header of a page:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/0d6929e4-6005-444a-a7fd-7b2904cd748b" />
