### PR TITLE
New: Britain's steepest road

### DIFF
--- a/content/daytrip/eu/gb/britains-steepest-road.md
+++ b/content/daytrip/eu/gb/britains-steepest-road.md
@@ -5,7 +5,7 @@ poster: 'Cain Mosni aka Camopants'
 lat: '57.418995'
 lng: '-5.708578'
 location: 'Bealach na Ba Viewpoint, Strathcarron IV54 8XF'
-title: 'Britain's steepest road'
+title: "Britain's steepest road"
 external_url: https://outaboutscotland.com/bealach-na-ba-highlands/
 ---
 Definitely not for the faint hearted or slipping clutches, this is Britain's steepest road (and narrow with it), reaching inclines of almost 20% (1:5).  Before attempting to drive it, research it carefully, and know what you are getting into.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Britain's steepest road
**Location:** Bealach na Ba Viewpoint, Strathcarron IV54 8XF
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://outaboutscotland.com/bealach-na-ba-highlands/

### Description
Definitely not for the faint hearted or slipping clutches, this is Britain's steepest road (and narrow with it), reaching inclines of almost 20% (1:5).  Before attempting to drive it, research it carefully, and know what you are getting into.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 98
**File:** `content/daytrip/eu/gb/britains-steepest-road.md`

Please review this venue submission and edit the content as needed before merging.