### PR TITLE
New: Wizards of the Toast from TimoMicro

### DIFF
--- a/content/daytrip/eu/gb/wizards-of-the-toast.md
+++ b/content/daytrip/eu/gb/wizards-of-the-toast.md
@@ -1,5 +1,5 @@
 ---
-slug: 'daytrip/eu/gb/wizards-of-the-toast'
+slug: 'daytrip/eu/pt/wizards-of-the-toast'
 date: '2025-05-30T09:11:11.091Z'
 poster: 'TimoMicro'
 lat: '38.769418'

--- a/content/daytrip/eu/gb/wizards-of-the-toast.md
+++ b/content/daytrip/eu/gb/wizards-of-the-toast.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/wizards-of-the-toast'
+date: '2025-05-30T09:11:11.091Z'
+poster: 'TimoMicro'
+lat: '38.769418'
+lng: '-9.101545'
+location: 'R. Conselheiro Lopo Vaz Lote C Loja D, 1800-142 Lisboa, Portugal'
+title: 'Wizards of the Toast'
+external_url: https://www.instagram.com/wizardsofthetoastpt/
+---
+Cafe/Bar focusing on board games and table top gaming.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wizards of the Toast
**Location:** R. Conselheiro Lopo Vaz Lote C Loja D, 1800-142 Lisboa, Portugal
**Submitted by:** TimoMicro
**Website:** https://www.instagram.com/wizardsofthetoastpt/

### Description
Cafe/Bar focusing on board games and table top gaming.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 157
**File:** `content/daytrip/eu/gb/wizards-of-the-toast.md`

Please review this venue submission and edit the content as needed before merging.