### PR TITLE
New: Powell Street Cable Car Turnaround from popey

### DIFF
--- a/content/daytrip/eu/gb/powell-street-cable-car-turnaround.md
+++ b/content/daytrip/eu/gb/powell-street-cable-car-turnaround.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/powell-street-cable-car-turnaround'
+date: '2025-06-01T14:37:49.871Z'
+poster: 'popey'
+lat: '37.784702'
+lng: '-122.407715'
+location: 'Powell Street & Market Street, San Francisco, CA, USA'
+title: 'Powell Street Cable Car Turnaround'
+external_url: https://www.sfmta.com/places/powell-cable-car-turnaround
+---
+The site of a cable-car 'turnaround' or 'turntable' at the end of the line. It draws quite a crowd, watching the gripman stop the car, then rotate the tracks and car, ready to go back down the hill again. 
+
+There's a stop on both sides, so you can get the cable-car up the hill, watch them turn around, then get the car back down. A line forms to get back on, though.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Powell Street Cable Car Turnaround
**Location:** Powell Street & Market Street, San Francisco, CA, USA
**Submitted by:** popey
**Website:** https://www.sfmta.com/places/powell-cable-car-turnaround

### Description
The site of a cable-car 'turnaround' or 'turntable' at the end of the line. It draws quite a crowd, watching the gripman stop the car, then rotate the tracks and car, ready to go back down the hill again. 

There's a stop on both sides, so you can get the cable-car up the hill, watch them turn around, then get the car back down. A line forms to get back on, though.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 193
**File:** `content/daytrip/eu/gb/powell-street-cable-car-turnaround.md`

Please review this venue submission and edit the content as needed before merging.