### PR TITLE
New: Centre for Computing History

### DIFF
--- a/content/daytrip/eu/gb/centre-for-computing-history.md
+++ b/content/daytrip/eu/gb/centre-for-computing-history.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/centre-for-computing-history'
+date: '2025-05-29T13:37:04.616Z'
+poster: 'Footleg'
+lat: '52.207909'
+lng: '0.149034'
+location: 'Rene Court Coldhams Road Cambridge CB1 3EW'
+title: 'Centre for Computing History'
+external_url: https://www.computinghistory.org.uk
+---
+Museum of history of personal computers. An educational charity to tell the story of the Information Age through exploring in a highly interactive way the historical, social and cultural impact of developments in personal computing. It maintains a long-term collection of objects to tell this story and exploits them through learning and events programmes.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Centre for Computing History
**Location:** Rene Court Coldhams Road Cambridge CB1 3EW
**Submitted by:** Footleg
**Website:** https://www.computinghistory.org.uk

### Description
Museum of history of personal computers. An educational charity to tell the story of the Information Age through exploring in a highly interactive way the historical, social and cultural impact of developments in personal computing. It maintains a long-term collection of objects to tell this story and exploits them through learning and events programmes.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 51
**File:** `content/daytrip/eu/gb/centre-for-computing-history.md`

Please review this venue submission and edit the content as needed before merging.