### PR TITLE
New: Hamilton Museum of Steam & Technology

### DIFF
--- a/content/daytrip/na/ca/hamilton-museum-of-steam-technology.md
+++ b/content/daytrip/na/ca/hamilton-museum-of-steam-technology.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/ca/hamilton-museum-of-steam-technology'
+date: '2025-05-29T14:50:40.775Z'
+poster: 'Paul Drye'
+lat: '43.256643'
+lng: '-79.77219'
+location: '900 Woodward Ave, Hamilton, Ontario, Canada'
+title: 'Hamilton Museum of Steam & Technology'
+external_url: https://www.hamilton.ca/things-do/hamilton-civic-museums/hamilton-museum-steam-technology-national-historic-site
+---
+The former waterworks for the city of Hamilton, this museum preserves two massive steam engines which were used to pump drinking water during the latter half of the 19th century.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hamilton Museum of Steam & Technology
**Location:** 900 Woodward Ave, Hamilton, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://www.hamilton.ca/things-do/hamilton-civic-museums/hamilton-museum-steam-technology-national-historic-site

### Description
The former waterworks for the city of Hamilton, this museum preserves two massive steam engines which were used to pump drinking water during the latter half of the 19th century.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 67
**File:** `content/daytrip/na/ca/hamilton-museum-of-steam-technology.md`

Please review this venue submission and edit the content as needed before merging.