### PR TITLE
New: The UK's most inland point

### DIFF
--- a/content/daytrip/eu/gb/the-uks-most-inland-point.md
+++ b/content/daytrip/eu/gb/the-uks-most-inland-point.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/the-uks-most-inland-point'
+date: '2025-05-29T12:06:43.113Z'
+lat: '52.726725'
+lng: '-1.620011'
+location: 'Swadlingcote, Derbyshire'
+title: 'The UK's most inland point'
+external_url: http://news.bbc.co.uk/1/hi/england/derbyshire/3090539.stm
+---
+Don't pester the farm residents, but this point is the furthest one can get from the sea in all directions - the most inland point - in Great Britain, approximately 70 miles from The Wash.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The UK's most inland point
**Location:** Swadlingcote, Derbyshire
**Submitted by:** Cain Mosni aka Camopants
**Website:** http://news.bbc.co.uk/1/hi/england/derbyshire/3090539.stm

### Description
Don't pester the farm residents, but this point is the furthest one can get from the sea in all directions - the most inland point - in Great Britain, approximately 70 miles from The Wash.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 26
**File:** `content/daytrip/eu/gb/the-uks-most-inland-point.md`

Please review this venue submission and edit the content as needed before merging.