### PR TITLE
New: Wolfsburg Planetarium from MarcN

### DIFF
--- a/content/daytrip/eu/de/wolfsburg-planetarium.md
+++ b/content/daytrip/eu/de/wolfsburg-planetarium.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/wolfsburg-planetarium'
+date: '2025-05-29T22:32:56.595Z'
+poster: 'MarcN'
+lat: '52.416989'
+lng: '10.7816'
+location: 'Uhlandweg 2, 38440 Wolfsburg, Germany'
+title: 'Wolfsburg Planetarium'
+external_url: https://planetarium-wolfsburg.de/
+---
+Planetarium with regular astronomical shows as well as special music programs and movies for younger visitors.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wolfsburg Planetarium
**Location:** Uhlandweg 2, 38440 Wolfsburg, Germany
**Submitted by:** MarcN
**Website:** https://planetarium-wolfsburg.de/

### Description
Planetarium with regular astronomical shows as well as special music programs and movies for younger visitors.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 124
**File:** `content/daytrip/eu/de/wolfsburg-planetarium.md`

Please review this venue submission and edit the content as needed before merging.