### PR TITLE
New: Scheunenwindmühle Saalow

### DIFF
--- a/content/daytrip/eu/de/scheunenwindmhle-saalow.md
+++ b/content/daytrip/eu/de/scheunenwindmhle-saalow.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/scheunenwindmhle-saalow'
+date: '2025-05-29T12:03:50.533Z'
+lat: '52.194893'
+lng: '13.378043'
+location: 'Scheunenwindmühle Saalow, Dorfaue Saalow, Saalow, Am Mellensee, Teltow-Fläming, Brandenburg, 15838, Deutschland'
+title: 'Scheunenwindmühle Saalow'
+external_url: https://scheunenwindmuehle.de/
+---
+A historic and one of a kind windmill built inside a barn. The barn doors open to reveal a wooden turbine that powers the milling mechanism. The windmill is maintained by volunteers.
+Tours for groups are available on special days and upon request. For more information see website. Wheelchair access is limited. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Scheunenwindmühle Saalow
**Location:** Scheunenwindmühle Saalow, Dorfaue Saalow, Saalow, Am Mellensee, Teltow-Fläming, Brandenburg, 15838, Deutschland
**Submitted by:** PizzaTreeIsland
**Website:** https://scheunenwindmuehle.de/

### Description
A historic and one of a kind windmill built inside a barn. The barn doors open to reveal a wooden turbine that powers the milling mechanism. The windmill is maintained by volunteers.
Tours for groups are available on special days and upon request. For more information see website. Wheelchair access is limited. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 27
**File:** `content/daytrip/eu/de/scheunenwindmhle-saalow.md`

Please review this venue submission and edit the content as needed before merging.