### PR TITLE
New: Leeds Industrial Museum

### DIFF
--- a/content/daytrip/eu/gb/leeds-industrial-museum.md
+++ b/content/daytrip/eu/gb/leeds-industrial-museum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/leeds-industrial-museum'
+date: '2025-05-29T11:12:59.803Z'
+lat: '53.8029'
+lng: '-1.58288'
+location: 'Canal Road, Leeds, LS12 1QF'
+title: 'Leeds Industrial Museum'
+external_url: https://museumsandgalleries.leeds.gov.uk/pQKYcJ/leeds-industrial-museum/home
+---
+Leeds Industrial Museum started life as a woollen mill, and you'll certainly find some impressive machinery related to spinning wool here, but the collections now its a museum go much further than that, covering engineering, railways, a steam engine to power the mill and cinema history (don't believe what anyone else says - it was invented in Leeds!)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Leeds Industrial Museum
**Location:** Canal Road, Leeds, LS12 1QF
**Submitted by:** Nav
**Website:** https://museumsandgalleries.leeds.gov.uk/pQKYcJ/leeds-industrial-museum/home

### Description
Leeds Industrial Museum started life as a woollen mill, and you'll certainly find some impressive machinery related to spinning wool here, but the collections now its a museum go much further than that, covering engineering, railways, a steam engine to power the mill and cinema history (don't believe what anyone else says - it was invented in Leeds!)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 18
**File:** `content/daytrip/eu/gb/leeds-industrial-museum.md`

Please review this venue submission and edit the content as needed before merging.