### PR TITLE
New: Audubon Aquarium of the Americas from MarcN

### DIFF
--- a/content/daytrip/eu/de/audubon-aquarium-of-the-americas.md
+++ b/content/daytrip/eu/de/audubon-aquarium-of-the-americas.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/de/audubon-aquarium-of-the-americas'
+date: '2025-05-29T23:25:55.872Z'
+poster: 'MarcN'
+lat: '29.950854'
+lng: '-90.063246'
+location: '1 Canal St New Orleans, LA 70130, Germany'
+title: 'Audubon Aquarium of the Americas'
+external_url: https://audubonnatureinstitute.org/aquarium
+---
+Exhibition on the aquatic life of the Americas with more than 10000 animals.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Audubon Aquarium of the Americas
**Location:** 1 Canal St New Orleans, LA 70130, Germany
**Submitted by:** MarcN
**Website:** https://audubonnatureinstitute.org/aquarium

### Description
Exhibition on the aquatic life of the Americas with more than 10000 animals.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 146
**File:** `content/daytrip/eu/de/audubon-aquarium-of-the-americas.md`

Please review this venue submission and edit the content as needed before merging.