### PR TITLE
New: Forge Mill Needle Museum from Matthew Somerville

### DIFF
--- a/content/daytrip/eu/gb/forge-mill-needle-museum.md
+++ b/content/daytrip/eu/gb/forge-mill-needle-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/forge-mill-needle-museum'
+date: '2025-05-29T23:26:59.856Z'
+poster: 'Matthew Somerville'
+lat: '52.315051'
+lng: '-1.934227'
+location: 'Forge Mill Needle Museum & Bordesley Abbey Visitor Centre, Needle Mill Lane, Riverside, Redditch, B98 8HY'
+title: 'Forge Mill Needle Museum'
+external_url: https://www.forgemill.org.uk/
+---
+Redditch once produced 90% of the world’s needles. This museum contains both the world's largest and smallest needles, was very interesting when we went there last weekend, and is also next to the ruins of Bordesley Abbey.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Forge Mill Needle Museum
**Location:** Forge Mill Needle Museum & Bordesley Abbey Visitor Centre, Needle Mill Lane, Riverside, Redditch, B98 8HY
**Submitted by:** Matthew Somerville
**Website:** https://www.forgemill.org.uk/

### Description
Redditch once produced 90% of the world’s needles. This museum contains both the world's largest and smallest needles, was very interesting when we went there last weekend, and is also next to the ruins of Bordesley Abbey.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 149
**File:** `content/daytrip/eu/gb/forge-mill-needle-museum.md`

Please review this venue submission and edit the content as needed before merging.