### PR TITLE
New: Hobbiton Movie Set - Lord of the Rings - The Hobbit from TimoMicro

### DIFF
--- a/content/daytrip/oc/nz/hobbiton-movie-set-lord-of-the-rings-the-hobbit.md
+++ b/content/daytrip/oc/nz/hobbiton-movie-set-lord-of-the-rings-the-hobbit.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/oc/nz/hobbiton-movie-set-lord-of-the-rings-the-hobbit'
+date: '2025-05-29T22:33:33.695Z'
+poster: 'TimoMicro'
+lat: '-37.857167'
+lng: '175.680871'
+location: '501 Buckland Road, Matamata, New Zealand'
+title: 'Hobbiton Movie Set - Lord of the Rings - The Hobbit'
+external_url: https://www.hobbitontours.com/
+---
+Guided tours of (recreations of) famous sets of Lord of the Rings and the Hobbit film trilogies. Visit the Shire, marvel at Hobbit holes, and have a drink at the Green Dragon Inn.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hobbiton Movie Set - Lord of the Rings - The Hobbit
**Location:** 501 Buckland Road, Matamata, New Zealand
**Submitted by:** TimoMicro
**Website:** https://www.hobbitontours.com/

### Description
Guided tours of (recreations of) famous sets of Lord of the Rings and the Hobbit film trilogies. Visit the Shire, marvel at Hobbit holes, and have a drink at the Green Dragon Inn.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 125
**File:** `content/daytrip/oc/nz/hobbiton-movie-set-lord-of-the-rings-the-hobbit.md`

Please review this venue submission and edit the content as needed before merging.