### PR TITLE
New: Woolwich foot tunnel

### DIFF
--- a/content/daytrip/eu/gb/woolwich-foot-tunnel.md
+++ b/content/daytrip/eu/gb/woolwich-foot-tunnel.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/woolwich-foot-tunnel'
+date: '2025-05-29T11:26:34.679Z'
+lat: '51.496267'
+lng: '0.062313'
+location: 'Glass Yard, Woolwich, London'
+title: 'Woolwich foot tunnel'
+external_url: https://www.royalgreenwich.gov.uk/parking-transport-and-streets/travel-foot-bike-or-public-transport/check-status-foot-tunnels-and
+---
+Opened in 1912, the Woolwich Foot Tunnel remains the longest pedestrian tunnel under the River Thames at slightly over half a kilometre end to end.  Access is near the Woolwich Ferry piers on the north and south banks of the river.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Woolwich foot tunnel
**Location:** Glass Yard, Woolwich, London
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://www.royalgreenwich.gov.uk/parking-transport-and-streets/travel-foot-bike-or-public-transport/check-status-foot-tunnels-and

### Description
Opened in 1912, the Woolwich Foot Tunnel remains the longest pedestrian tunnel under the River Thames at slightly over half a kilometre end to end.  Access is near the Woolwich Ferry piers on the north and south banks of the river.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 20
**File:** `content/daytrip/eu/gb/woolwich-foot-tunnel.md`

Please review this venue submission and edit the content as needed before merging.