### PR TITLE
New: Aardman Animation studio tour

### DIFF
--- a/content/daytrip/eu/gb/aardman-animation-studio-tour.md
+++ b/content/daytrip/eu/gb/aardman-animation-studio-tour.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/aardman-animation-studio-tour'
+date: '2025-05-29T17:28:28.686Z'
+poster: 'Cain Mosni aka Camopants'
+lat: '51.447529'
+lng: '-2.608114'
+location: 'Aardman Animation, 129 Gas Ferry Road, Bristol, BS1 6UN'
+title: 'Aardman Animation studio tour'
+external_url: https://www.aardman.com/attractions-live-experiences/art-of-aardman/
+---
+Best known for Morph, Wallace and Gromit, and the Chicken Run films, Aardman animation is a long-standing and well respected "claymation" stop frame animation studio.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Aardman Animation studio tour
**Location:** Aardman Animation, 129 Gas Ferry Road, Bristol, BS1 6UN
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://www.aardman.com/attractions-live-experiences/art-of-aardman/

### Description
Best known for Morph, Wallace and Gromit, and the Chicken Run films, Aardman animation is a long-standing and well respected "claymation" stop frame animation studio.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 96
**File:** `content/daytrip/eu/gb/aardman-animation-studio-tour.md`

Please review this venue submission and edit the content as needed before merging.