### PR TITLE
New: Isole Borromee (Borromean Islands)

### DIFF
--- a/content/daytrip/eu/it/isole-borromee-borromean-islands.md
+++ b/content/daytrip/eu/it/isole-borromee-borromean-islands.md
@@ -8,4 +8,6 @@ location: 'Lago Maggiore, Piedmont, Italy'
 title: 'Isole Borromee (Borromean Islands)'
 external_url: https://en.wikipedia.org/wiki/Borromean_Islands
 ---
+Three islands in Lake Maggiore featuring a 17th-century palazzo and associated Italianate garden. The nerdy part is that Hotel Adriano from Hayao Miyazaki's anime Porco Rosso strongly resembles an amalgam of two of the islands, Isola Bella and Isola Madre. Ghibli fans should not miss this! 
 
+They are accessible by ferry from the on-shore towns of Stresa, Laveno, Pallanza, and Intra—best to go in the morning if you want to see all of them as the last trip usually departs early in the afternoon.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Isole Borromee (Borromean Islands)
**Location:** Lago Maggiore, Piedmont, Italy
**Submitted by:** Paul Drye
**Website:** https://en.wikipedia.org/wiki/Borromean_Islands

### Description
Three islands in Lake Maggiore featuring a 17th-century palazzo and associated Italianate garden. The nerdy part is that Hotel Adriano from Hayao Miyazaki's anime Porco Rosso strongly resembles an amalgam of two of the islands, Isola Bella and Isola Madre. Ghibli fans should not miss this! 

They are accessible by ferry from the on-shore towns of Stresa, Laveno, Pallanza, and Intra—best to go in the morning if you want to see all of them as the last trip usually departs early in the afternoon.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 79
**File:** `content/daytrip/eu/it/isole-borromee-borromean-islands.md`

Please review this venue submission and edit the content as needed before merging.