### PR TITLE
New: Clifton Observatory

### DIFF
--- a/content/daytrip/eu/gb/clifton-observatory.md
+++ b/content/daytrip/eu/gb/clifton-observatory.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/eu/gb/clifton-observatory'
+date: '2025-05-29T11:59:06.881Z'
+lat: '51.456599'
+lng: '-2.626483'
+location: 'Litfield Place, Clifton, Bristol BS8 3LT'
+title: 'Clifton Observatory'
+external_url: https://cliftonobservatory.com
+---
+A camera obscura with views across the Bristol skyline, built in the tower of the old Bristol Observatory. Has displays of the history of the observatory, and a rooftop cafe with a spectacular view over Bristol and the Clifton Suspension Bridge.
+
+Also the entrance to Ghyston's Cave, which opens in the side of the Avon gorge, giving a lower view of the suspension bridge and gorge.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Clifton Observatory
**Location:** Litfield Place, Clifton, Bristol BS8 3LT
**Submitted by:** Hugo
**Website:** https://cliftonobservatory.com

### Description
A camera obscura with views across the Bristol skyline, built in the tower of the old Bristol Observatory. Has displays of the history of the observatory, and a rooftop cafe with a spectacular view over Bristol and the Clifton Suspension Bridge.

Also the entrance to Ghyston's Cave, which opens in the side of the Avon gorge, giving a lower view of the suspension bridge and gorge.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 29
**File:** `content/daytrip/eu/gb/clifton-observatory.md`

Please review this venue submission and edit the content as needed before merging.