### PR TITLE
New: The Monterey Bay Aquarium

### DIFF
--- a/content/daytrip/na/us/the-monterey-bay-aquarium.md
+++ b/content/daytrip/na/us/the-monterey-bay-aquarium.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/na/us/the-monterey-bay-aquarium'
+date: '2025-05-29T10:39:58.928Z'
+lat: '36.617922'
+lng: '-121.901797'
+location: '886 Cannery Row, Monterey, CA 93940, United States'
+title: 'The Monterey Bay Aquarium'
+external_url: https://www.montereybayaquarium.org/
+---
+A world class aquarium in its own right, Star Trek fans will recognise this as the location of the Cetacean Institute from Star Trek IV: The Voyage Home.
+
+Sadly, the whale exhibit is no longer here after their mysterious release in 1986.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Monterey Bay Aquarium
**Location:** 886 Cannery Row, Monterey, CA 93940, United States
**Submitted by:** JohnD
**Website:** https://www.montereybayaquarium.org/

### Description
A world class aquarium in its own right, Star Trek fans will recognise this as the location of the Cetacean Institute from Star Trek IV: The Voyage Home.

Sadly, the whale exhibit is no longer here after their mysterious release in 1986.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 13
**File:** `content/daytrip/na/us/the-monterey-bay-aquarium.md`

Please review this venue submission and edit the content as needed before merging.