### PR TITLE
New: Crofton Pumping Station

### DIFF
--- a/content/daytrip/eu/gb/crofton-pumping-station.md
+++ b/content/daytrip/eu/gb/crofton-pumping-station.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/crofton-pumping-station'
+date: '2025-05-29T11:12:22.849Z'
+lat: '51.358878'
+lng: '-1.625869'
+location: 'Crofton Beam Engines, Crofton, Marlborough, Wiltshire, SN8 3DW'
+title: 'Crofton Pumping Station'
+external_url: https://www.croftonbeamengines.org/about/
+---
+The oldest beam engine still in its original location -- made in 1812. Filling the top pound of the Kennet and Avon Canal, the engine still pumps water to the canal on steaming days.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Crofton Pumping Station
**Location:** Crofton Beam Engines, Crofton, Marlborough, Wiltshire, SN8 3DW
**Submitted by:** Hugo
**Website:** https://www.croftonbeamengines.org/about/

### Description
The oldest beam engine still in its original location -- made in 1812. Filling the top pound of the Kennet and Avon Canal, the engine still pumps water to the canal on steaming days.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 17
**File:** `content/daytrip/eu/gb/crofton-pumping-station.md`

Please review this venue submission and edit the content as needed before merging.