### PR TITLE
New: Deutsches Erdölmuseum Wietze from MarcN

### DIFF
--- a/content/daytrip/eu/de/deutsches-erdlmuseum-wietze.md
+++ b/content/daytrip/eu/de/deutsches-erdlmuseum-wietze.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/deutsches-erdlmuseum-wietze'
+date: '2025-05-29T22:52:39.454Z'
+poster: 'MarcN'
+lat: '52.659616'
+lng: '9.833193'
+location: 'Schwarzer Weg 7-9, 29323 Wietze, Germany'
+title: 'Deutsches Erdölmuseum Wietze'
+external_url: https://www.erdoelmuseum.de/
+---
+Exhibition on oil production in general and on production at the museum site, where oil has been extracted since the 17th century. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Deutsches Erdölmuseum Wietze
**Location:** Schwarzer Weg 7-9, 29323 Wietze, Germany
**Submitted by:** MarcN
**Website:** https://www.erdoelmuseum.de/

### Description
Exhibition on oil production in general and on production at the museum site, where oil has been extracted since the 17th century. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 137
**File:** `content/daytrip/eu/de/deutsches-erdlmuseum-wietze.md`

Please review this venue submission and edit the content as needed before merging.