### PR TITLE
New: Heinz Nixdorf MuseumsForum from Nerd

### DIFF
--- a/content/daytrip/eu/gb/heinz-nixdorf-museumsforum.md
+++ b/content/daytrip/eu/gb/heinz-nixdorf-museumsforum.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/heinz-nixdorf-museumsforum'
+date: '2025-05-29T21:48:39.013Z'
+poster: 'Nerd'
+lat: '51.731339'
+lng: '8.735654'
+location: 'Fürstenallee 7, 33102 Paderborn'
+title: 'Heinz Nixdorf MuseumsForum'
+external_url: https://hnf.de
+---
+The world's largest computer museum!
+
+You can take a look at old and modern technology and even try some of it out yourself. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Heinz Nixdorf MuseumsForum
**Location:** Fürstenallee 7, 33102 Paderborn
**Submitted by:** Nerd
**Website:** https://hnf.de

### Description
The world's largest computer museum!

You can take a look at old and modern technology and even try some of it out yourself. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 87
**File:** `content/daytrip/eu/gb/heinz-nixdorf-museumsforum.md`

Please review this venue submission and edit the content as needed before merging.