### PR TITLE
New: Muumimuseo (Moomin Museum) from Paul Drye

### DIFF
--- a/content/daytrip/eu/fi/muumimuseo-moomin-museum.md
+++ b/content/daytrip/eu/fi/muumimuseo-moomin-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/fi/muumimuseo-moomin-museum'
+date: '2025-05-30T20:59:40.943Z'
+poster: 'Paul Drye'
+lat: '61.496064'
+lng: '23.782895'
+location: 'Tampere Hall, Yliopistonkatu 55, Tampere, Finland'
+title: 'Muumimuseo (Moomin Museum)'
+external_url: https://www.muumimuseo.fi/en/etusivu/
+---
+An art museum dedicated to the beloved Moomin books by Tove Jansson.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Muumimuseo (Moomin Museum)
**Location:** Tampere Hall, Yliopistonkatu 55, Tampere, Finland
**Submitted by:** Paul Drye
**Website:** https://www.muumimuseo.fi/en/etusivu/

### Description
An art museum dedicated to the beloved Moomin books by Tove Jansson.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 177
**File:** `content/daytrip/eu/fi/muumimuseo-moomin-museum.md`

Please review this venue submission and edit the content as needed before merging.