### PR TITLE
New: Falkirk Wheel from Hugo

### DIFF
--- a/content/daytrip/eu/gb/falkirk-wheel.md
+++ b/content/daytrip/eu/gb/falkirk-wheel.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/falkirk-wheel'
+date: '2025-05-30T13:25:12.517Z'
+poster: 'Hugo'
+lat: '56.000337'
+lng: '-3.841717'
+location: 'The Falkirk Wheel, Lime Road, Falkirk FK1 4RS'
+title: 'Falkirk Wheel'
+external_url: https://www.scottishcanals.co.uk/visit/canals/visit-the-forth-clyde-canal/attractions/the-falkirk-wheel
+---
+The world's only rotating boat lift.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Falkirk Wheel
**Location:** The Falkirk Wheel, Lime Road, Falkirk FK1 4RS
**Submitted by:** Hugo
**Website:** https://www.scottishcanals.co.uk/visit/canals/visit-the-forth-clyde-canal/attractions/the-falkirk-wheel

### Description
The world's only rotating boat lift.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 164
**File:** `content/daytrip/eu/gb/falkirk-wheel.md`

Please review this venue submission and edit the content as needed before merging.