### PR TITLE
New: Portable Airship Hangar from popey

### DIFF
--- a/content/daytrip/eu/gb/portable-airship-hangar.md
+++ b/content/daytrip/eu/gb/portable-airship-hangar.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/portable-airship-hangar'
+date: '2025-05-31T12:33:34.565Z'
+poster: 'popey'
+lat: '51.284843'
+lng: '-0.760999'
+location: 'Portable Airship Hangar, Fowler Avenue, Farnborough Business Park, Farnborough, Rushmoor, Hampshire, England, GU14 7JF, United Kingdom'
+title: 'Portable Airship Hangar'
+external_url: https://historicengland.org.uk/listing/the-list/list-entry/1393074
+---
+Portable airship shed built in 1912; the frame was reassembled in this location in 2004. It's now in a commercial office park on the edge of Farnborough Airport.
+
+The construction forms a quiet space, often popular with photographers, especially at sunset.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Portable Airship Hangar
**Location:** Portable Airship Hangar, Fowler Avenue, Farnborough Business Park, Farnborough, Rushmoor, Hampshire, England, GU14 7JF, United Kingdom
**Submitted by:** popey
**Website:** https://historicengland.org.uk/listing/the-list/list-entry/1393074

### Description
Portable airship shed built in 1912; the frame was reassembled in this location in 2004. It's now in a commercial office park on the edge of Farnborough Airport.

The construction forms a quiet space, often popular with photographers, especially at sunset.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 184
**File:** `content/daytrip/eu/gb/portable-airship-hangar.md`

Please review this venue submission and edit the content as needed before merging.