### PR TITLE
New: Alice Holt Forest Café from popey

### DIFF
--- a/content/daytrip/eu/gb/alice-holt-forest-caf.md
+++ b/content/daytrip/eu/gb/alice-holt-forest-caf.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/alice-holt-forest-caf'
+date: '2025-05-31T15:36:48.378Z'
+poster: 'popey'
+lat: '51.168908'
+lng: '-0.839623'
+location: 'Alice Holt Forest Café, Hardings Road, Bucks Horn Oak, Binsted, East Hampshire, Hampshire, England, GU10 4LF, United Kingdom'
+title: 'Alice Holt Forest Café'
+external_url: https://www.forestryengland.uk/alice-holt-forest
+---
+Alice Holt is a large wood with a children's play area, a cafe, bike hire, "Go Ape" for children and adults to get up in the trees. There's space for picnicking or just taking a nice long stroll.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Alice Holt Forest Café
**Location:** Alice Holt Forest Café, Hardings Road, Bucks Horn Oak, Binsted, East Hampshire, Hampshire, England, GU10 4LF, United Kingdom
**Submitted by:** popey
**Website:** https://www.forestryengland.uk/alice-holt-forest

### Description
Alice Holt is a large wood with a children's play area, a cafe, bike hire, "Go Ape" for children and adults to get up in the trees. There's space for picnicking or just taking a nice long stroll.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 186
**File:** `content/daytrip/eu/gb/alice-holt-forest-caf.md`

Please review this venue submission and edit the content as needed before merging.