### PR TITLE
New: Treasure Island from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/treasure-island.md
+++ b/content/daytrip/na/ca/treasure-island.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/ca/treasure-island'
+date: '2025-05-29T22:19:37.553Z'
+poster: 'Paul Drye'
+lat: '45.763332'
+lng: '-82.177563'
+location: 'Manitoulin Island, Ontario, Canada'
+title: 'Treasure Island'
+external_url: https://en.wikipedia.org/wiki/Treasure_Island_(Ontario)
+---
+Treasure Island is the world's largest island in a lake (Lake Mindemoya) on an island (Manitoulin Island) in a lake (Lake Huron). While not accessible to the public, it can be sight-seen from the nearby Lake Mindemoya Park, off Highway 551 to the east.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Treasure Island
**Location:** Manitoulin Island, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://en.wikipedia.org/wiki/Treasure_Island_(Ontario)

### Description
Treasure Island is the world's largest island in a lake (Lake Mindemoya) on an island (Manitoulin Island) in a lake (Lake Huron). While not accessible to the public, it can be sight-seen from the nearby Lake Mindemoya Park, off Highway 551 to the east.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 108
**File:** `content/daytrip/na/ca/treasure-island.md`

Please review this venue submission and edit the content as needed before merging.