### PR TITLE
New: Stott Park Bobbin Mill

### DIFF
--- a/content/daytrip/eu/gb/stott-park-bobbin-mill.md
+++ b/content/daytrip/eu/gb/stott-park-bobbin-mill.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/stott-park-bobbin-mill'
+date: '2025-05-29T12:01:24.980Z'
+lat: '54.2852440898436'
+lng: '-2.96529528522713'
+location: 'Finsthwaite, Ulverston, Cumbria, LA12 8AX '
+title: 'Stott Park Bobbin Mill'
+external_url: https://www.english-heritage.org.uk/visit/places/stott-park-bobbin-mill/
+---
+An original bobbin mill with working machinery from the 1870s. Incredibly, was in operation using this machinery right up until the 1960s. Book a guided tour to view the mill, including firing up the machines, and you can freely explore the acres of woodland surrounding it.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Stott Park Bobbin Mill
**Location:** Finsthwaite, Ulverston, Cumbria, LA12 8AX 
**Submitted by:** Sarah Dal
**Website:** https://www.english-heritage.org.uk/visit/places/stott-park-bobbin-mill/

### Description
An original bobbin mill with working machinery from the 1870s. Incredibly, was in operation using this machinery right up until the 1960s. Book a guided tour to view the mill, including firing up the machines, and you can freely explore the acres of woodland surrounding it.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 30
**File:** `content/daytrip/eu/gb/stott-park-bobbin-mill.md`

Please review this venue submission and edit the content as needed before merging.