### PR TITLE
New: Klimahaus Bremerhaven from MarcN

### DIFF
--- a/content/daytrip/eu/de/klimahaus-bremerhaven.md
+++ b/content/daytrip/eu/de/klimahaus-bremerhaven.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/klimahaus-bremerhaven'
+date: '2025-05-29T22:35:37.342Z'
+poster: 'MarcN'
+lat: '53.543119'
+lng: '8.574378'
+location: 'Am Längengrad 8, 27568 Bremerhaven, Germany'
+title: 'Klimahaus Bremerhaven'
+external_url: https://www.klimahaus-bremerhaven.de/
+---
+A journey through all climate zones of Earth along the eighth degree of longitude. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Klimahaus Bremerhaven
**Location:** Am Längengrad 8, 27568 Bremerhaven, Germany
**Submitted by:** MarcN
**Website:** https://www.klimahaus-bremerhaven.de/

### Description
A journey through all climate zones of Earth along the eighth degree of longitude. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 131
**File:** `content/daytrip/eu/de/klimahaus-bremerhaven.md`

Please review this venue submission and edit the content as needed before merging.