### PR TITLE
New: Greenham Common control tower and missile silos / bunkers

### DIFF
--- a/content/daytrip/eu/gb/greenham-common-control-tower-and-missile-silos-bunkers.md
+++ b/content/daytrip/eu/gb/greenham-common-control-tower-and-missile-silos-bunkers.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/greenham-common-control-tower-and-missile-silos-bunkers'
+date: '2025-05-29T14:49:54.956Z'
+poster: 'Neil'
+lat: '51.382146'
+lng: '-1.284456'
+location: 'Greenham Control Tower and Cafe, Burys Bank Rd, Newbury, RG19 8BZ'
+title: 'Greenham Common control tower and missile silos / bunkers'
+external_url: https://www.greenhamtower.org.uk
+---
+The former control tower (now a cafe and small museum) for the Greenham Common airbase. Across the common (and behind fences) are missile silos / bunkers.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Greenham Common control tower and missile silos / bunkers
**Location:** Greenham Control Tower and Cafe, Burys Bank Rd, Newbury, RG19 8BZ
**Submitted by:** Neil
**Website:** https://www.greenhamtower.org.uk

### Description
The former control tower (now a cafe and small museum) for the Greenham Common airbase. Across the common (and behind fences) are missile silos / bunkers.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 64
**File:** `content/daytrip/eu/gb/greenham-common-control-tower-and-missile-silos-bunkers.md`

Please review this venue submission and edit the content as needed before merging.