### PR TITLE
New: Huntarian Museum from TimoMicro

### DIFF
--- a/content/daytrip/eu/gb/huntarian-museum.md
+++ b/content/daytrip/eu/gb/huntarian-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/huntarian-museum'
+date: '2025-05-30T09:12:42.932Z'
+poster: 'TimoMicro'
+lat: '55.871746'
+lng: '-4.288359'
+location: 'University Ave, Glasgow G12 8QQ, United Kingdom'
+title: 'Huntarian Museum'
+external_url: https://www.gla.ac.uk/hunterian/
+---
+"The oldest public museum in Scotland, with collections spanning arts, sciences and humanities, The Hunterian is at the forefront of university museums around the world."


### PR DESCRIPTION
## New Venue Submission

**Venue:** Huntarian Museum
**Location:** University Ave, Glasgow G12 8QQ, United Kingdom
**Submitted by:** TimoMicro
**Website:** https://www.gla.ac.uk/hunterian/

### Description
"The oldest public museum in Scotland, with collections spanning arts, sciences and humanities, The Hunterian is at the forefront of university museums around the world."

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 159
**File:** `content/daytrip/eu/gb/huntarian-museum.md`

Please review this venue submission and edit the content as needed before merging.