### PR TITLE
New: The Bells of St Clement’s from Catriona

### DIFF
--- a/content/daytrip/eu/gb/the-bells-of-st-clements.md
+++ b/content/daytrip/eu/gb/the-bells-of-st-clements.md
@@ -1,0 +1,12 @@
+---
+slug: 'daytrip/eu/gb/the-bells-of-st-clements'
+date: '2025-05-30T16:07:18.731Z'
+poster: 'Catriona'
+lat: '52.209056'
+lng: '0.117872'
+location: 'St Clement’s Church'
+title: 'The Bells of St Clement’s'
+external_url: https://bells-of-stclements.scy.org.uk/index.php
+---
+As far as I know this is the only place in the country offering daily public demonstrations of the art of bellringing. The half-hour experience includes an introduction to the history of ringing, how the patterns of ‘changes’ are constructed, and the opportunity to have a go at chiming a bell, full-circle ringing, and change ringing on handbells.
+Open from 2-3pm every weekday afternoon, £8 each. Can be booked in advance or walk-in on the day. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Bells of St Clement’s
**Location:** St Clement’s Church
**Submitted by:** Catriona
**Website:** https://bells-of-stclements.scy.org.uk/index.php

### Description
As far as I know this is the only place in the country offering daily public demonstrations of the art of bellringing. The half-hour experience includes an introduction to the history of ringing, how the patterns of ‘changes’ are constructed, and the opportunity to have a go at chiming a bell, full-circle ringing, and change ringing on handbells.
Open from 2-3pm every weekday afternoon, £8 each. Can be booked in advance or walk-in on the day. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 167
**File:** `content/daytrip/eu/gb/the-bells-of-st-clements.md`

Please review this venue submission and edit the content as needed before merging.