### PR TITLE
New: Mikasa Memorial Ship from Shiawase

### DIFF
--- a/content/daytrip/as/jp/mikasa-memorial-ship.md
+++ b/content/daytrip/as/jp/mikasa-memorial-ship.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/as/jp/mikasa-memorial-ship'
+date: '2025-05-29T23:23:44.927Z'
+poster: 'Shiawase'
+lat: '35.28507'
+lng: '139.674296'
+location: '82-19 Inaokacho, Yokosuka, Kanagawa 238-0003, Japan'
+title: 'Mikasa Memorial Ship'
+external_url: https://www.kinenkan-mikasa.or.jp/index.html
+---
+The restored pre dreadnaught ship used as Admiral Togo's flagship at the battle of Tsushima when Japan defeated the Russian fleet in 1905. 
+Sadly encased in concrete and stripped of many fittings at the insistence of the occupying powers post ww2, you'd wonder how much of Ship of Theseus is going on. Nevertheless it is an important historical ship and now unique. 
+Situated in Yokosuka. Where the US Navy has a huge base and you can also see JSDF vessels in the bay. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Mikasa Memorial Ship
**Location:** 82-19 Inaokacho, Yokosuka, Kanagawa 238-0003, Japan
**Submitted by:** Shiawase
**Website:** https://www.kinenkan-mikasa.or.jp/index.html

### Description
The restored pre dreadnaught ship used as Admiral Togo's flagship at the battle of Tsushima when Japan defeated the Russian fleet in 1905. 
Sadly encased in concrete and stripped of many fittings at the insistence of the occupying powers post ww2, you'd wonder how much of Ship of Theseus is going on. Nevertheless it is an important historical ship and now unique. 
Situated in Yokosuka. Where the US Navy has a huge base and you can also see JSDF vessels in the bay. 


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 140
**File:** `content/daytrip/as/jp/mikasa-memorial-ship.md`

Please review this venue submission and edit the content as needed before merging.