### PR TITLE
New: 2 Willow Road from popey

### DIFF
--- a/content/daytrip/eu/gb/2-willow-road.md
+++ b/content/daytrip/eu/gb/2-willow-road.md
@@ -1,0 +1,15 @@
+---
+slug: 'daytrip/eu/gb/2-willow-road'
+date: '2025-06-01T13:58:53.951Z'
+poster: 'popey'
+lat: '51.557143'
+lng: '-0.169151'
+location: '2 Willow Road, Downshire Hill, London NW3'
+title: '2 Willow Road'
+external_url: https://www.nationaltrust.org.uk/visit/london/2-willow-road
+---
+Designed and lived in by influential architect Ernő Goldfinger.
+
+This is a National Trust venue. Tickets for 2 Willow Road are released two weeks in advance on Thursdays. It's only available for tours from March to October.
+
+There's a YouTube video titled [2 Willow Road](https://www.youtube.com/watch?v=kVSVwDdSKuA) that shows some of the features inside the venue.


### PR DESCRIPTION
## New Venue Submission

**Venue:** 2 Willow Road
**Location:** 2 Willow Road, Downshire Hill, London NW3
**Submitted by:** popey
**Website:** https://www.nationaltrust.org.uk/visit/london/2-willow-road

### Description
Designed and lived in by influential architect Ernő Goldfinger.

This is a National Trust venue. Tickets for 2 Willow Road are released two weeks in advance on Thursdays. It's only available for tours from March to October.

There's a YouTube video titled [2 Willow Road](https://www.youtube.com/watch?v=kVSVwDdSKuA) that shows some of the features inside the venue.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 191
**File:** `content/daytrip/eu/gb/2-willow-road.md`

Please review this venue submission and edit the content as needed before merging.