### PR TITLE
New: Meiji Mura from Shiawase

### DIFF
--- a/content/daytrip/as/jp/meiji-mura.md
+++ b/content/daytrip/as/jp/meiji-mura.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/as/jp/meiji-mura'
+date: '2025-05-29T22:51:00.283Z'
+poster: 'Shiawase'
+lat: '35.340553'
+lng: '136.988783'
+location: '〒484-0000 Aichi-ken, Inuyama-shi, Uchiyama 1'
+title: 'Meiji Mura'
+external_url: https://www.meijimura.com/
+---
+An open air architectural park North East of Nagoya comprised of buildings relocated from all over Japan. The Meiji period is roughly comparable to Victorian and was the era when Japan opened to the West. 
+Notable buildings are Lafcadio Hearne's house and Natsume Soseki's house. There is also an early wooden Japanese prison. Most famous is the Lobby and Entrance of Frank Lloyd Wright's Tokyo Imperial Hotel. 
+The park can be access by bus from Inuyama, itself a short train ride from Nagoya. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Meiji Mura
**Location:** 〒484-0000 Aichi-ken, Inuyama-shi, Uchiyama 1
**Submitted by:** Shiawase
**Website:** https://www.meijimura.com/

### Description
An open air architectural park North East of Nagoya comprised of buildings relocated from all over Japan. The Meiji period is roughly comparable to Victorian and was the era when Japan opened to the West. 
Notable buildings are Lafcadio Hearne's house and Natsume Soseki's house. There is also an early wooden Japanese prison. Most famous is the Lobby and Entrance of Frank Lloyd Wright's Tokyo Imperial Hotel. 
The park can be access by bus from Inuyama, itself a short train ride from Nagoya. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 134
**File:** `content/daytrip/as/jp/meiji-mura.md`

Please review this venue submission and edit the content as needed before merging.