### PR TITLE
New: Cragend Farm from Chris

### DIFF
--- a/content/daytrip/eu/gb/cragend-farm.md
+++ b/content/daytrip/eu/gb/cragend-farm.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/cragend-farm'
+date: '2025-05-29T22:52:59.014Z'
+poster: 'Chris'
+lat: '55.301977'
+lng: '-1.86524'
+location: 'Cragend Farm Rothbury Morpeth Northumberland NE65 7XN'
+title: 'Cragend Farm'
+external_url: https://cragendfarm.co.uk/tours/
+---
+Celtic Camp and Ducal Border Reiver settlement, remodelled by Victorian Lord Armstrong of Cragside as his show case for hydraulic machinery. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cragend Farm
**Location:** Cragend Farm Rothbury Morpeth Northumberland NE65 7XN
**Submitted by:** Chris
**Website:** https://cragendfarm.co.uk/tours/

### Description
Celtic Camp and Ducal Border Reiver settlement, remodelled by Victorian Lord Armstrong of Cragside as his show case for hydraulic machinery. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 138
**File:** `content/daytrip/eu/gb/cragend-farm.md`

Please review this venue submission and edit the content as needed before merging.