### PR TITLE
Shuffle map links around

### DIFF
--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -1,17 +1,13 @@
 {{ define "main" }}
 <article>
     <header id="post-header">
-        <h1>{{ .Title }}
+        <h1>                {{ if .Params.lat }}
+                    &nbsp;
+                    <a href="/#{{ .Params.slug }}" title="Show {{ .Title }} on the map"><i class="fa-solid fa-map-location-dot"></i></a>{{ end }}&nbsp;{{ .Title }}
             {{ if .Params.external_url }}
                 &nbsp;
                 <a href="{{ .Params.external_url }}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
             {{ end }}
-                {{ if .Params.lat }}
-                    &nbsp;
-                    <a href="https://www.google.com/maps?ll={{ .Params.lat }},{{ .Params.lng }}&q={{ .Params.lat }},{{ .Params.lng }}&hl=en&t=m&z=15" target="_blank" class="external-link" title="Google Maps"><i class="fa-solid fa-map"></i></a>
-                    &nbsp;
-                    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i></a>
-                {{ end }}
         </h1>
             <div>
                 <!-- Created Date -->
@@ -35,11 +31,15 @@
                 {{- end }}
             </div>
     </header>
-    <p><a href="/#{{ .Params.slug }}">Show {{ .Title }} on the map</a></p>
     <hr>
     {{- .Content -}}
 </article>
 <hr>
+{{ if .Params.lat }}
+    <a href="https://www.google.com/maps?ll={{ .Params.lat }},{{ .Params.lng }}&q={{ .Params.lat }},{{ .Params.lng }}&hl=en&t=m&z=15" target="_blank" class="external-link" title="Google Maps"><i class="fa-solid fa-map"></i> Open in Google Maps</a>
+    <br>
+    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i> Open in OpenStreetMap</a>
+{{ end }}
 {{ partial "repository-link.html" (dict "action" "edit" "page" .) }}
 {{ partial "repository-link.html" (dict "action" "view" "page" .) }}
 {{ end }}

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
             map.flyTo([lat, lng], 19);
         }
         const icon = document.createElement("i");
-        icon.className = "fa-solid fa-location-pin";
+        icon.className = "fa-solid fa-map-location-dot";
         button.append(icon);
         a.parentNode.insertBefore(button, a.nextElementSibling);
     })


### PR DESCRIPTION
Prioritize link to our map on venue pages, and move external links down to the footer.