### PR TITLE
New: The Broad Street Pump

### DIFF
--- a/content/daytrip/eu/gb/the-broad-street-pump.md
+++ b/content/daytrip/eu/gb/the-broad-street-pump.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-broad-street-pump'
+date: '2025-05-29T19:23:39.883Z'
+poster: 'TimoMicro'
+lat: '51.51333'
+lng: '-0.13668'
+location: '39 Broadwick St, Carnaby, London W1F 9QJ, United Kingdom'
+title: 'The Broad Street Pump'
+external_url: https://en.wikipedia.org/wiki/1854_Broad_Street_cholera_outbreak
+---
+The father of modern epidemiology, doctor John Snow, tracked down the cause of the 1859 cholera epidemic in London to this pump's contaminated water.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Broad Street Pump
**Location:** 39 Broadwick St, Carnaby, London W1F 9QJ, United Kingdom
**Submitted by:** TimoMicro
**Website:** https://en.wikipedia.org/wiki/1854_Broad_Street_cholera_outbreak

### Description
The father of modern epidemiology, doctor John Snow, tracked down the cause of the 1859 cholera epidemic in London to this pump's contaminated water.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 115
**File:** `content/daytrip/eu/gb/the-broad-street-pump.md`

Please review this venue submission and edit the content as needed before merging.