### PR TITLE
New: Parque de las Ciencias Andalucía

### DIFF
--- a/content/daytrip/zz/gd/parque-de-las-ciencias-andaluca.md
+++ b/content/daytrip/zz/gd/parque-de-las-ciencias-andaluca.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/zz/gd/parque-de-las-ciencias-andaluca'
+date: '2025-05-29T12:10:58.165Z'
+lat: '37.162685'
+lng: '-3.605801'
+location: 'Av. de la Ciencia, s/n, Ronda, 18006 Granada'
+title: 'Parque de las Ciencias Andalucía'
+external_url: https://www.parqueciencias.com
+---
+Small but well-formed science museum. Includes the Biodome, with exhibits of animals living in constructed habitats.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Parque de las Ciencias Andalucía
**Location:** Av. de la Ciencia, s/n, Ronda, 18006 Granada
**Submitted by:** Hugo
**Website:** https://www.parqueciencias.com

### Description
Small but well-formed science museum. Includes the Biodome, with exhibits of animals living in constructed habitats.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 23
**File:** `content/daytrip/zz/gd/parque-de-las-ciencias-andaluca.md`

Please review this venue submission and edit the content as needed before merging.