### PR TITLE
New: Kyoto Railway Museum  from Shiawase

### DIFF
--- a/content/daytrip/as/jp/kyoto-railway-museum-.md
+++ b/content/daytrip/as/jp/kyoto-railway-museum-.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/as/jp/kyoto-railway-museum-'
+date: '2025-05-30T16:11:21.201Z'
+poster: 'Shiawase'
+lat: '34.987473'
+lng: '135.257436'
+location: 'Kankijicho, Shimogyo-ku, Kyoto'
+title: 'Kyoto Railway Museum '
+external_url: https://www.kyotorailwaymuseum.jp/en/
+---
+Trains! This museum has a collection of locomotives including several working steam trains. It is built on the site of a roundhouse of service sheds and a working turntable. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Kyoto Railway Museum 
**Location:** Kankijicho, Shimogyo-ku, Kyoto
**Submitted by:** Shiawase
**Website:** https://www.kyotorailwaymuseum.jp/en/

### Description
Trains! This museum has a collection of locomotives including several working steam trains. It is built on the site of a roundhouse of service sheds and a working turntable. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 173
**File:** `content/daytrip/as/jp/kyoto-railway-museum-.md`

Please review this venue submission and edit the content as needed before merging.