### PR TITLE
New: Woodhorn Museum

### DIFF
--- a/content/daytrip/eu/gb/woodhorn-museum.md
+++ b/content/daytrip/eu/gb/woodhorn-museum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/woodhorn-museum'
+date: '2025-05-29T12:24:48.392Z'
+lat: '55.189159'
+lng: '-1.547012'
+location: 'Woodhorn Museum, Queen Elizabeth II Country Park, Ashington, Northumberland NE63 9YF'
+title: 'Woodhorn Museum'
+external_url: https://museumsnorthumberland.org.uk/woodhorn-museum/
+---
+A mining museum at a former colliery, one of the last deep pits to operate in the UK. As well as the industrial history of the region, the site also has an excellent programme of arts and events, hosts the County Archives, and nearby Woodhorn Colliery Railway through the Country Park is currently in restoration (as of May 2025)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Woodhorn Museum
**Location:** Woodhorn Museum, Queen Elizabeth II Country Park, Ashington, Northumberland NE63 9YF
**Submitted by:** Sarah Dal
**Website:** https://museumsnorthumberland.org.uk/woodhorn-museum/

### Description
A mining museum at a former colliery, one of the last deep pits to operate in the UK. As well as the industrial history of the region, the site also has an excellent programme of arts and events, hosts the County Archives, and nearby Woodhorn Colliery Railway through the Country Park is currently in restoration (as of May 2025)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 41
**File:** `content/daytrip/eu/gb/woodhorn-museum.md`

Please review this venue submission and edit the content as needed before merging.