### PR TITLE
New: Riverside Museum

### DIFF
--- a/content/daytrip/eu/gb/riverside-museum.md
+++ b/content/daytrip/eu/gb/riverside-museum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/riverside-museum'
+date: '2025-05-29T11:03:18.117Z'
+lat: '55.865102'
+lng: '-4.305589'
+location: '100 Pointhouse Rd, Glasgow G3 8RS'
+title: 'Riverside Museum'
+external_url: https://www.glasgowlife.org.uk/museums/venues/riverside-museum
+---
+Modern transport museum, mostly focused on Glasgow/Scotland, featuring vehicles from throughout the 20th century.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Riverside Museum
**Location:** 100 Pointhouse Rd, Glasgow G3 8RS
**Submitted by:** Alicolliar
**Website:** https://www.glasgowlife.org.uk/museums/venues/riverside-museum

### Description
Modern transport museum, mostly focused on Glasgow/Scotland, featuring vehicles from throughout the 20th century.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 15
**File:** `content/daytrip/eu/gb/riverside-museum.md`

Please review this venue submission and edit the content as needed before merging.