### PR TITLE
New: MathsCity

### DIFF
--- a/content/daytrip/eu/gb/mathscity.md
+++ b/content/daytrip/eu/gb/mathscity.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/mathscity'
+date: '2025-05-29T09:47:42.924Z'
+lng: '-1.5460432'
+lat: '53.7968822'
+location: 'Upper Floor, Trinity, Shopping Centre, Leeds LS1 5AT'
+title: 'MathsCity'
+external_url: https://mathscity.co.uk/
+---
+MathsCity is a hands-on maths activity centre, with puzzles, toys, a giant kaleidoscope and a human-sized bubble maker, as well as codebreaking activities, mathematical demonstrations and extra activities run during the holidays.


### PR DESCRIPTION
## New Venue Submission

**Venue:** MathsCity
**Location:** Upper Floor, Trinity, Shopping Centre, Leeds LS1 5AT
**Submitted by:** Katie Steckles
**Website:** https://mathscity.co.uk/

### Description
MathsCity is a hands-on maths activity centre, with puzzles, toys, a giant kaleidoscope and a human-sized bubble maker, as well as codebreaking activities, mathematical demonstrations and extra activities run during the holidays.

### Review Checklist
- [x] Verify the venue information is accurate
- [x] Check that the location coordinates are correct
- [x] Ensure the description is appropriate and well-written
- [x] Confirm the external website link works
- [x] Review the generated slug and front matter

**Submission ID:** 7
**File:** `content/daytrip/eu/gb/mathscity.md`

Please review this venue submission and edit the content as needed before merging.