### PR TITLE
New: H.P. Lovecraft's Grave from Paul Drye

### DIFF
--- a/content/daytrip/eu/gb/hp-lovecrafts-grave.md
+++ b/content/daytrip/eu/gb/hp-lovecrafts-grave.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/hp-lovecrafts-grave'
+date: '2025-05-29T23:24:25.782Z'
+poster: 'Paul Drye'
+lat: '41.854075'
+lng: '-71.381055'
+location: 'Hemlock Avenue, Swan Point Cemetary, Providence, Rhode Island, United States'
+title: 'H.P. Lovecraft's Grave'
+external_url: https://www.findagrave.com/memorial/1188/hp-lovecraft
+---
+The final resting place of weird fiction writer H.P. Lovecraft. Find the large obelisk devoted to the Philips family and right next to it is the small marker for his grave, inscribed "I AM PROVIDENCE".

--- a/content/daytrip/eu/gb/hp-lovecrafts-grave.md
+++ b/content/daytrip/eu/gb/hp-lovecrafts-grave.md
@@ -1,11 +1,11 @@
 ---
-slug: 'daytrip/eu/gb/hp-lovecrafts-grave'
+slug: 'daytrip/na/us/hp-lovecrafts-grave'
 date: '2025-05-29T23:24:25.782Z'
 poster: 'Paul Drye'
 lat: '41.854075'
 lng: '-71.381055'
 location: 'Hemlock Avenue, Swan Point Cemetary, Providence, Rhode Island, United States'
-title: 'H.P. Lovecraft's Grave'
+title: "H.P. Lovecraft's Grave"
 external_url: https://www.findagrave.com/memorial/1188/hp-lovecraft
 ---
 The final resting place of weird fiction writer H.P. Lovecraft. Find the large obelisk devoted to the Philips family and right next to it is the small marker for his grave, inscribed "I AM PROVIDENCE".


### PR DESCRIPTION
## New Venue Submission

**Venue:** H.P. Lovecraft's Grave
**Location:** Hemlock Avenue, Swan Point Cemetary, Providence, Rhode Island, United States
**Submitted by:** Paul Drye
**Website:** https://www.findagrave.com/memorial/1188/hp-lovecraft

### Description
The final resting place of weird fiction writer H.P. Lovecraft. Find the large obelisk devoted to the Philips family and right next to it is the small marker for his grave, inscribed "I AM PROVIDENCE".

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 142
**File:** `content/daytrip/eu/gb/hp-lovecrafts-grave.md`

Please review this venue submission and edit the content as needed before merging.