### PR TITLE
New: Wien river retention basins 

### DIFF
--- a/content/daytrip/eu/au/wien-river-retention-basins.md
+++ b/content/daytrip/eu/au/wien-river-retention-basins.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/au/wien-river-retention-basins'
+date: '2025-05-29T14:41:46.380Z'
+poster: 'same'
+lat: '48.206114'
+lng: '16.231935'
+location: 'Near Vienna S-Bahn station "Wolf in der Au" '
+title: 'Wien river retention basins '
+external_url: https://de.wikipedia.org/wiki/R%C3%BCckhaltebecken_Auhof
+---
+The Wien is usually a ridiculously tiny river. But due to surrounding geology, heavy rain can sometimes make it grow to 2000 times its size. These massive basins can hold the water for a few hours to protect the city.
+
+Since the basins are only rarely filled, a lot of plant and animal life develops in them, and the huge walls are a beautiful contrast to that. You are not supposed to walk on the walls, but you can. The spot that I put the pin in is nice for picnics. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wien river retention basins 
**Location:** Near Vienna S-Bahn station "Wolf in der Au" 
**Submitted by:** same
**Website:** https://de.wikipedia.org/wiki/R%C3%BCckhaltebecken_Auhof

### Description
The Wien is usually a ridiculously tiny river. But due to surrounding geology, heavy rain can sometimes make it grow to 2000 times its size. These massive basins can hold the water for a few hours to protect the city.

Since the basins are only rarely filled, a lot of plant and animal life develops in them, and the huge walls are a beautiful contrast to that. You are not supposed to walk on the walls, but you can. The spot that I put the pin in is nice for picnics. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 80
**File:** `content/daytrip/eu/au/wien-river-retention-basins.md`

Please review this venue submission and edit the content as needed before merging.