### PR TITLE
New: Bolton Steam Museum

### DIFF
--- a/content/daytrip/eu/gb/bolton-steam-museum.md
+++ b/content/daytrip/eu/gb/bolton-steam-museum.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/bolton-steam-museum'
+date: '2025-05-29T12:50:20.859Z'
+lat: '53.584799'
+lng: '-2.454833'
+location: 'Mornington Road, Off Chorley Old Road, Bolton, BL1 4EU'
+title: 'Bolton Steam Museum'
+external_url: https://www.nmes.org/index.html
+---
+A large collection of steam engines -- from giant three-storey machines, down to small barring engines (used to start the big ones). Open Wednesdays and Sundays, running the machines on electricity. Actually steaming three or four times a summer.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bolton Steam Museum
**Location:** Mornington Road, Off Chorley Old Road, Bolton, BL1 4EU
**Submitted by:** Hugo
**Website:** https://www.nmes.org/index.html

### Description
A large collection of steam engines -- from giant three-storey machines, down to small barring engines (used to start the big ones). Open Wednesdays and Sundays, running the machines on electricity. Actually steaming three or four times a summer.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 47
**File:** `content/daytrip/eu/gb/bolton-steam-museum.md`

Please review this venue submission and edit the content as needed before merging.