### PR TITLE
New: The Jet Age Museum from AnotherFriendlyNerd

### DIFF
--- a/content/daytrip/eu/gb/the-jet-age-museum.md
+++ b/content/daytrip/eu/gb/the-jet-age-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-jet-age-museum'
+date: '2025-05-30T11:01:24.123Z'
+poster: 'AnotherFriendlyNerd'
+lat: '51.895523'
+lng: '-2.174746'
+location: 'Jet Age Museum Meteor Business Park Cheltenham Road East Gloucester, GL2 9QL'
+title: 'The Jet Age Museum'
+external_url: https://jetagemuseum.org/
+---
+A FREE to enter museum which, rather predictably, is all about the development of the jet engine. One of the best exhibits is the cockpit of a Vulcan bomber, which visitors can climb up into.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Jet Age Museum
**Location:** Jet Age Museum Meteor Business Park Cheltenham Road East Gloucester, GL2 9QL
**Submitted by:** AnotherFriendlyNerd
**Website:** https://jetagemuseum.org/

### Description
A FREE to enter museum which, rather predictably, is all about the development of the jet engine. One of the best exhibits is the cockpit of a Vulcan bomber, which visitors can climb up into.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 161
**File:** `content/daytrip/eu/gb/the-jet-age-museum.md`

Please review this venue submission and edit the content as needed before merging.