### PR TITLE
New: Manchester Science and Industry Museum

### DIFF
--- a/content/daytrip/eu/gb/manchester-science-and-industry-museum.md
+++ b/content/daytrip/eu/gb/manchester-science-and-industry-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/manchester-science-and-industry-museum'
+date: '2025-05-29T14:57:36.430Z'
+poster: 'Hugo'
+lat: '53.477046'
+lng: '-2.25503'
+location: 'Science and Industry Museum Liverpool Road Manchester M3 4FP'
+title: 'Manchester Science and Industry Museum'
+external_url: https://www.scienceandindustrymuseum.org.uk
+---
+Everything technological about Manchester, from cotton and steam to a replica of Baby, the computer built in Manchester in 1948.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Manchester Science and Industry Museum
**Location:** Science and Industry Museum Liverpool Road Manchester M3 4FP
**Submitted by:** Hugo
**Website:** https://www.scienceandindustrymuseum.org.uk

### Description
Everything technological about Manchester, from cotton and steam to a replica of Baby, the computer built in Manchester in 1948.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 60
**File:** `content/daytrip/eu/gb/manchester-science-and-industry-museum.md`

Please review this venue submission and edit the content as needed before merging.