### PR TITLE
New: Museum for Papirkunst from Hugo

### DIFF
--- a/content/daytrip/eu/dk/museum-for-papirkunst.md
+++ b/content/daytrip/eu/dk/museum-for-papirkunst.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/dk/museum-for-papirkunst'
+date: '2025-05-30T13:34:27.538Z'
+poster: 'Hugo'
+lat: '57.247747'
+lng: '9.622001'
+location: 'Ilsigvej 2, DK-9492 Blokhus, Danmark'
+title: 'Museum for Papirkunst'
+external_url: https://www.museumforpapirkunst.dk
+---
+A museum of paper art


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum for Papirkunst
**Location:** Ilsigvej 2, DK-9492 Blokhus, Danmark
**Submitted by:** Hugo
**Website:** https://www.museumforpapirkunst.dk

### Description
A museum of paper art

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 165
**File:** `content/daytrip/eu/dk/museum-for-papirkunst.md`

Please review this venue submission and edit the content as needed before merging.