### PR TITLE
New: Anthorn Radio Station

### DIFF
--- a/content/daytrip/eu/gb/anthorn-radio-station.md
+++ b/content/daytrip/eu/gb/anthorn-radio-station.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/anthorn-radio-station'
+date: '2025-05-29T11:59:33.131Z'
+lat: '54.911578'
+lng: '-3.278421'
+location: 'Bowness Common, Bowness, Anthorn, Cumberland, England, CA7 5AN'
+title: 'Anthorn Radio Station'
+external_url: https://www.npl.co.uk/msf-signal
+---
+Anthorn is where the UK's atomic clock radio signal is broadcast from.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Anthorn Radio Station
**Location:** Bowness Common, Bowness, Anthorn, Cumberland, England, CA7 5AN
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://www.npl.co.uk/msf-signal

### Description
Anthorn is where the UK's atomic clock radio signal is broadcast from.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 28
**File:** `content/daytrip/eu/gb/anthorn-radio-station.md`

Please review this venue submission and edit the content as needed before merging.