### PR TITLE
New: Historisch-Technisches Museum Peenemünde

### DIFF
--- a/content/daytrip/eu/de/historisch-technisches-museum-peenemnde.md
+++ b/content/daytrip/eu/de/historisch-technisches-museum-peenemnde.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/de/historisch-technisches-museum-peenemnde'
+date: '2025-05-29T12:01:55.012Z'
+lat: '54.137822'
+lng: '13.7689689'
+location: 'Im Kraftwerk, 17449 Peenemünde'
+title: 'Historisch-Technisches Museum Peenemünde'
+external_url: https://museum-peenemuende.de/
+---
+Where Wernherr von Braun, during World War II, developed German rocket weapons that led directly into the US space program, ICBMs etc.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Historisch-Technisches Museum Peenemünde
**Location:** Im Kraftwerk, 17449 Peenemünde
**Submitted by:** pesco
**Website:** https://museum-peenemuende.de/

### Description
Where Wernherr von Braun, during World War II, developed German rocket weapons that led directly into the US space program, ICBMs etc.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 34
**File:** `content/daytrip/eu/de/historisch-technisches-museum-peenemnde.md`

Please review this venue submission and edit the content as needed before merging.