### PR TITLE
New: Sonnenborgh Observatory from TimoMicro

### DIFF
--- a/content/daytrip/eu/nl/sonnenborgh-observatory.md
+++ b/content/daytrip/eu/nl/sonnenborgh-observatory.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/nl/sonnenborgh-observatory'
+date: '2025-05-29T22:22:11.708Z'
+poster: 'TimoMicro'
+lat: '52.085489'
+lng: '5.128158'
+location: 'Zonnenburg 2, 3512 NL, Utrecht'
+title: 'Sonnenborgh Observatory'
+external_url: https://www.sonnenborgh.nl/english
+---
+19th century solar observatory, currently a museum with a host of exhibits, multiple working telescopes and as it is built in a 16th-century fortification, also contains exhibits dedicated to archaeological finds and local history


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sonnenborgh Observatory
**Location:** Zonnenburg 2, 3512 NL, Utrecht
**Submitted by:** TimoMicro
**Website:** https://www.sonnenborgh.nl/english

### Description
19th century solar observatory, currently a museum with a host of exhibits, multiple working telescopes and as it is built in a 16th-century fortification, also contains exhibits dedicated to archaeological finds and local history

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 116
**File:** `content/daytrip/eu/nl/sonnenborgh-observatory.md`

Please review this venue submission and edit the content as needed before merging.