### PR TITLE
New: Sutton Hoo from Starmouse

### DIFF
--- a/content/daytrip/eu/gb/sutton-hoo.md
+++ b/content/daytrip/eu/gb/sutton-hoo.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/sutton-hoo'
+date: '2025-06-01T11:06:06.437Z'
+poster: 'Starmouse'
+lat: '52.09533'
+lng: '1.34243'
+location: 'Tranmer House, Sutton Hoo, Woodbridge, Suffolk, IP12 3DJ. '
+title: 'Sutton Hoo'
+external_url: https://www.nationaltrust.org.uk/visit/suffolk/sutton-hoo
+---
+Awe-inspiring Anglo-Saxon royal burial site


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sutton Hoo
**Location:** Tranmer House, Sutton Hoo, Woodbridge, Suffolk, IP12 3DJ. 
**Submitted by:** Starmouse
**Website:** https://www.nationaltrust.org.uk/visit/suffolk/sutton-hoo

### Description
Awe-inspiring Anglo-Saxon royal burial site

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 190
**File:** `content/daytrip/eu/gb/sutton-hoo.md`

Please review this venue submission and edit the content as needed before merging.