### PR TITLE
New: Stratford Butterfly Farm

### DIFF
--- a/content/daytrip/eu/gb/stratford-butterfly-farm.md
+++ b/content/daytrip/eu/gb/stratford-butterfly-farm.md
@@ -1,0 +1,15 @@
+---
+slug: 'daytrip/eu/gb/stratford-butterfly-farm'
+date: '2025-05-29T13:40:41.178Z'
+poster: 'NAB'
+lat: '52.18945'
+lng: '-1.700081'
+location: "Swan's Nest Lane, Stratford-upon-Avon, Warwickshire, CV37 7LS"
+title: 'Stratford Butterfly Farm'
+external_url: https://www.butterflyfarm.co.uk
+---
+"The UK's largest tropical butterfly paradise"
+
+A self-contained rainforest simulation where biology and ecology converge. The Stratford Butterfly Farm consists a number of climate-controlled greenhouses each housing hundreds of exotic butterflies.
+
+Whether you're into entomology, tropical ecosystems or the mechanics of rainforest climate control, this place is worth exploring.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Stratford Butterfly Farm
**Location:** Swan’s Nest Lane, Stratford-upon-Avon, Warwickshire, CV37 7LS
**Submitted by:** NAB
**Website:** https://www.butterflyfarm.co.uk

### Description
"The UK’s largest tropical butterfly paradise"

A self-contained rainforest simulation where biology and ecology converge. The Stratford Butterfly Farm consists a number of climate-controlled greenhouses each housing hundreds of exotic butterflies.

Whether you're into entomology, tropical ecosystems or the mechanics of rainforest climate control, this place is worth exploring.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 39
**File:** `content/daytrip/eu/gb/stratford-butterfly-farm.md`

Please review this venue submission and edit the content as needed before merging.