### PR TITLE
Increase zoom level for OSM

### DIFF
--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -10,7 +10,7 @@
                     &nbsp;
                     <a href="http://maps.google.com/maps?z=12&t=m&q=loc:{{ .Params.lat }}+{{ .Params.lng }}" target="_blank" class="external-link" title="Google Maps"> <i class="fa-solid fa-map"></i></a>
                     &nbsp;
-                    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=12/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i></a>
+                    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i></a>
                 {{ end }}
         </h1>
             <div>


### PR DESCRIPTION
Each page has generated OSM and GMaps links.
The OSM default zoom level (12) was too far out to be useful, and didn't match the zoom level on GMaps. So I have zoomed it in a lot more, which seems more useful.