### PR TITLE
New: Torture Museum from MarcN

### DIFF
--- a/content/daytrip/eu/nl/torture-museum.md
+++ b/content/daytrip/eu/nl/torture-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/nl/torture-museum'
+date: '2025-05-29T23:25:38.023Z'
+poster: 'MarcN'
+lat: '52.367277'
+lng: '4.890659'
+location: 'Singel 449, 1012 WP Amsterdam, Netherlands'
+title: 'Torture Museum'
+external_url: https://torturemuseum.org/
+---
+Exhibition on over 40 instruments of punishment from different parts of Europe, from the inquisition chair to the guillotine.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Torture Museum
**Location:** Singel 449, 1012 WP Amsterdam, Netherlands
**Submitted by:** MarcN
**Website:** https://torturemuseum.org/

### Description
Exhibition on over 40 instruments of punishment from different parts of Europe, from the inquisition chair to the guillotine.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 145
**File:** `content/daytrip/eu/nl/torture-museum.md`

Please review this venue submission and edit the content as needed before merging.