### PR TITLE
New: Maritiem Museum from MarcN

### DIFF
--- a/content/daytrip/eu/nl/maritiem-museum.md
+++ b/content/daytrip/eu/nl/maritiem-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/nl/maritiem-museum'
+date: '2025-05-29T22:20:50.771Z'
+poster: 'MarcN'
+lat: '51.91742'
+lng: '4.482132'
+location: 'Leuvehaven 1, 3011 EA Rotterdam, Netherlands '
+title: 'Maritiem Museum'
+external_url: https://maritiemmuseum.nl/
+---
+A museum about maritime history. Located next to the museum harbour which contains a collection of historic vessels and cranes. There is a maritime themed playground on the roof of the museum. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Maritiem Museum
**Location:** Leuvehaven 1, 3011 EA Rotterdam, Netherlands 
**Submitted by:** MarcN
**Website:** https://maritiemmuseum.nl/

### Description
A museum about maritime history. Located next to the museum harbour which contains a collection of historic vessels and cranes. There is a maritime themed playground on the roof of the museum. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 111
**File:** `content/daytrip/eu/nl/maritiem-museum.md`

Please review this venue submission and edit the content as needed before merging.