### PR TITLE
New: Hengoed Viaduct from CraigM

### DIFF
--- a/content/daytrip/eu/gb/hengoed-viaduct.md
+++ b/content/daytrip/eu/gb/hengoed-viaduct.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/hengoed-viaduct'
+date: '2025-05-30T16:07:52.826Z'
+poster: 'CraigM'
+lat: '51.646785'
+lng: '-3.223372'
+location: 'Hengoed/Maesycwmmer, Caerphilly, South Wales'
+title: 'Hengoed Viaduct'
+external_url: https://en.wikipedia.org/wiki/Hengoed_Viaduct
+---
+Hengoed Viaduct is a disused railway viaduct located above the village of Maesycwmmer, in Caerphilly county borough, South Wales. Grade II* listed, it was originally built to carry the Taff Vale Extension of the Newport, Abergavenny and Hereford Railway (NA&HR) across the Rhymney River, and is now part of National Cycle Route 47.
+
+At its eastern end to the "Wheel o Drams" sculpture, a ~20m vertical circle of coal railway trucks, formerly commonplace in these South Wales valleys.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hengoed Viaduct
**Location:** Hengoed/Maesycwmmer, Caerphilly, South Wales
**Submitted by:** CraigM
**Website:** https://en.wikipedia.org/wiki/Hengoed_Viaduct

### Description
Hengoed Viaduct is a disused railway viaduct located above the village of Maesycwmmer, in Caerphilly county borough, South Wales. Grade II* listed, it was originally built to carry the Taff Vale Extension of the Newport, Abergavenny and Hereford Railway (NA&HR) across the Rhymney River, and is now part of National Cycle Route 47.

At its eastern end to the "Wheel o Drams" sculpture, a ~20m vertical circle of coal railway trucks, formerly commonplace in these South Wales valleys.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 168
**File:** `content/daytrip/eu/gb/hengoed-viaduct.md`

Please review this venue submission and edit the content as needed before merging.