### PR TITLE
New: Stella Maris Old Cemetery from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/stella-maris-old-cemetery.md
+++ b/content/daytrip/na/ca/stella-maris-old-cemetery.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/ca/stella-maris-old-cemetery'
+date: '2025-05-29T23:27:25.374Z'
+poster: 'Paul Drye'
+lat: '44.189005'
+lng: '-66.159496'
+location: '8261 Highway 1, Meteghan, Nova Scotia, Canada'
+title: 'Stella Maris Old Cemetery'
+external_url: https://www.historicmysteries.com/history/jerome-of-sandy-cove/2187/
+---
+If you're interested in unsolved mysteries, this cemetery has a grave marker for "Jerome" who washed up on the shore at nearby Sandy Cove. He had two amputated legs and never spoke once for the rest of his life—a period of almost fifty years.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Stella Maris Old Cemetery
**Location:** 8261 Highway 1, Meteghan, Nova Scotia, Canada
**Submitted by:** Paul Drye
**Website:** https://www.historicmysteries.com/history/jerome-of-sandy-cove/2187/

### Description
If you're interested in unsolved mysteries, this cemetery has a grave marker for "Jerome" who washed up on the shore at nearby Sandy Cove. He had two amputated legs and never spoke once for the rest of his life—a period of almost fifty years.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 150
**File:** `content/daytrip/na/ca/stella-maris-old-cemetery.md`

Please review this venue submission and edit the content as needed before merging.