### PR TITLE
New: Chasewater Railway

### DIFF
--- a/content/daytrip/eu/gb/chasewater-railway.md
+++ b/content/daytrip/eu/gb/chasewater-railway.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/chasewater-railway'
+date: '2025-05-29T11:03:33.590Z'
+lat: '52.662563'
+lng: '-1.952949'
+location: 'Chasewater Country Park, Brownhills West Station, Pool Lane, Brownhills, Staffordshire, WS8 7NL'
+title: 'Chasewater Railway'
+external_url: https://www.chasewaterrailway.co.uk/
+---
+A 4-mile heritage railway run by volunteers in the Chasewater Country Park. It has four stops, with two stations running a tea room, a cafe, a Model Railway and Gift Shop.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Chasewater Railway
**Location:** Chasewater Country Park, Brownhills West Station, Pool Lane, Brownhills, Staffordshire, WS8 7NL
**Submitted by:** theaardvark
**Website:** https://www.chasewaterrailway.co.uk/

### Description
A 4-mile heritage railway run by volunteers in the Chasewater Country Park. It has four stops, with two stations running a tea room, a cafe, a Model Railway and Gift Shop.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 16
**File:** `content/daytrip/eu/gb/chasewater-railway.md`

Please review this venue submission and edit the content as needed before merging.