### PR TITLE
New: Silbury Hill

### DIFF
--- a/content/daytrip/eu/gb/silbury-hill.md
+++ b/content/daytrip/eu/gb/silbury-hill.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/silbury-hill'
+date: '2025-05-29T13:37:20.738Z'
+poster: 'Hugo'
+lat: '51.415695'
+lng: '-1.857333'
+location: 'Avebury, United Kingdom'
+title: 'Silbury Hill'
+external_url: https://www.english-heritage.org.uk/visit/places/silbury-hill/
+---
+A prehistoric chalk mound, part of the Avebury neolithic complex. Built around 4500 years ago, it's one of the largest ancient man-made hills in the world. Nobody knows why it was built -- it's not a tomb, and probably wasn't intended as a fortification.
+
+Sadly, you can't walk on the hill these days (it's considered unstable, due to so many exploratory diggings by archaeologists and treasure hunters), but if you're in Avebury, it's worth taking a short trip outside the town to visit.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Silbury Hill
**Location:** Avebury, United Kingdom
**Submitted by:** Hugo
**Website:** https://www.english-heritage.org.uk/visit/places/silbury-hill/

### Description
A prehistoric chalk mound, part of the Avebury neolithic complex. Built around 4500 years ago, it's one of the largest ancient man-made hills in the world. Nobody knows why it was built -- it's not a tomb, and probably wasn't intended as a fortification.

Sadly, you can't walk on the hill these days (it's considered unstable, due to so many exploratory diggings by archaeologists and treasure hunters), but if you're in Avebury, it's worth taking a short trip outside the town to visit.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 52
**File:** `content/daytrip/eu/gb/silbury-hill.md`

Please review this venue submission and edit the content as needed before merging.