### PR TITLE
New: Crossness Pumping Station

### DIFF
--- a/content/daytrip/eu/gb/crossness-pumping-station.md
+++ b/content/daytrip/eu/gb/crossness-pumping-station.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/crossness-pumping-station'
+date: '2025-05-29T14:39:56.998Z'
+poster: 'Hugo'
+lat: '51.509073'
+lng: '0.138445'
+location: 'The Old Works, Thames Water S.T.W., Bazalgette Way, London SE2 9AQ'
+title: 'Crossness Pumping Station'
+external_url: https://crossness.org.uk
+---
+Part of Bazalgette's plan for improving London's sewers after the Great Stink of 1858, the Crossness Pumping Station is a beautiful Victorian building housing a working beam engine and pumps.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Crossness Pumping Station
**Location:** The Old Works, Thames Water S.T.W., Bazalgette Way, London SE2 9AQ
**Submitted by:** Hugo
**Website:** https://crossness.org.uk

### Description
Part of Bazalgette's plan for improving London's sewers after the Great Stink of 1858, the Crossness Pumping Station is a beautiful Victorian building housing a working beam engine and pumps.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 70
**File:** `content/daytrip/eu/gb/crossness-pumping-station.md`

Please review this venue submission and edit the content as needed before merging.