### PR TITLE
New: Big Mine Run Geyser from Paul Drye

### DIFF
--- a/content/daytrip/na/us/big-mine-run-geyser.md
+++ b/content/daytrip/na/us/big-mine-run-geyser.md
@@ -1,0 +1,15 @@
+---
+slug: 'daytrip/na/us/big-mine-run-geyser'
+date: '2025-05-30T16:10:02.849Z'
+poster: 'Paul Drye'
+lat: '40.786512'
+lng: '-76.318738'
+location: '2-528 Big Mine Run Road, Ashland, Pennsylvania, United States'
+title: 'Big Mine Run Geyser'
+external_url: https://uncoveringpa.com/big-mine-run-geyser-in-pennsylvania
+---
+The only geyser in the state of Pennsylvania, one with an unusual back story.
+
+The abandoned town of Centralia is nearby and the heat of the long-term underground coal seam fire there affected the flooded tunnels of the former Bast Colliery. That drives the colliery's water up, where it gushes as much as 15 feet in the air during periods of heavy rain.
+
+The geyser is on private land but can be seen about 5-10 meters away from the side of Big Run Mine Road.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Big Mine Run Geyser
**Location:** 2-528 Big Mine Run Road, Ashland, Pennsylvania, United States
**Submitted by:** Paul Drye
**Website:** https://uncoveringpa.com/big-mine-run-geyser-in-pennsylvania

### Description
The only geyser in the state of Pennsylvania, one with an unusual back story.

The abandoned town of Centralia is nearby and the heat of the long-term underground coal seam fire there affected the flooded tunnels of the former Bast Colliery. That drives the colliery's water up, where it gushes as much as 15 feet in the air during periods of heavy rain.

The geyser is on private land but can be seen about 5-10 meters away from the side of Big Run Mine Road.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 172
**File:** `content/daytrip/na/us/big-mine-run-geyser.md`

Please review this venue submission and edit the content as needed before merging.