### PR TITLE
New: Walchenseekraftwerk

### DIFF
--- a/content/daytrip/eu/gb/walchenseekraftwerk.md
+++ b/content/daytrip/eu/gb/walchenseekraftwerk.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/walchenseekraftwerk'
+date: '2025-05-29T14:45:02.447Z'
+poster: 'PopeySentMeHere'
+lat: '47.630361'
+lng: '11.339242'
+location: 'Altjoch 21, 82431 Kochel a. See'
+title: 'Walchenseekraftwerk'
+external_url: https://www.uniper.energy/de/deutschland/kraftwerke-deutschland/kraftwerksgruppe-isar/walchenseekraftwerk
+---
+One of the oldest Water-Turbine-Plants in the World (in use since 1924). Can be visited independently, guided tours about once a week. Are is also nice for hiking, taking a boat trip across the lake or relaxing at the Kristall-Therme.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Walchenseekraftwerk
**Location:** Altjoch 21, 82431 Kochel a. See
**Submitted by:** PopeySentMeHere
**Website:** https://www.uniper.energy/de/deutschland/kraftwerke-deutschland/kraftwerksgruppe-isar/walchenseekraftwerk

### Description
One of the oldest Water-Turbine-Plants in the World (in use since 1924). Can be visited independently, guided tours about once a week. Are is also nice for hiking, taking a boat trip across the lake or relaxing at the Kristall-Therme.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 78
**File:** `content/daytrip/eu/gb/walchenseekraftwerk.md`

Please review this venue submission and edit the content as needed before merging.