### PR TITLE
New: High Down Rocket Test Site from Paul Drye

### DIFF
--- a/content/daytrip/eu/gb/high-down-rocket-test-site.md
+++ b/content/daytrip/eu/gb/high-down-rocket-test-site.md
@@ -1,0 +1,15 @@
+---
+slug: 'daytrip/eu/gb/high-down-rocket-test-site'
+date: '2025-05-30T13:37:55.175Z'
+poster: 'Paul Drye'
+lat: '50.661371'
+lng: '-1.577793'
+location: 'Needles PO39 0JH, United Kingdom'
+title: 'High Down Rocket Test Site'
+external_url: https://en.wikipedia.org/wiki/High_Down_Rocket_Test_Site
+---
+Most come here for the Needles, two rock spires off the coast, but next door to the viewpoint are what’s left of High Down Rocket Test Site.
+
+In the 50s and 60s the UK tried to be a third contestant in the Space Race and here they tested their rockets. The Black Arrow that sent Britain's launched the UK’s one-and-only indigenous orbital mission was among them.
+
+Only walkways and the foundations of the test stands remain, but a two-room museum is at the Needles New Battery a short walk away.


### PR DESCRIPTION
## New Venue Submission

**Venue:** High Down Rocket Test Site
**Location:** Needles PO39 0JH, United Kingdom
**Submitted by:** Paul Drye
**Website:** https://en.wikipedia.org/wiki/High_Down_Rocket_Test_Site

### Description
Most come here for the Needles, two rock spires off the coast, but next door to the viewpoint are what’s left of High Down Rocket Test Site.

In the 50s and 60s the UK tried to be a third contestant in the Space Race and here they tested their rockets. The Black Arrow that sent Britain's launched the UK’s one-and-only indigenous orbital mission was among them.

Only walkways and the foundations of the test stands remain, but a two-room museum is at the Needles New Battery a short walk away.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 166
**File:** `content/daytrip/eu/gb/high-down-rocket-test-site.md`

Please review this venue submission and edit the content as needed before merging.