### PR TITLE
New: Konrad-Zuse-Museum

### DIFF
--- a/content/daytrip/eu/de/konrad-zuse-museum.md
+++ b/content/daytrip/eu/de/konrad-zuse-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/konrad-zuse-museum'
+date: '2025-05-29T14:47:09.825Z'
+poster: 'MarcN'
+lat: '50.671701'
+lng: '9.765574'
+location: 'Kirchplatz 4-6, 36088 Hünfeld, Germany'
+title: 'Konrad-Zuse-Museum'
+external_url: https://www.zuse-museum-huenfeld.de/de/
+---
+An exhibition about the history of the city if Hünfeld. A section of the museum deals with the life and work of Konrad Zuse, who lived in Hünfeld from 1957 until his death in 1995. The computer inventor Konrad Zuse developed computer systems from 1934 and founded the Zuse company in 1949.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Konrad-Zuse-Museum
**Location:** Kirchplatz 4-6, 36088 Hünfeld, Germany
**Submitted by:** MarcN
**Website:** https://www.zuse-museum-huenfeld.de/de/

### Description
An exhibition about the history of the city if Hünfeld. A section of the museum deals with the life and work of Konrad Zuse, who lived in Hünfeld from 1957 until his death in 1995. The computer inventor Konrad Zuse developed computer systems from 1934 and founded the Zuse company in 1949.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 73
**File:** `content/daytrip/eu/de/konrad-zuse-museum.md`

Please review this venue submission and edit the content as needed before merging.