### PR TITLE
New: Orford Ness

### DIFF
--- a/content/daytrip/eu/gb/orford-ness.md
+++ b/content/daytrip/eu/gb/orford-ness.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/orford-ness'
+date: '2025-05-29T10:23:04.414Z'
+lat: '52.086046'
+lng: '1.556797'
+location: 'Quay Street, Orford, Suffolk, IP12 2NU'
+title: 'Orford Ness'
+external_url: https://www.nationaltrust.org.uk/visit/suffolk/orford-ness-national-nature-reserve
+---
+An ex Ministry of Defence testing ground for weapons testing, radar, and atomic weapons development. Includes old bunkers, abandoned weapons labs, and lovely coastal scenery. Access by boat, check ahead for opening times.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Orford Ness
**Location:** Quay Street, Orford, Suffolk, IP12 2NU
**Submitted by:** Floppy
**Website:** https://www.nationaltrust.org.uk/visit/suffolk/orford-ness-national-nature-reserve

### Description
An ex Ministry of Defence testing ground for weapons testing, radar, and atomic weapons development. Includes old bunkers, abandoned weapons labs, and lovely coastal scenery. Access by boat, check ahead for opening times.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 10
**File:** `content/daytrip/eu/gb/orford-ness.md`

Please review this venue submission and edit the content as needed before merging.