### PR TITLE
New: Colne Valley Museum

### DIFF
--- a/content/daytrip/eu/gb/colne-valley-museum.md
+++ b/content/daytrip/eu/gb/colne-valley-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/colne-valley-museum'
+date: '2025-05-29T19:24:09.383Z'
+poster: 'Bombur'
+lat: '53.638678'
+lng: '-1.856604'
+location: 'Cliffe Ash, Golcar, Huddersfield, HD7 4PY'
+title: 'Colne Valley Museum'
+external_url: https://www.colnevalleymuseum.org.uk/
+---
+"Discover what life was like in about 1840 when the cottages were inhabited by families of handloom weavers". Insight into the time period surrounding the Luddite movement. Apparently has a replica of Enoch's Hammer.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Colne Valley Museum
**Location:** Cliffe Ash, Golcar, Huddersfield, HD7 4PY
**Submitted by:** Bombur
**Website:** https://www.colnevalleymuseum.org.uk/

### Description
"Discover what life was like in about 1840 when the cottages were inhabited by families of handloom weavers". Insight into the time period surrounding the Luddite movement. Apparently has a replica of Enoch's Hammer.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 113
**File:** `content/daytrip/eu/gb/colne-valley-museum.md`

Please review this venue submission and edit the content as needed before merging.