### PR TITLE
New: Grande Arche de la Défense from Hugo

### DIFF
--- a/content/daytrip/eu/fr/grande-arche-de-la-dfense.md
+++ b/content/daytrip/eu/fr/grande-arche-de-la-dfense.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/fr/grande-arche-de-la-dfense'
+date: '2025-05-29T21:52:43.233Z'
+poster: 'Hugo'
+lat: '48.892226'
+lng: '2.236946'
+location: 'La Défense, Paris'
+title: 'Grande Arche de la Défense'
+external_url: https://www.grandearche.com/grande-arche-monument-majeur-de-defense-de-paris/
+---
+A monumental building, designed to complement the Arc de Triomphe, and to cap the end of the Avenue des Champs-Élysées from the Louvre to La Défense. The building is skewed off the line of the avenue by a few degrees, to match the angle of the Arc de Triomphe.
+
+There is a rooftop terrace and restaurant, from which you can see spectacular views of Paris, and the ruler-straight route back down to the pyramid at the entrance to the Louvre.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Grande Arche de la Défense
**Location:** La Défense, Paris
**Submitted by:** Hugo
**Website:** https://www.grandearche.com/grande-arche-monument-majeur-de-defense-de-paris/

### Description
A monumental building, designed to complement the Arc de Triomphe, and to cap the end of the Avenue des Champs-Élysées from the Louvre to La Défense. The building is skewed off the line of the avenue by a few degrees, to match the angle of the Arc de Triomphe.

There is a rooftop terrace and restaurant, from which you can see spectacular views of Paris, and the ruler-straight route back down to the pyramid at the entrance to the Louvre.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 93
**File:** `content/daytrip/eu/fr/grande-arche-de-la-dfense.md`

Please review this venue submission and edit the content as needed before merging.