### PR TITLE
Maps url was brokeon on mobile fixes #32

### DIFF
--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -8,7 +8,7 @@
             {{ end }}
                 {{ if .Params.lat }}
                     &nbsp;
-                    <a href="http://maps.google.com/maps?z=12&t=m&q=loc:{{ .Params.lat }}+{{ .Params.lng }}" target="_blank" class="external-link" title="Google Maps"> <i class="fa-solid fa-map"></i></a>
+                    <a href="https://www.google.com/maps?ll={{ .Params.lat }},{{ .Params.lng }}&q={{ .Params.lat }},{{ .Params.lng }}&hl=en&t=m&z=15" target="_blank" class="external-link" title="Google Maps"><i class="fa-solid fa-map"></i></a>
                     &nbsp;
                     <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i></a>
                 {{ end }}


### PR DESCRIPTION
Change url to something that works consistently on desktop and mobile (when gmaps app is installed).