### PR TITLE
New: Solway Aviation museum 

### DIFF
--- a/content/daytrip/eu/gb/solway-aviation-museum-.md
+++ b/content/daytrip/eu/gb/solway-aviation-museum-.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/solway-aviation-museum-'
+date: '2025-05-29T13:39:18.081Z'
+poster: 'g7kse'
+lat: '54.943489'
+lng: '-2.805676'
+location: 'Solway Aviation Museum, Aviation House, Carlisle Airport, Crosby-on-Eden, Cumbria, CA6 4NW'
+title: 'Solway Aviation museum '
+external_url: https://www.solway-aviation-museum.co.uk/
+---
+It's got a Vulcan and the last remaining Beverley is in restoration. Not as big as some of the others but the Beverley is a treat.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Solway Aviation museum 
**Location:** Solway Aviation Museum, Aviation House, Carlisle Airport, Crosby-on-Eden, Cumbria, CA6 4NW
**Submitted by:** g7kse
**Website:** https://www.solway-aviation-museum.co.uk/

### Description
It's got a Vulcan and the last remaining Beverley is in restoration. Not as big as some of the others but the Beverley is a treat.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 59
**File:** `content/daytrip/eu/gb/solway-aviation-museum-.md`

Please review this venue submission and edit the content as needed before merging.