### PR TITLE
New: Surgeon's Hall Museums

### DIFF
--- a/content/daytrip/eu/gb/surgeons-hall-museums.md
+++ b/content/daytrip/eu/gb/surgeons-hall-museums.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/surgeons-hall-museums'
+date: '2025-05-29T13:42:27.537Z'
+poster: 'Hugo'
+lat: '55.946729'
+lng: '-3.184673'
+location: 'Surgeons' Hall Museums, Nicolson Street, Edinburgh, EH8 9DW'
+title: 'Surgeon's Hall Museums'
+external_url: https://museum.rcsed.ac.uk
+---
+The history of surgery in Edinburgh. Has many medical specimens on show, as well as an original operating theatre.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Surgeon's Hall Museums
**Location:** Surgeons' Hall Museums, Nicolson Street, Edinburgh, EH8 9DW
**Submitted by:** Hugo
**Website:** https://museum.rcsed.ac.uk

### Description
The history of surgery in Edinburgh. Has many medical specimens on show, as well as an original operating theatre.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 63
**File:** `content/daytrip/eu/gb/surgeons-hall-museums.md`

Please review this venue submission and edit the content as needed before merging.