### PR TITLE
New: Staatliches Naturhistorisches Museum from MarcN

### DIFF
--- a/content/daytrip/eu/de/staatliches-naturhistorisches-museum.md
+++ b/content/daytrip/eu/de/staatliches-naturhistorisches-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/staatliches-naturhistorisches-museum'
+date: '2025-05-29T22:19:16.705Z'
+poster: 'MarcN'
+lat: '52.27521'
+lng: '10.529484'
+location: 'Pockelsstraße 10, 38106 Braunschweig, Germany'
+title: 'Staatliches Naturhistorisches Museum'
+external_url: https://3landesmuseen-braunschweig.de/en/staatliches-naturhistorisches-museum
+---
+The public displays of the State Natural History Museum include an aquarium, dioramas, and exhibitions of birds, mammals, insects, fossils, and meteorites. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Staatliches Naturhistorisches Museum
**Location:** Pockelsstraße 10, 38106 Braunschweig, Germany
**Submitted by:** MarcN
**Website:** https://3landesmuseen-braunschweig.de/en/staatliches-naturhistorisches-museum

### Description
The public displays of the State Natural History Museum include an aquarium, dioramas, and exhibitions of birds, mammals, insects, fossils, and meteorites. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 107
**File:** `content/daytrip/eu/de/staatliches-naturhistorisches-museum.md`

Please review this venue submission and edit the content as needed before merging.