### PR TITLE
New: Seehundstation Friedrichskoog from MarcN

### DIFF
--- a/content/daytrip/eu/de/seehundstation-friedrichskoog.md
+++ b/content/daytrip/eu/de/seehundstation-friedrichskoog.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/seehundstation-friedrichskoog'
+date: '2025-05-29T22:35:02.188Z'
+poster: 'MarcN'
+lat: '54.001035'
+lng: '8.876041'
+location: 'An der Seeschleuse 4, 25718 Friedrichskoog, Germany'
+title: 'Seehundstation Friedrichskoog'
+external_url: https://www.seehundstation-friedrichskoog.de/
+---
+Seal Centre which allows visitors to observe the seals on land and through the large viewing windows underwater.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Seehundstation Friedrichskoog
**Location:** An der Seeschleuse 4, 25718 Friedrichskoog, Germany
**Submitted by:** MarcN
**Website:** https://www.seehundstation-friedrichskoog.de/

### Description
Seal Centre which allows visitors to observe the seals on land and through the large viewing windows underwater.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 129
**File:** `content/daytrip/eu/de/seehundstation-friedrichskoog.md`

Please review this venue submission and edit the content as needed before merging.