### PR TITLE
New: Ulster Transport Museum from Nerd

### DIFF
--- a/content/daytrip/eu/gb/ulster-transport-museum.md
+++ b/content/daytrip/eu/gb/ulster-transport-museum.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/ulster-transport-museum'
+date: '2025-05-31T21:05:42.104Z'
+poster: 'Nerd'
+lat: '54.65509'
+lng: '-5.803202'
+location: 'Ulster Transport Museum, 153, Bangor Road, Holywood, County Down, Northern Ireland, BT18 0EU, United Kingdom'
+title: 'Ulster Transport Museum'
+external_url: http://www.nmni.com/uftm
+---
+Lots of interesting rail, bus and aviation exhibits. The perfect place for transport nerds.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ulster Transport Museum
**Location:** Ulster Transport Museum, 153, Bangor Road, Holywood, County Down, Northern Ireland, BT18 0EU, United Kingdom
**Submitted by:** Nerd
**Website:** http://www.nmni.com/uftm

### Description
Lots of interesting rail, bus and aviation exhibits. The perfect place for transport nerds.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 188
**File:** `content/daytrip/eu/gb/ulster-transport-museum.md`

Please review this venue submission and edit the content as needed before merging.