### PR TITLE
New: Ring of Brodgar

### DIFF
--- a/content/daytrip/eu/gb/ring-of-brodgar.md
+++ b/content/daytrip/eu/gb/ring-of-brodgar.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/ring-of-brodgar'
+date: '2025-05-29T13:38:47.030Z'
+poster: 'Hugo'
+lat: '59.001455'
+lng: '-3.229637'
+location: 'About 5m north east of Stromness on the B9055, Orkney, Scotland. HY 294 134'
+title: 'Ring of Brodgar'
+external_url: https://www.historicenvironment.scot/visit-a-place/places/ring-of-brodgar-stone-circle-and-henge/
+---
+A prehistoric stone circle and henge -- one of the best preserved stone circles in Britain. Nearby, there are a number of other prehistoric sites (Stones of Stenness, Big Howe, and the Barnhouse Settlement).


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ring of Brodgar
**Location:** About 5m north east of Stromness on the B9055, Orkney, Scotland. HY 294 134
**Submitted by:** Hugo
**Website:** https://www.historicenvironment.scot/visit-a-place/places/ring-of-brodgar-stone-circle-and-henge/

### Description
A prehistoric stone circle and henge -- one of the best preserved stone circles in Britain. Nearby, there are a number of other prehistoric sites (Stones of Stenness, Big Howe, and the Barnhouse Settlement).

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 57
**File:** `content/daytrip/eu/gb/ring-of-brodgar.md`

Please review this venue submission and edit the content as needed before merging.