### PR TITLE
New: Dan-yr-Ogof

### DIFF
--- a/content/daytrip/eu/gb/dan-yr-ogof.md
+++ b/content/daytrip/eu/gb/dan-yr-ogof.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/dan-yr-ogof'
+date: '2025-05-29T13:38:26.188Z'
+poster: 'Hugo'
+lat: '51.831442'
+lng: '-3.685291'
+location: 'Dan-yr-Ogof, The National Showcaves Centre for Wales, Abercrave, Swansea SA9 1GJ'
+title: 'Dan-yr-Ogof'
+external_url: https://www.showcaves.co.uk
+---
+Tours of spectacular limestone caves. A dinosaur park. A reproduction iron-age village. Heavy horses. Lots and lots of things to do.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dan-yr-Ogof
**Location:** Dan-yr-Ogof, The National Showcaves Centre for Wales, Abercrave, Swansea SA9 1GJ
**Submitted by:** Hugo
**Website:** https://www.showcaves.co.uk

### Description
Tours of spectacular limestone caves. A dinosaur park. A reproduction iron-age village. Heavy horses. Lots and lots of things to do.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 55
**File:** `content/daytrip/eu/gb/dan-yr-ogof.md`

Please review this venue submission and edit the content as needed before merging.