### PR TITLE
New: The National Archives

### DIFF
--- a/content/daytrip/eu/gb/the-national-archives.md
+++ b/content/daytrip/eu/gb/the-national-archives.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-national-archives'
+date: '2025-05-29T17:30:33.180Z'
+poster: 'betandr'
+lat: '51.481119'
+lng: '-0.279213'
+location: 'The National Archives, Kew, Richmond, TW9 4DU'
+title: 'The National Archives'
+external_url: https://www.nationalarchives.gov.uk/
+---
+The National Archives in Kew is pretty much the UK's ultimate data backup with over 1,000 years of history stored in one place. From medieval manuscripts to Cold War secrets, it's like a real-life time machine for information geeks. Think government-grade lore library meets digital archive. Browse declassified spy files, old maps, or even the Domesday Book.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The National Archives
**Location:** The National Archives, Kew, Richmond, TW9 4DU
**Submitted by:** betandr
**Website:** https://www.nationalarchives.gov.uk/

### Description
The National Archives in Kew is pretty much the UK's ultimate data backup with over 1,000 years of history stored in one place. From medieval manuscripts to Cold War secrets, it’s like a real-life time machine for information geeks. Think government-grade lore library meets digital archive. Browse declassified spy files, old maps, or even the Domesday Book.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 99
**File:** `content/daytrip/eu/gb/the-national-archives.md`

Please review this venue submission and edit the content as needed before merging.