### PR TITLE
New: Railway Museum from TimoMicro

### DIFF
--- a/content/daytrip/eu/nl/railway-museum.md
+++ b/content/daytrip/eu/nl/railway-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/nl/railway-museum'
+date: '2025-05-29T22:22:24.751Z'
+poster: 'TimoMicro'
+lat: '52.087948'
+lng: '5.131044'
+location: 'Maliebaanstation 16, 3581 LE, Utrecht'
+title: 'Railway Museum'
+external_url: https://www.spoorwegmuseum.nl/en/
+---
+Former railway station turned railway museum. Focuses on both the history and future of train travel, has original infrastructure like turn-tables, historic trains and interactive exhibits.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Railway Museum
**Location:** Maliebaanstation 16, 3581 LE, Utrecht
**Submitted by:** TimoMicro
**Website:** https://www.spoorwegmuseum.nl/en/

### Description
Former railway station turned railway museum. Focuses on both the history and future of train travel, has original infrastructure like turn-tables, historic trains and interactive exhibits.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 117
**File:** `content/daytrip/eu/nl/railway-museum.md`

Please review this venue submission and edit the content as needed before merging.