### PR TITLE
New: Rendlesham UFO Landing Site

### DIFF
--- a/content/daytrip/eu/gb/rendlesham-ufo-landing-site.md
+++ b/content/daytrip/eu/gb/rendlesham-ufo-landing-site.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/rendlesham-ufo-landing-site'
+date: '2025-05-29T10:23:54.212Z'
+lat: '52.089844'
+lng: '1.448779'
+location: 'Rendlesham Forest, Tangham, Woodbridge, IP12 3NF'
+title: 'Rendlesham UFO Landing Site'
+external_url: https://www.forestryengland.uk/rendlesham-forest/ufo-trail-rendlesham-forest
+---
+A short woodland walk to a sculpture commemorating the Rendlesham UFO Incident in 1980.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Rendlesham UFO Landing Site
**Location:** Rendlesham Forest, Tangham, Woodbridge, IP12 3NF
**Submitted by:** Floppy
**Website:** https://www.forestryengland.uk/rendlesham-forest/ufo-trail-rendlesham-forest

### Description
A short woodland walk to a sculpture commemorating the Rendlesham UFO Incident in 1980.

### Review Checklist
- [x] Verify the venue information is accurate
- [x] Check that the location coordinates are correct
- [x] Ensure the description is appropriate and well-written
- [x] Confirm the external website link works
- [x] Review the generated slug and front matter

**Submission ID:** 11
**File:** `content/daytrip/eu/gb/rendlesham-ufo-landing-site.md`

Please review this venue submission and edit the content as needed before merging.