### PR TITLE
New: Warrington Transporter Bridge from losttourist

### DIFF
--- a/content/daytrip/eu/gb/warrington-transporter-bridge.md
+++ b/content/daytrip/eu/gb/warrington-transporter-bridge.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/warrington-transporter-bridge'
+date: '2025-05-30T20:59:25.560Z'
+poster: 'losttourist'
+lat: '53.383636'
+lng: '-2.607161'
+location: 'Access from Quay Fold, next to Pink Eye Building'
+title: 'Warrington Transporter Bridge'
+external_url: http://www.warringtontransporterbridge.co.uk/
+---
+There were never many transporter bridges built in the UK and there are very few of them left. Warrington's is unique in that it was built to carry rail rather than road traffic.
+
+The only easy access route is via a permissive path through the old Unilever factory ... although that's a little bit of a nerdy adventure in its own right!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Warrington Transporter Bridge
**Location:** Access from Quay Fold, next to Pink Eye Building
**Submitted by:** losttourist
**Website:** http://www.warringtontransporterbridge.co.uk/

### Description
There were never many transporter bridges built in the UK and there are very few of them left. Warrington's is unique in that it was built to carry rail rather than road traffic.

The only easy access route is via a permissive path through the old Unilever factory ... although that's a little bit of a nerdy adventure in its own right!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 176
**File:** `content/daytrip/eu/gb/warrington-transporter-bridge.md`

Please review this venue submission and edit the content as needed before merging.