### PR TITLE
New: Legoland Billund

### DIFF
--- a/content/daytrip/eu/gb/legoland-billund.md
+++ b/content/daytrip/eu/gb/legoland-billund.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/legoland-billund'
+date: '2025-05-29T19:24:52.205Z'
+poster: 'MarcN'
+lat: '55.73564'
+lng: '9.126828'
+location: 'Nordmarksvej 9, 7190 Billund, Denmark'
+title: 'Legoland Billund'
+external_url: https://www.legoland.dk/
+---
+What can I say? It's Legoland! A large open air exhibition of Lego models of European cities and famous locations around the world. Plus a Lego themed amusement park.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Legoland Billund
**Location:** Nordmarksvej 9, 7190 Billund, Denmark
**Submitted by:** MarcN
**Website:** https://www.legoland.dk/

### Description
What can I say? It's Legoland! A large open air exhibition of Lego models of European cities and famous locations around the world. Plus a Lego themed amusement park.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 112
**File:** `content/daytrip/eu/gb/legoland-billund.md`

Please review this venue submission and edit the content as needed before merging.