### PR TITLE
New: Wigtown from Hugo

### DIFF
--- a/content/daytrip/eu/gb/wigtown.md
+++ b/content/daytrip/eu/gb/wigtown.md
@@ -1,0 +1,15 @@
+---
+slug: 'daytrip/eu/gb/wigtown'
+date: '2025-05-30T13:24:47.885Z'
+poster: 'Hugo'
+lat: '54.868149'
+lng: '-4.442768'
+location: 'Wigtown, Dumfries and Galloway, Scotland'
+title: 'Wigtown'
+external_url: https://www.wigtown-booktown.co.uk
+---
+Lots of books, mostly second-hand.
+
+Not as big as Hay on Wye, but still very much worth a visit.
+
+"At the Sign of the Green Dragon" is a specialist SF&F shop with a large stock on the outskirts of the town.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wigtown
**Location:** Wigtown, Dumfries and Galloway, Scotland
**Submitted by:** Hugo
**Website:** https://www.wigtown-booktown.co.uk

### Description
Lots of books, mostly second-hand.

Not as big as Hay on Wye, but still very much worth a visit.

"At the Sign of the Green Dragon" is a specialist SF&F shop with a large stock on the outskirts of the town.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 163
**File:** `content/daytrip/eu/gb/wigtown.md`

Please review this venue submission and edit the content as needed before merging.