### PR TITLE
New: Jodrell Bank Observatory from losttourist

### DIFF
--- a/content/daytrip/eu/gb/jodrell-bank-observatory.md
+++ b/content/daytrip/eu/gb/jodrell-bank-observatory.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/jodrell-bank-observatory'
+date: '2025-05-30T17:34:17.673Z'
+poster: 'losttourist'
+lat: '53.236455'
+lng: '-2.308524'
+location: '  Bomish Lane, Nr. Macclesfield, Cheshire SK11 9DW'
+title: 'Jodrell Bank Observatory'
+external_url: https://www.jodrellbank.net/
+---
+This is the site of one of the world's first radio telescopes -- and it's still working and still in regular use by cosmologists and astronomers. It has a fantastic visitor centre and is a great day out for geeky kids and geeky adults alike!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Jodrell Bank Observatory
**Location:**   Bomish Lane, Nr. Macclesfield, Cheshire SK11 9DW
**Submitted by:** losttourist
**Website:** https://www.jodrellbank.net/

### Description
This is the site of one of the world's first radio telescopes -- and it's still working and still in regular use by cosmologists and astronomers. It has a fantastic visitor centre and is a great day out for geeky kids and geeky adults alike!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 175
**File:** `content/daytrip/eu/gb/jodrell-bank-observatory.md`

Please review this venue submission and edit the content as needed before merging.