### PR TITLE
New: Retrodome from Retrodome

### DIFF
--- a/content/daytrip/eu/gb/retrodome.md
+++ b/content/daytrip/eu/gb/retrodome.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/retrodome'
+date: '2025-05-31T14:48:53.286Z'
+poster: 'Retrodome'
+lat: '53.54889'
+lng: '-1.480485'
+location: 'Retrodome, Thomas Street, Worsbrough Common, Kingstone, Barnsley, South Yorkshire, England, S70 1LH, United Kingdom'
+title: 'Retrodome'
+external_url: https://retrodome.co.uk
+---
+The Retrodome is heaven for fans of old arcade games. Tickets are valid for the day, you can come and go as you please and play over 200 classic arcade games, all free-to-play. There's also mini golf, a bar, and they serve food as well.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Retrodome
**Location:** Retrodome, Thomas Street, Worsbrough Common, Kingstone, Barnsley, South Yorkshire, England, S70 1LH, United Kingdom
**Submitted by:** Retrodome
**Website:** https://retrodome.co.uk

### Description
The Retrodome is heaven for fans of old arcade games. Tickets are valid for the day, you can come and go as you please and play over 200 classic arcade games, all free-to-play. There's also mini golf, a bar, and they serve food as well.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 185
**File:** `content/daytrip/eu/gb/retrodome.md`

Please review this venue submission and edit the content as needed before merging.