### PR TITLE
New: Under the Pier Show

### DIFF
--- a/content/daytrip/eu/gb/under-the-pier-show.md
+++ b/content/daytrip/eu/gb/under-the-pier-show.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/under-the-pier-show'
+date: '2025-05-29T14:41:07.616Z'
+poster: 'David'
+lat: '52.33052'
+lng: '1.686069'
+location: 'Southwold Pier, Southwold'
+title: 'Under the Pier Show'
+external_url: https://www.underthepier.com/
+---
+Satirical and entertaining coin-operated arcade machines by Tim Hunkin.  


### PR DESCRIPTION
## New Venue Submission

**Venue:** Under the Pier Show
**Location:** Southwold Pier, Southwold
**Submitted by:** David
**Website:** https://www.underthepier.com/

### Description
Satirical and entertaining coin-operated arcade machines by Tim Hunkin.  

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 77
**File:** `content/daytrip/eu/gb/under-the-pier-show.md`

Please review this venue submission and edit the content as needed before merging.