### PR TITLE
New: Carnglaze Caverns

### DIFF
--- a/content/daytrip/eu/gb/carnglaze-caverns.md
+++ b/content/daytrip/eu/gb/carnglaze-caverns.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/carnglaze-caverns'
+date: '2025-05-29T12:12:07.344Z'
+lat: '50.472443'
+lng: '-4.55658'
+location: 'Carnglaze Caverns, St Neot, Liskeard, Cornwall, PL14 6HQ'
+title: 'Carnglaze Caverns'
+external_url: https://www.carnglaze.com
+---
+A pair of artificial caves, made by mining slate. The upper cavern is used for events (concerts, weddings). The lower cavern has a lake (which is actually a flooded third cavern).


### PR DESCRIPTION
## New Venue Submission

**Venue:** Carnglaze Caverns
**Location:** Carnglaze Caverns, St Neot, Liskeard, Cornwall, PL14 6HQ
**Submitted by:** Hugo
**Website:** https://www.carnglaze.com

### Description
A pair of artificial caves, made by mining slate. The upper cavern is used for events (concerts, weddings). The lower cavern has a lake (which is actually a flooded third cavern).

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 37
**File:** `content/daytrip/eu/gb/carnglaze-caverns.md`

Please review this venue submission and edit the content as needed before merging.