### PR TITLE
New: The MAD Museum (Mechanical Art and Design)

### DIFF
--- a/content/daytrip/eu/gb/the-mad-museum-mechanical-art-and-design.md
+++ b/content/daytrip/eu/gb/the-mad-museum-mechanical-art-and-design.md
@@ -1,0 +1,14 @@
+---
+slug: 'daytrip/eu/gb/the-mad-museum-mechanical-art-and-design'
+date: '2025-05-29T12:04:41.582Z'
+lat: '52.193061'
+lng: '-1.706931'
+location: 'Henley Street, Stratford-upon-Avon, Warwickshire. CV37 6PT.'
+title: 'The MAD Museum (Mechanical Art and Design)'
+external_url: https://themadmuseum.co.uk
+---
+The MAD Museum (Mechanical Art and Design) is a wonderfully eccentric attraction located in the heart of Stratford-upon-Avon. 
+
+The museum showcases a collection of interactive mechanical art, with a focus on kinetic sculptures and automata.
+
+Imagine the imaginative contraptions from Wallace and Gromit, the creativity of Scrapheap Challenge or the whimsical inventions in Chitty Chitty Bang Bang and you're half way there.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The MAD Museum (Mechanical Art and Design)
**Location:** Henley Street, Stratford-upon-Avon, Warwickshire. CV37 6PT.
**Submitted by:** NAB
**Website:** https://themadmuseum.co.uk

### Description
The MAD Museum (Mechanical Art and Design) is a wonderfully eccentric attraction located in the heart of Stratford-upon-Avon. 

The museum showcases a collection of interactive mechanical art, with a focus on kinetic sculptures and automata.

Imagine the imaginative contraptions from Wallace and Gromit, the creativity of Scrapheap Challenge or the whimsical inventions in Chitty Chitty Bang Bang and you're half way there.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 35
**File:** `content/daytrip/eu/gb/the-mad-museum-mechanical-art-and-design.md`

Please review this venue submission and edit the content as needed before merging.