### PR TITLE
New: Nagoya City Science Museum from Shiawase

### DIFF
--- a/content/daytrip/as/jp/nagoya-city-science-museum.md
+++ b/content/daytrip/as/jp/nagoya-city-science-museum.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/as/jp/nagoya-city-science-museum'
+date: '2025-05-29T22:34:42.631Z'
+poster: 'Shiawase'
+lat: '35.165073'
+lng: '136.900093'
+location: '17-1, Sakae 2-chome, Naka-ku, Nagoya, 460-0008 Japan'
+title: 'Nagoya City Science Museum'
+external_url: https://www.ncsm.city.nagoya.jp/en/
+---
+A science museum and planetarium. The exhibits are very hands on and aimed at schoolchildren. Unfortunately, unlike a lot of Japanese museums there are very few english explanations or captions. I found the old Zeiss planetarium projector quite interesting as well as an artificial vortex spanning a number of floors. 
+Outside there is a Japanese space rocket, which you can examine even without entering the museum.
+Not an exhibit but the hydraulic pistons for earthquake damping are interesting too


### PR DESCRIPTION
## New Venue Submission

**Venue:** Nagoya City Science Museum
**Location:** 17-1, Sakae 2-chome, Naka-ku, Nagoya, 460-0008 Japan
**Submitted by:** Shiawase
**Website:** https://www.ncsm.city.nagoya.jp/en/

### Description
A science museum and planetarium. The exhibits are very hands on and aimed at schoolchildren. Unfortunately, unlike a lot of Japanese museums there are very few english explanations or captions. I found the old Zeiss planetarium projector quite interesting as well as an artificial vortex spanning a number of floors. 
Outside there is a Japanese space rocket, which you can examine even without entering the museum.
Not an exhibit but the hydraulic pistons for earthquake damping are interesting too

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 128
**File:** `content/daytrip/as/jp/nagoya-city-science-museum.md`

Please review this venue submission and edit the content as needed before merging.