### PR TITLE
New: Oxford Museum of the History of Science

### DIFF
--- a/content/daytrip/eu/gb/oxford-museum-of-the-history-of-science.md
+++ b/content/daytrip/eu/gb/oxford-museum-of-the-history-of-science.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/oxford-museum-of-the-history-of-science'
+date: '2025-05-29T14:48:04.978Z'
+poster: 'Hugo'
+lat: '51.754234'
+lng: '-1.255504'
+location: 'History of Science Museum, Broad Street, Oxford OX1 3AZ '
+title: 'Oxford Museum of the History of Science'
+external_url: https://hsm.ox.ac.uk
+---
+Opposite Blackwells, and tucked in next to the Sheldonian, the Oxford Museum of Science is an eclectic collection of scientific objects, including a blackboard used by Einstein (with his writing still on it), and Lewis Carroll's photography kit.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Oxford Museum of the History of Science
**Location:** History of Science Museum, Broad Street, Oxford OX1 3AZ 
**Submitted by:** Hugo
**Website:** https://hsm.ox.ac.uk

### Description
Opposite Blackwells, and tucked in next to the Sheldonian, the Oxford Museum of Science is an eclectic collection of scientific objects, including a blackboard used by Einstein (with his writing still on it), and Lewis Carroll's photography kit.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 75
**File:** `content/daytrip/eu/gb/oxford-museum-of-the-history-of-science.md`

Please review this venue submission and edit the content as needed before merging.