### PR TITLE
New: Rock Point Provincial Park (Fossil Reef)

### DIFF
--- a/content/daytrip/na/ca/rock-point-provincial-park-fossil-reef.md
+++ b/content/daytrip/na/ca/rock-point-provincial-park-fossil-reef.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/ca/rock-point-provincial-park-fossil-reef'
+date: '2025-05-29T14:46:54.761Z'
+poster: 'Paul Drye'
+lat: '42.843279'
+lng: '-79.547753'
+location: '215 Niece Rd Dunnville, Ontario, Canada'
+title: 'Rock Point Provincial Park (Fossil Reef)'
+external_url: https://www.ontarioparks.ca/park/rockpoint
+---
+Notable for a fossilized reef in its eastern end, Rock Point is a pebbly beach on the shores of Lake Erie, with short hiking trails north of the beach. The reef is a flat shelf of rock along the shore just before Rockhouse Point, a bit above the waterline. It dates back to the Devonian, about 350 million years ago, consisting mainly of crushed elements but also more-complete rugose and tabulate corals.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Rock Point Provincial Park (Fossil Reef)
**Location:** 215 Niece Rd Dunnville, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://www.ontarioparks.ca/park/rockpoint

### Description
Notable for a fossilized reef in its eastern end, Rock Point is a pebbly beach on the shores of Lake Erie, with short hiking trails north of the beach. The reef is a flat shelf of rock along the shore just before Rockhouse Point, a bit above the waterline. It dates back to the Devonian, about 350 million years ago, consisting mainly of crushed elements but also more-complete rugose and tabulate corals.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 72
**File:** `content/daytrip/na/ca/rock-point-provincial-park-fossil-reef.md`

Please review this venue submission and edit the content as needed before merging.