### PR TITLE
New: Baston Lodge; childhood home of Alan Turing

### DIFF
--- a/content/daytrip/eu/gb/baston-lodge.md
+++ b/content/daytrip/eu/gb/baston-lodge.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/baston-lodge'
+date: '2025-05-29T10:22:11.313Z'
+lat: '50.855136'
+lng: '0.553147'
+location: '1 Upper Maze Hill, St Leonards-on-Sea, Hastings, East Sussex'
+title: 'Baston Lodge; childhood home of Alan Turing'
+external_url: https://en.wikipedia.org/wiki/Baston_Lodge
+---
+The house in which Alan Turing resided with his brother John as wards, while their parents were stationed abroad in the Indian Civil Service.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Baston Lodge; childhood home of Alan Turing
**Location:** 1 Upper Maze Hill, St Leonards-on-Sea, Hastings, East Sussex
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://en.wikipedia.org/wiki/Baston_Lodge

### Description
The house in which Alan Turing resided with his brother John as wards, while their parents were stationed abroad in the Indian Civil Service.

### Review Checklist
- [x] Verify the venue information is accurate
- [x] Check that the location coordinates are correct
- [x] Ensure the description is appropriate and well-written
- [x] Confirm the external website link works
- [x] Review the generated slug and front matter

**Submission ID:** 9
**File:** `content/daytrip/eu/gb/baston-lodge.md`

Please review this venue submission and edit the content as needed before merging.