### PR TITLE
New: The Royal Berkshire Medical Museum from Hugo

### DIFF
--- a/content/daytrip/eu/gb/the-royal-berkshire-medical-museum.md
+++ b/content/daytrip/eu/gb/the-royal-berkshire-medical-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-royal-berkshire-medical-museum'
+date: '2025-05-30T16:09:43.247Z'
+poster: 'Hugo'
+lat: '51.451389'
+lng: '-0.958622'
+location: 'Royal Berkshire Hospital, London Road, Reading'
+title: 'The Royal Berkshire Medical Museum'
+external_url: https://www.royalberkshire.nhs.uk/about-us/medical-museum
+---
+A small museum of medicine, in the old classical frontage of the Royal Berkshire Hopsital.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Royal Berkshire Medical Museum
**Location:** Royal Berkshire Hospital, London Road, Reading
**Submitted by:** Hugo
**Website:** https://www.royalberkshire.nhs.uk/about-us/medical-museum

### Description
A small museum of medicine, in the old classical frontage of the Royal Berkshire Hopsital.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 170
**File:** `content/daytrip/eu/gb/the-royal-berkshire-medical-museum.md`

Please review this venue submission and edit the content as needed before merging.