### PR TITLE
New: Arithmeum

### DIFF
--- a/content/daytrip/eu/de/arithmeum.md
+++ b/content/daytrip/eu/de/arithmeum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/de/arithmeum'
+date: '2025-05-29T12:03:17.378Z'
+lat: '50.730765'
+lng: '7.104726'
+location: 'Lennéstr. 2, 53113 Bonn'
+title: 'Arithmeum'
+external_url: https://www.arithmeum.uni-bonn.de/en/arithmeum.html
+---
+A museum of calculation tools, with several replicas with instructions for you to try out.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Arithmeum
**Location:** Lennéstr. 2, 53113 Bonn
**Submitted by:** Aesdeef
**Website:** https://www.arithmeum.uni-bonn.de/en/arithmeum.html

### Description
A museum of calculation tools, with several replicas with instructions for you to try out.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 31
**File:** `content/daytrip/eu/de/arithmeum.md`

Please review this venue submission and edit the content as needed before merging.