### PR TITLE
New: Natuurhistorisch Museum Rotterdam from TimoMicro

### DIFF
--- a/content/daytrip/eu/nl/natuurhistorisch-museum-rotterdam.md
+++ b/content/daytrip/eu/nl/natuurhistorisch-museum-rotterdam.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/nl/natuurhistorisch-museum-rotterdam'
+date: '2025-05-29T22:28:46.532Z'
+poster: 'TimoMicro'
+lat: '51.910758'
+lng: '4.472476'
+location: 'Westzeedijk 345, 3015 AA, Rotterdam'
+title: 'Natuurhistorisch Museum Rotterdam'
+external_url: https://www.hetnatuurhistorisch.nl/en/exhibitions/permanent/dead-animal-tales/
+---
+Museum of Natural History, and notably the location of the annual Dead Duck Day on June 5th. Dead Duck Day is a commemoration for the mallard, famous for earning Kees Moeliker the IgNobel Prize in Biology in 2003 for his paper "The first case of homosexual necrophilia in the mallard Anas platyrhynchos (Aves: Anatidae)". The museum has a quirky collection.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Natuurhistorisch Museum Rotterdam
**Location:** Westzeedijk 345, 3015 AA, Rotterdam
**Submitted by:** TimoMicro
**Website:** https://www.hetnatuurhistorisch.nl/en/exhibitions/permanent/dead-animal-tales/

### Description
Museum of Natural History and notably the location of the annual Dead Duck Day on June 5th. Dead Duck Day is a commemoration for the mallard famous for earning Kees Moeliker the IgNobel Prize in Biology in 2003 for his paper "The first case of homosexual necrophilia in the mallard Anas platyrhynchos (Aves: Anatidae)". The museum has a quirky collection.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 122
**File:** `content/daytrip/eu/nl/natuurhistorisch-museum-rotterdam.md`

Please review this venue submission and edit the content as needed before merging.