### PR TITLE
New: British Lawnmower Museum

### DIFF
--- a/content/daytrip/eu/gb/british-lawnmower-museum.md
+++ b/content/daytrip/eu/gb/british-lawnmower-museum.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/eu/gb/british-lawnmower-museum'
+date: '2025-05-29T09:32:47.305Z'
+lat: '53.6391054'
+lng: '-3.0054189'
+location: '106-114 Shakespeare St, Southport PR8 5AJ'
+title: 'British Lawnmower Museum'
+external_url: https://www.lawnmowerworld.co.uk/
+---
+(From their website)
+
+The British Lawnmover Museum is one of the Worlds leading authorities on vintage lawnmowers and are now specialists in antique garden machinery, supplying parts, archive conservation of manuscript materials and valuing machines from all over the world. See 'Lawnmowers of the Rich and Famous' including Prince Charles and Princess Diana, Brian May, Nicholas Parsons, Eric Morcambe, Hilda Ogden, Alan Titchmarsh and many more.


### PR DESCRIPTION
## New Venue Submission

**Venue:** British Lawnmower Museum
**Location:** 106-114 Shakespeare St, Southport PR8 5AJ
**Submitted by:** M6WIQ
**Website:** https://www.lawnmowerworld.co.uk/

### Description
(From their website)

The British Lawnmover Museum is one of the Worlds leading authorities on vintage lawnmowers and are now specialists in antique garden machinery, supplying parts, archive conservation of manuscript materials and valuing machines from all over the world. See 'Lawnmowers of the Rich and Famous' including Prince Charles and Princess Diana, Brian May, Nicholas Parsons, Eric Morcambe, Hilda Ogden, Alan Titchmarsh and many more.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 4
**File:** `content/daytrip/eu/gb/british-lawnmower-museum.md`

Please review this venue submission and edit the content as needed before merging.