### PR TITLE
New: Museum of Water and Steam from Bruno Girin

### DIFF
--- a/content/daytrip/eu/gb/museum-of-water-and-steam.md
+++ b/content/daytrip/eu/gb/museum-of-water-and-steam.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/museum-of-water-and-steam'
+date: '2025-05-29T22:34:06.871Z'
+poster: 'Bruno Girin'
+lat: '51.488844'
+lng: '-0.29058'
+location: 'Green Dragon Lane, TW8 0EN'
+title: 'Museum of Water and Steam'
+external_url: https://waterandsteam.org.uk/
+---
+Former water pumping station. They now host humongous steam engines and a miniature steam railway. Great day out for kids of all ages.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum of Water and Steam
**Location:** Green Dragon Lane, TW8 0EN
**Submitted by:** Bruno Girin
**Website:** https://waterandsteam.org.uk/

### Description
Former water pumping station. They now host humongous steam engines and a miniature steam railway. Great day out for kids of all ages.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 126
**File:** `content/daytrip/eu/gb/museum-of-water-and-steam.md`

Please review this venue submission and edit the content as needed before merging.