### PR TITLE
New: The Vintage Penny Machine Arcade from Paul Drye

### DIFF
--- a/content/daytrip/eu/gb/the-vintage-penny-machine-arcade.md
+++ b/content/daytrip/eu/gb/the-vintage-penny-machine-arcade.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/the-vintage-penny-machine-arcade'
+date: '2025-05-30T16:08:51.800Z'
+poster: 'Paul Drye'
+lat: '50.949698'
+lng: '0.729486'
+location: 'Rye Heritage Centre, Strand Quay, The Old Sail Loft Rye, Rye, United Kingdom'
+title: 'The Vintage Penny Machine Arcade'
+external_url: https://www.ryeheritage.co.uk/explore/vintage-arcade-amusements/
+---
+A collection of playable Victorian-era pier penny arcade machines.
+
+The same building also features The Smugglers Attic, a short show (5 minutes long) celebrating the history of smugglers in the region and a model diorama of the town of Rye as it was in the mid-19th century.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Vintage Penny Machine Arcade
**Location:** Rye Heritage Centre, Strand Quay, The Old Sail Loft Rye, Rye, United Kingdom
**Submitted by:** Paul Drye
**Website:** https://www.ryeheritage.co.uk/explore/vintage-arcade-amusements/

### Description
A collection of playable Victorian-era pier penny arcade machines.

The same building also features The Smugglers Attic, a short show (5 minutes long) celebrating the history of smugglers in the region and a model diorama of the town of Rye as it was in the mid-19th century.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 171
**File:** `content/daytrip/eu/gb/the-vintage-penny-machine-arcade.md`

Please review this venue submission and edit the content as needed before merging.