### PR TITLE
New: Old Sarum

### DIFF
--- a/content/daytrip/eu/gb/old-sarum.md
+++ b/content/daytrip/eu/gb/old-sarum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/old-sarum'
+date: '2025-05-29T12:48:37.531Z'
+lat: '51.09328'
+lng: '-1.800256'
+location: 'Castle Road, Salisbury, Wiltshire, SP1 3SD'
+title: 'Old Sarum'
+external_url: https://www.english-heritage.org.uk/visit/places/old-sarum/
+---
+Old Sarum is the remains of a major town, in use from 400 BCE to 1220 CE. In the 13th century, the town migrated down the hill to the new location of Salisbury, which had a new cathedral, and by 1220, Old Sarum was abandoned. The site has the remains of the Norman castle, the church, and the town walls.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Old Sarum
**Location:** Castle Road, Salisbury, Wiltshire, SP1 3SD
**Submitted by:** Hugo
**Website:** https://www.english-heritage.org.uk/visit/places/old-sarum/

### Description
Old Sarum is the remains of a major town, in use from 400 BCE to 1220 CE. In the 13th century, the town migrated down the hill to the new location of Salisbury, which had a new cathedral, and by 1220, Old Sarum was abandoned. The site has the remains of the Norman castle, the church, and the town walls.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 45
**File:** `content/daytrip/eu/gb/old-sarum.md`

Please review this venue submission and edit the content as needed before merging.