### PR TITLE
New: Osborne House from popey

### DIFF
--- a/content/daytrip/eu/gb/osborne-house.md
+++ b/content/daytrip/eu/gb/osborne-house.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/osborne-house'
+date: '2025-06-01T14:37:40.426Z'
+poster: 'popey'
+lat: '50.750549'
+lng: '-1.269999'
+location: 'Osborne House, York Ave, East Cowes, Isle of Wight, United Kingdom'
+title: 'Osborne House'
+external_url: https://www.english-heritage.org.uk/visit/places/osborne/
+---
+Osborne House is a former royal residence on the Isle of Wight, built between 1845-1851 as Queen Victoria and Prince Albert's summer retreat.
+
+Queen Victoria died there in 1901, after which King Edward VII donated the house to the state. The house served various purposes, including a Royal Navy training college. Now managed by English Heritage since 1986, it operates as a public museum showcasing Victoria's private royal apartments and estate.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Osborne House
**Location:** Osborne House, York Ave, East Cowes, Isle of Wight, United Kingdom
**Submitted by:** popey
**Website:** https://www.english-heritage.org.uk/visit/places/osborne/

### Description
Osborne House is a former royal residence on the Isle of Wight, built between 1845-1851 as Queen Victoria and Prince Albert's summer retreat.

Queen Victoria died there in 1901, after which King Edward VII donated the house to the state. The house served various purposes, including a Royal Navy training college. Now managed by English Heritage since 1986, it operates as a public museum showcasing Victoria's private royal apartments and estate.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 192
**File:** `content/daytrip/eu/gb/osborne-house.md`

Please review this venue submission and edit the content as needed before merging.