### PR TITLE
New: HMS Belfast from popey

### DIFF
--- a/content/daytrip/eu/gb/hms-belfast.md
+++ b/content/daytrip/eu/gb/hms-belfast.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/hms-belfast'
+date: '2025-06-01T14:37:57.491Z'
+poster: 'popey'
+lat: '51.506543'
+lng: '-0.081152'
+location: 'HMS Belfast, The Queen's Walk, Bermondsey Village, The Borough, London Borough of Southwark, London, Greater London, England, SE1 2JH, United Kingdom'
+title: 'HMS Belfast'
+external_url: https://www.iwm.org.uk/visits/hms-belfast
+---
+A museum ship, permanently berthed on the River Thames in London. A fascinating place to visit, especially if you're not familiar with the insides and day-to-day functioning of a war ship.


### PR DESCRIPTION
## New Venue Submission

**Venue:** HMS Belfast
**Location:** HMS Belfast, The Queen's Walk, Bermondsey Village, The Borough, London Borough of Southwark, London, Greater London, England, SE1 2JH, United Kingdom
**Submitted by:** popey
**Website:** https://www.iwm.org.uk/visits/hms-belfast

### Description
A museum ship, permanently berthed on the River Thames in London. A fascinating place to visit, especially if you're not familiar with the insides and day-to-day functioning of a war ship.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 194
**File:** `content/daytrip/eu/gb/hms-belfast.md`

Please review this venue submission and edit the content as needed before merging.