### PR TITLE
New: High Scores Arcade from Don Marti

### DIFF
--- a/content/daytrip/na/us/high-scores-arcade.md
+++ b/content/daytrip/na/us/high-scores-arcade.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/us/high-scores-arcade'
+date: '2025-05-30T22:46:33.002Z'
+poster: 'Don Marti'
+lat: '37.76436447708'
+lng: '-122.24257366071'
+location: '1414 Park Street, Alameda, CA 94507'
+title: 'High Scores Arcade'
+external_url: https://www.highscoresarcade.com/
+---
+Play vintage 1980s arcade games on the original hardware. Try Centipede, Joust, Defender, and more. (Hourly or daily admission, all games on free play)


### PR DESCRIPTION
## New Venue Submission

**Venue:** High Scores Arcade
**Location:** 1414 Park Street, Alameda, CA 94507
**Submitted by:** Don Marti
**Website:** https://www.highscoresarcade.com/

### Description
Play vintage 1980s arcade games on the original hardware. Try Centipede, Joust, Defender, and more. (Hourly or daily admission, all games on free play)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 180
**File:** `content/daytrip/na/us/high-scores-arcade.md`

Please review this venue submission and edit the content as needed before merging.