### PR TITLE
New: The Vagina Museum from TimoMicro

### DIFF
--- a/content/daytrip/eu/gb/the-vagina-museum.md
+++ b/content/daytrip/eu/gb/the-vagina-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-vagina-museum'
+date: '2025-05-30T09:12:00.087Z'
+poster: 'TimoMicro'
+lat: '51.530359'
+lng: '-0.056895'
+location: 'Arches 275-276, Poyser Street, London E2 9RF, United Kingdom'
+title: 'The Vagina Museum'
+external_url: https://www.vaginamuseum.co.uk/
+---
+Museum of gynaecological anatomy, founded to improve understanding of and spark open conversations about gynaecological anatomy, erase stigma around topics such as intersex bodies, act as a forum for feminism and LGBTQIA+ rights, challenge cis- and heteronormative behaviour and promote inclusive values.       


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Vagina Museum
**Location:** Arches 275-276, Poyser Street, London E2 9RF, United Kingdom
**Submitted by:** TimoMicro
**Website:** https://www.vaginamuseum.co.uk/

### Description
Museum of gynaecological anatomy, founded to improve understanding of and spark open conversations about gynaecological anatomy, erase stigma around topics such as intersex bodies, act as a forum for feminism and LGBTQIA+ rights, challenge cis- and heteronormative behaviour and promote inclusive values.       

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 158
**File:** `content/daytrip/eu/gb/the-vagina-museum.md`

Please review this venue submission and edit the content as needed before merging.