### PR TITLE
New: West Kennet Long Barrow

### DIFF
--- a/content/daytrip/eu/gb/west-kennet-long-barrow.md
+++ b/content/daytrip/eu/gb/west-kennet-long-barrow.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/west-kennet-long-barrow'
+date: '2025-05-29T13:38:10.298Z'
+poster: 'Hugo'
+lat: '51.40861'
+lng: '-1.850595'
+location: 'Avebury, United Kingdom'
+title: 'West Kennet Long Barrow'
+external_url: https://www.english-heritage.org.uk/visit/places/west-kennet-long-barrow/
+---
+An early Neolithic chambered long barrow. The barrow is open, and you can walk inside to see the individual chambers.


### PR DESCRIPTION
## New Venue Submission

**Venue:** West Kennet Long Barrow
**Location:** Avebury, United Kingdom
**Submitted by:** Hugo
**Website:** https://www.english-heritage.org.uk/visit/places/west-kennet-long-barrow/

### Description
An early Neolithic chambered long barrow. The barrow is open, and you can walk inside to see the individual chambers.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 53
**File:** `content/daytrip/eu/gb/west-kennet-long-barrow.md`

Please review this venue submission and edit the content as needed before merging.