### PR TITLE
New: Bekonscot Model Village from h2g2bob

### DIFF
--- a/content/daytrip/eu/gb/bekonscot-model-village.md
+++ b/content/daytrip/eu/gb/bekonscot-model-village.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/bekonscot-model-village'
+date: '2025-05-30T22:46:06.973Z'
+poster: 'h2g2bob'
+lat: '51.613873'
+lng: '-0.64491'
+location: ' Warwick Road, Beaconsfield, HP9 2PL'
+title: 'Bekonscot Model Village'
+external_url: https://www.bekonscot.co.uk/
+---
+Everything you expect from a charming model village: houses, churches, cricket pitch, harbour, colliery, etc.
+
+Plus model trains. Lots of model trains, running all the time by nerds who'll happily chat about block signalling.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bekonscot Model Village
**Location:**  Warwick Road, Beaconsfield, HP9 2PL
**Submitted by:** h2g2bob
**Website:** https://www.bekonscot.co.uk/

### Description
Everything you expect from a charming model village: houses, churches, cricket pitch, harbour, colliery, etc.

Plus model trains. Lots of model trains, running all the time by nerds who'll happily chat about block signalling.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 179
**File:** `content/daytrip/eu/gb/bekonscot-model-village.md`

Please review this venue submission and edit the content as needed before merging.