### PR TITLE
New: Merril Collection of Science Fiction, Speculation & Fantasy from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/merril-collection-of-science-fiction-speculation-fantasy.md
+++ b/content/daytrip/na/ca/merril-collection-of-science-fiction-speculation-fantasy.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/na/ca/merril-collection-of-science-fiction-speculation-fantasy'
+date: '2025-05-30T13:20:36.410Z'
+poster: 'Paul Drye'
+lat: '43.657984'
+lng: '-79.398193'
+location: '239 College Street, 3rd floor, Toronto, Ontario, Canada'
+title: 'Merril Collection of Science Fiction, Speculation & Fantasy'
+external_url: https://www.torontopubliclibrary.ca/merril/
+---
+A research collection of science fiction, fantasy, and speculative literature consisting of more than 80,000 works of fiction, non-fiction, role-playing games, manuscripts, original art, and correspondence. Members of the public can take any item may be taken to its reading room after filling in a brief form and showing some ID. They do ask that you call ahead if you want to see original art.
+
+Located in the Lillian H. Smith branch of the Toronto Public Library system.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Merril Collection of Science Fiction, Speculation & Fantasy
**Location:** 239 College Street, 3rd floor, Toronto, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://www.torontopubliclibrary.ca/merril/

### Description
A research collection of science fiction, fantasy, and speculative literature consisting of more than 80,000 works of fiction, non-fiction, role-playing games, manuscripts, original art, and correspondence. Members of the public can take any item may be taken to its reading room after filling in a brief form and showing some ID. They do ask that you call ahead if you want to see original art.

Located in the Lillian H. Smith branch of the Toronto Public Library system.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 162
**File:** `content/daytrip/na/ca/merril-collection-of-science-fiction-speculation-fantasy.md`

Please review this venue submission and edit the content as needed before merging.