### PR TITLE
New: Home computer museum

### DIFF
--- a/content/daytrip/eu/nl/home-computer-museum.md
+++ b/content/daytrip/eu/nl/home-computer-museum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/nl/home-computer-museum'
+date: '2025-05-29T12:06:09.871Z'
+lat: '51.479705'
+lng: '5.65806'
+location: 'Noord Koninginnewal 28, Helmond, NL'
+title: 'Home computer museum'
+external_url: https://www.homecomputermuseum.nl/
+---
+Interactive museum of home computers from the 1970's, 80's and 90's. Many exotic models, many in working condition, and a lot that you can actually try out and use to program some lines of BASIC, or play games from Pacman to Unreal Tournament.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Home computer museum
**Location:** Noord Koninginnewal 28, Helmond, NL
**Submitted by:** GolezTrol
**Website:** https://www.homecomputermuseum.nl/

### Description
Interactive museum of home computers from the 1970's, 80's and 90's. Many exotic models, many in working condition, and a lot that you can actually try out and use to program some lines of BASIC, or play games from Pacman to Unreal Tournament.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 24
**File:** `content/daytrip/eu/nl/home-computer-museum.md`

Please review this venue submission and edit the content as needed before merging.