### PR TITLE
New: Imber Village

### DIFF
--- a/content/daytrip/eu/gb/imber-village.md
+++ b/content/daytrip/eu/gb/imber-village.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/eu/gb/imber-village'
+date: '2025-05-29T12:48:16.890Z'
+lat: '51.236129'
+lng: '-2.050667'
+location: 'Imber, Wiltshire, United Kingdom'
+title: 'Imber Village'
+external_url: https://www.imbervillage.co.uk
+---
+Placed right in the middle of Salisbury Plain, Imber was turned into a training centre for American troops in 1943. All of the inhabitants of the village were ejected with only a few weeks notice, and the village has remained uninhabited ever since. It is still used as a training ground for the British armed forces.
+
+Once or twice a year, the village is opened to the public, and tours are available.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Imber Village
**Location:** Imber, Wiltshire, United Kingdom
**Submitted by:** Hugo
**Website:** https://www.imbervillage.co.uk

### Description
Placed right in the middle of Salisbury Plain, Imber was turned into a training centre for American troops in 1943. All of the inhabitants of the village were ejected with only a few weeks notice, and the village has remained uninhabited ever since. It is still used as a training ground for the British armed forces.

Once or twice a year, the village is opened to the public, and tours are available.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 46
**File:** `content/daytrip/eu/gb/imber-village.md`

Please review this venue submission and edit the content as needed before merging.