### PR TITLE
New: Depot 5 from wLana

### DIFF
--- a/content/daytrip/eu/gb/depot-5.md
+++ b/content/daytrip/eu/gb/depot-5.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/eu/gb/depot-5'
+date: '2025-05-29T21:39:03.827Z'
+poster: 'wLana'
+lat: '49.4738846'
+lng: '8.4870059'
+location: 'Möhlstraße 31, 68165 Mannheim'
+title: 'Depot 5'
+external_url: https://depotfuenf.de/
+---
+A small, volunteer-run local transport museum in the Rhine-Neckar region.
+Volunteers lead tours through the history of the local transport system once a week. Size: three rooms. Opening hours should be checked online in advance, and registration is recommended.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Depot 5
**Location:** Möhlstraße 31, 68165 Mannheim
**Submitted by:** wLana
**Website:** https://depotfuenf.de/

### Description
A small, volunteer-run local transport museum in the Rhine-Neckar region.
Volunteers lead tours through the history of the local transport system once a week. Size: three rooms. Opening hours should be checked online in advance, and registration is recommended.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 86
**File:** `content/daytrip/eu/gb/depot-5.md`

Please review this venue submission and edit the content as needed before merging.