### PR TITLE
New: Caen Hill Locks

### DIFF
--- a/content/daytrip/eu/gb/caen-hill-locks.md
+++ b/content/daytrip/eu/gb/caen-hill-locks.md
@@ -1,0 +1,10 @@
+---
+slug: 'daytrip/eu/gb/caen-hill-locks'
+date: '2025-05-29T12:52:28.913Z'
+lat: '51.351945'
+lng: '-2.033673'
+location: 'Canal & River Trust car park (P&D), The Locks, Rowde, Devizes, SN10 1RF'
+title: 'Caen Hill Locks'
+external_url: https://canalrivertrust.org.uk/canals-and-rivers/places-to-visit/caen-hill-locks
+---
+Also known as the Devizes Cascade, this sequence of 29 connected locks on the Kennet and Avon Canal is the longest sequence of locks in the UK. The steepest central section has 16 locks back-to-back, with reservoir ponds to preserve water as much as possible.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Caen Hill Locks
**Location:** Canal & River Trust car park (P&D), The Locks, Rowde, Devizes, SN10 1RF
**Submitted by:** Hugo
**Website:** https://canalrivertrust.org.uk/canals-and-rivers/places-to-visit/caen-hill-locks

### Description
Also known as the Devizes Cascade, this sequence of 29 connected locks on the Kennet and Avon Canal is the longest sequence of locks in the UK. The steepest central section has 16 locks back-to-back, with reservoir ponds to preserve water as much as possible.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 50
**File:** `content/daytrip/eu/gb/caen-hill-locks.md`

Please review this venue submission and edit the content as needed before merging.