### PR TITLE
New: Chineham Incinerator

### DIFF
--- a/content/daytrip/eu/gb/chineham-incinerator.md
+++ b/content/daytrip/eu/gb/chineham-incinerator.md
@@ -1,0 +1,14 @@
+---
+slug: 'daytrip/eu/gb/chineham-incinerator'
+date: '2025-05-29T12:52:06.213Z'
+lat: '51.292634'
+lng: '-1.0398349'
+location: 'Whitmarsh Ln, Chineham, Basingstoke RG24 8LL, Hampshire, United Kingdom'
+title: 'Chineham Incinerator'
+external_url: https://www.hampshire.veolia.co.uk/energy-recovery/chineham
+---
+# Chineham Energy Recovery Facility
+
+My Wife suggested visiting an incinerator - I thought she was mad! But Chineham Wonder Day was brilliant. Best bit: operating a massive grab moving tonnes of waste via joystick in the control room. Educational without being preachy, showing how rubbish becomes electricity. Heavy machinery + learning = perfect nerdy day out.
+
+- [Check Wonder Days](https://www.hampshire.veolia.co.uk/about/corporate-responsibility/wonder-open-days)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Chineham Incinerator
**Location:** Whitmarsh Ln, Chineham, Basingstoke RG24 8LL, Hampshire, United Kingdom
**Submitted by:** Wimpy
**Website:** https://www.hampshire.veolia.co.uk/energy-recovery/chineham

### Description
# Chineham Energy Recovery Facility

My Wife suggested visiting an incinerator - I thought she was mad! But Chineham Wonder Day was brilliant. Best bit: operating a massive grab moving tonnes of waste via joystick in the control room. Educational without being preachy, showing how rubbish becomes electricity. Heavy machinery + learning = perfect nerdy day out.

- [Check Wonder Days](https://www.hampshire.veolia.co.uk/about/corporate-responsibility/wonder-open-days)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 49
**File:** `content/daytrip/eu/gb/chineham-incinerator.md`

Please review this venue submission and edit the content as needed before merging.