### PR TITLE
New: USS Hornet Museum from OldSchoolDad510

### DIFF
--- a/content/daytrip/na/us/uss-hornet-museum.md
+++ b/content/daytrip/na/us/uss-hornet-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/na/us/uss-hornet-museum'
+date: '2025-05-30T22:55:22.577Z'
+poster: 'OldSchoolDad510'
+lat: '37.772691'
+lng: '-122.302884'
+location: '707 W Hornet Ave, Alameda, California, USA'
+title: 'USS Hornet Museum'
+external_url: https://uss-hornet.org/
+---
+Explore the ship that recovered the Apollo 11 astronauts. In service from World War II until the 1970s, the USS Hornet is now a museum featuring historic aircraft, other US Navy history displays, a ham radio shack, and more. Sign up for a guided tour even if you have toured that part of the ship already -- each volunteer brings their own unique knowledge and/or sea stories to the tour.


### PR DESCRIPTION
## New Venue Submission

**Venue:** USS Hornet Museum
**Location:** 707 W Hornet Ave, Alameda, California, USA
**Submitted by:** OldSchoolDad510
**Website:** https://uss-hornet.org/

### Description
Explore the ship that recovered the Apollo 11 astronauts. In service from World War II until the 1970s, the USS Hornet is now a museum featuring historic aircraft, other US Navy history displays, a ham radio shack, and more. Sign up for a guided tour even if you have toured that part of the ship already -- each volunteer brings their own unique knowledge and/or sea stories to the tour.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 181
**File:** `content/daytrip/na/us/uss-hornet-museum.md`

Please review this venue submission and edit the content as needed before merging.