### PR TITLE
New: National Railway Museum

### DIFF
--- a/content/daytrip/eu/gb/national-railway-museum.md
+++ b/content/daytrip/eu/gb/national-railway-museum.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/national-railway-museum'
+date: '2025-05-29T17:27:01.721Z'
+poster: 'Hugo'
+lat: '53.959931'
+lng: '-1.095232'
+location: 'National Railway Museum, Leeman Road, York YO26 4XJ'
+title: 'National Railway Museum'
+external_url: https://www.railwaymuseum.org.uk
+---
+Everything to do with trains! Locomotives, rolling stock, and more.
+
+They have a Shinkansen, Flying Scotsman, and Mallard, the holder of the speed record for a steam train.


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Railway Museum
**Location:** National Railway Museum, Leeman Road, York YO26 4XJ
**Submitted by:** Hugo
**Website:** https://www.railwaymuseum.org.uk

### Description
Everything to do with trains! Locomotives, rolling stock, and more.

They have a Shinkansen, Flying Scotsman, and Mallard, the holder of the speed record for a steam train.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 92
**File:** `content/daytrip/eu/gb/national-railway-museum.md`

Please review this venue submission and edit the content as needed before merging.