### PR TITLE
New: Herstmonceux Observatory

### DIFF
--- a/content/daytrip/eu/gb/herstmonceux-observatory.md
+++ b/content/daytrip/eu/gb/herstmonceux-observatory.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/herstmonceux-observatory'
+date: '2025-05-29T14:40:40.052Z'
+poster: 'Hugo'
+lat: '50.86978'
+lng: '0.345919'
+location: 'Herstmonceux, Hailsham N27 1RN'
+title: 'Herstmonceux Observatory'
+external_url: https://www.the-observatory.org
+---
+When London got too bright in the 1950s, the Royal Observatory was moved from Greenwich to Herstmonceux in East Sussex. While no longer used for scientific observation (Eastbourne and Hailsham are now too bright), it still contains working telescopes, and a small hands-on science centre.
+
+There is Herstmonceux Castle nearby on the same site, for those interested in the historical buildings and gardens.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Herstmonceux Observatory
**Location:** Herstmonceux, Hailsham N27 1RN
**Submitted by:** Hugo
**Website:** https://www.the-observatory.org

### Description
When London got too bright in the 1950s, the Royal Observatory was moved from Greenwich to Herstmonceux in East Sussex. While no longer used for scientific observation (Eastbourne and Hailsham are now too bright), it still contains working telescopes, and a small hands-on science centre.

There is Herstmonceux Castle nearby on the same site, for those interested in the historical buildings and gardens.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 81
**File:** `content/daytrip/eu/gb/herstmonceux-observatory.md`

Please review this venue submission and edit the content as needed before merging.