### PR TITLE
New: Canadian Warplane Heritage Museum

### DIFF
--- a/content/daytrip/eu/gb/canadian-warplane-heritage-museum.md
+++ b/content/daytrip/eu/gb/canadian-warplane-heritage-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/canadian-warplane-heritage-museum'
+date: '2025-05-29T13:40:12.690Z'
+poster: 'Paul Drye'
+lat: '43.160208'
+lng: '-79.925585'
+location: '9280 Airport Road, Mount Hope, Ontario'
+title: 'Canadian Warplane Heritage Museum'
+external_url: https://www.warplane.com/
+---
+An aviation museum specializing in Canadian-flown military aircraft. As well as display craft, 10 are in flying condition and can be booked in advance by passengers looking to fly in them for 20 minutes to 1 hour.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Canadian Warplane Heritage Museum
**Location:** 9280 Airport Road, Mount Hope, Ontario
**Submitted by:** Paul Drye
**Website:** https://www.warplane.com/

### Description
An aviation museum specializing in Canadian-flown military aircraft. As well as display craft, 10 are in flying condition and can be booked in advance by passengers looking to fly in them for 20 minutes to 1 hour.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 62
**File:** `content/daytrip/eu/gb/canadian-warplane-heritage-museum.md`

Please review this venue submission and edit the content as needed before merging.