### PR TITLE
New: Heinz Nixdorf MuseumsForum

### DIFF
--- a/content/daytrip/eu/de/heinz-nixdorf-museumsforum.md
+++ b/content/daytrip/eu/de/heinz-nixdorf-museumsforum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/heinz-nixdorf-museumsforum'
+date: '2025-05-29T14:51:23.581Z'
+poster: 'MarcN'
+lat: '51.731322'
+lng: '8.735611'
+location: 'Fürstenallee 7, 33102 Paderborn, Germany'
+title: 'Heinz Nixdorf MuseumsForum'
+external_url: https://hnf.de
+---
+The world's largest computer museum. The exhibition ranges from the first human writings and calculations to calculating machines, typewrites, iconic early computers to modern day robots. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Heinz Nixdorf MuseumsForum
**Location:** Fürstenallee 7, 33102 Paderborn, Germany
**Submitted by:** MarcN
**Website:** https://hnf.de

### Description
The world's largest computer museum. The exhibition ranges from the first human writings and calculations to calculating machines, typewrites, iconic early computers to modern day robots. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 69
**File:** `content/daytrip/eu/de/heinz-nixdorf-museumsforum.md`

Please review this venue submission and edit the content as needed before merging.