### PR TITLE
New: Whipple Museum of the History of Science

### DIFF
--- a/content/daytrip/eu/gb/whipple-museum-of-the-history-of-science.md
+++ b/content/daytrip/eu/gb/whipple-museum-of-the-history-of-science.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/whipple-museum-of-the-history-of-science'
+date: '2025-05-29T14:50:03.915Z'
+poster: 'Hugo'
+lat: '52.202871'
+lng: '0.119476'
+location: 'Whipple Museum of the History of Science, Free School Lane, Cambridge CB2 3RH'
+title: 'Whipple Museum of the History of Science'
+external_url: https://www.whipplemuseum.cam.ac.uk
+---
+A small but well-formed science museum. Has one of Herschel's telescopes, a section on the (mostly female) instrument-makers of the 18th and 19th centuries, a room of globes, and a huge collection of calculators.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Whipple Museum of the History of Science
**Location:** Whipple Museum of the History of Science, Free School Lane, Cambridge CB2 3RH
**Submitted by:** Hugo
**Website:** https://www.whipplemuseum.cam.ac.uk

### Description
A small but well-formed science museum. Has one of Herschel's telescopes, a section on the (mostly female) instrument-makers of the 18th and 19th centuries, a room of globes, and a huge collection of calculators.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 65
**File:** `content/daytrip/eu/gb/whipple-museum-of-the-history-of-science.md`

Please review this venue submission and edit the content as needed before merging.