### PR TITLE
New: Imperial War Museums Duxford

### DIFF
--- a/content/daytrip/eu/gb/imperial-war-museums-duxford.md
+++ b/content/daytrip/eu/gb/imperial-war-museums-duxford.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/imperial-war-museums-duxford'
+date: '2025-05-29T14:47:33.373Z'
+poster: 'Hugo'
+lat: '52.096353'
+lng: '0.132995'
+location: 'Duxford, Cambridgeshire, CB22 4QR'
+title: 'Imperial War Museums Duxford'
+external_url: https://www.iwm.org.uk/visits/iwm-duxford
+---
+The "Large Objects" collection of the Imperial War Museums. Has a huge number of aircraft, including a Concorde fitted out for scientific research, a B-52, and an Avro Vulcan nuclear bomber.
+
+Also has a collection of tanks and other military vehicles on site, and a recreation of a WWII flight operations centre.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Imperial War Museums Duxford
**Location:** Duxford, Cambridgeshire, CB22 4QR
**Submitted by:** Hugo
**Website:** https://www.iwm.org.uk/visits/iwm-duxford

### Description
The "Large Objects" collection of the Imperial War Museums. Has a huge number of aircraft, including a Concorde fitted out for scientific research, a B-52, and an Avro Vulcan nuclear bomber.

Also has a collection of tanks and other military vehicles on site, and a recreation of a WWII flight operations centre.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 74
**File:** `content/daytrip/eu/gb/imperial-war-museums-duxford.md`

Please review this venue submission and edit the content as needed before merging.