### PR TITLE
New: Caister Castle Car Collection from popey

### DIFF
--- a/content/daytrip/eu/gb/caister-castle-car-collection.md
+++ b/content/daytrip/eu/gb/caister-castle-car-collection.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/caister-castle-car-collection'
+date: '2025-06-01T14:38:05.691Z'
+poster: 'popey'
+lat: '52.650199'
+lng: '1.700864'
+location: 'Castle Bungalow, Castle Ln, West Caister, Great Yarmouth NR30 5SN'
+title: 'Caister Castle Car Collection'
+external_url: https://www.caistercastle.co.uk/
+---
+Do you like castles and cars? Well, you're in luck here! On the same site, you can visit the ruins of a 400+ year-old Caister Castle and one of the largest privately held car collections in the UK.
+
+There isn't much of the castle left, but there is a tower to climb. This is compensated by a huge collection of cars, motorcycles, and quirky vehicles. There are guides all through the museum, ready to tell the stories of each car. It is worth a visit.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Caister Castle Car Collection
**Location:** Castle Bungalow, Castle Ln, West Caister, Great Yarmouth NR30 5SN
**Submitted by:** popey
**Website:** https://www.caistercastle.co.uk/

### Description
Do you like castles and cars? Well, you're in luck here! On the same site, you can visit the ruins of a 400+ year-old Caister Castle and one of the largest privately held car collections in the UK.

There isn't much of the castle left, but there is a tower to climb. This is compensated by a huge collection of cars, motorcycles, and quirky vehicles. There are guides all through the museum, ready to tell the stories of each car. It is worth a visit.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 195
**File:** `content/daytrip/eu/gb/caister-castle-car-collection.md`

Please review this venue submission and edit the content as needed before merging.