### PR TITLE
New: The Beguiling from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/the-beguiling.md
+++ b/content/daytrip/na/ca/the-beguiling.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/ca/the-beguiling'
+date: '2025-05-29T23:24:56.766Z'
+poster: 'Paul Drye'
+lat: '43.65739'
+lng: '-79.402083'
+location: '319 College St, Toronto, Ontario, Canada'
+title: 'The Beguiling'
+external_url: https://beguilingbooks.com/about-us
+---
+If you're into alternative comics, quite possibly the best comic store in Canada if not the world. Next door is Little Island Comics, an associated store devoted to young readers.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Beguiling
**Location:** 319 College St, Toronto, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://beguilingbooks.com/about-us

### Description
If you're into alternative comics, quite possibly the best comic store in Canada if not the world. Next door is Little Island Comics, an associated store devoted to young readers.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 143
**File:** `content/daytrip/na/ca/the-beguiling.md`

Please review this venue submission and edit the content as needed before merging.