### PR TITLE
New: The Look Out Discovery Centre Play Area from popey

### DIFF
--- a/content/daytrip/eu/gb/the-look-out-discovery-centre-play-area.md
+++ b/content/daytrip/eu/gb/the-look-out-discovery-centre-play-area.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/the-look-out-discovery-centre-play-area'
+date: '2025-05-31T15:36:58.507Z'
+poster: 'popey'
+lat: '51.386815'
+lng: '-0.740477'
+location: 'The Look Out Discovery Centre Play Area, Psyclo Path, Crowthorne, Bracknell Forest, England, RG12 7QW, United Kingdom'
+title: 'The Look Out Discovery Centre Play Area'
+external_url: https://www.bracknell-forest.gov.uk/leisure-and-events/look-out-discovery-centre
+---
+The Look Out features a large wood area for exploring, a children's play area, picnic areas, an indoor "Discovery Centre", and a "Go Ape" for children and adults to get up in the trees.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Look Out Discovery Centre Play Area
**Location:** The Look Out Discovery Centre Play Area, Psyclo Path, Crowthorne, Bracknell Forest, England, RG12 7QW, United Kingdom
**Submitted by:** popey
**Website:** https://www.bracknell-forest.gov.uk/leisure-and-events/look-out-discovery-centre

### Description
The Look Out features a large wood area for exploring, a children's play area, picnic areas, an indoor "Discovery Centre", and a "Go Ape" for children and adults to get up in the trees.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 187
**File:** `content/daytrip/eu/gb/the-look-out-discovery-centre-play-area.md`

Please review this venue submission and edit the content as needed before merging.