### PR TITLE
New: Flugwerft Oberschleißheim

### DIFF
--- a/content/daytrip/eu/de/flugwerft-oberschleiheim.md
+++ b/content/daytrip/eu/de/flugwerft-oberschleiheim.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/flugwerft-oberschleiheim'
+date: '2025-05-29T14:48:14.985Z'
+poster: 'PopeySentMeHere'
+lat: '48.245397'
+lng: '11.555557'
+location: 'Effnerstraﬂe 18, 85764 Oberschleiﬂheim '
+title: 'Flugwerft Oberschleiﬂheim'
+external_url: https://www.deutsches-museum.de/flugwerft-schleissheim
+---
+Small airplane Museum, part of "Deutsches Museum", but can/should be visisted independently of the main museum.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Flugwerft Oberschleißheim
**Location:** Effnerstraße 18, 85764 Oberschleißheim 
**Submitted by:** PopeySentMeHere
**Website:** https://www.deutsches-museum.de/flugwerft-schleissheim

### Description
Small airplane Museum, part of "Deutsches Museum", but can/should be visisted independently of the main museum.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 76
**File:** `content/daytrip/eu/de/flugwerft-oberschleiheim.md`

Please review this venue submission and edit the content as needed before merging.