### PR TITLE
New: SCMAGLEV and railway park from Shiawase

### DIFF
--- a/content/daytrip/as/jp/scmaglev-and-railway-park.md
+++ b/content/daytrip/as/jp/scmaglev-and-railway-park.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/as/jp/scmaglev-and-railway-park'
+date: '2025-05-29T22:25:58.784Z'
+poster: 'Shiawase'
+lat: '35.048795'
+lng: '136.850767'
+location: '3 Chome-2-2 Kinjofuto, Minato Ward, Nagoya, Aichi 455-0848'
+title: 'SCMAGLEV and railway park'
+external_url: https://museum.jr-central.co.jp/en/
+---
+Everything you might want to know about shinkansen (bullet trains) and the new maglev train. They have everything from the test model of the maglev to early rolling stock built in the UK. There is also a chance to try a driving simulator, however places are allocated through a lottery system using your entrance ticket. 
+Access is via the Aonami Line from Nagoya JR station. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** SCMAGLEV and railway park
**Location:** 3 Chome-2-2 Kinjofuto, Minato Ward, Nagoya, Aichi 455-0848
**Submitted by:** Shiawase
**Website:** https://museum.jr-central.co.jp/en/

### Description
Everything you might want to know about shinkansen (bullet trains) and the new maglev train. They have everything from the test model of the maglev to early rolling stock built in the UK. There is also a chance to try a driving simulator, however places are allocated through a lottery system using your entrance ticket. 
Access is via the Aonami Line from Nagoya JR station. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 119
**File:** `content/daytrip/as/jp/scmaglev-and-railway-park.md`

Please review this venue submission and edit the content as needed before merging.