### PR TITLE
New: Will & Lyra's Bench from Mark

### DIFF
--- a/content/daytrip/eu/gb/will-lyras-bench.md
+++ b/content/daytrip/eu/gb/will-lyras-bench.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/will-lyras-bench'
+date: '2025-06-01T19:06:11.274Z'
+poster: 'Mark'
+lat: '51.749876'
+lng: '-1.248241'
+location: 'University of Oxford Botanic Gardens'
+title: “Will & Lyra's Bench”
+external_url: https://www.obga.ox.ac.uk/visit-garden
+---
+The real-world location of the bench where Will and Lyra meet at the end of the His Dark Materials trilogy.
+
+The garden also features Lewis Caroll-themed sculptures, the site of the tree where J.R.R Tolkien would sit and write, and some interesting plants.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Will & Lyra's Bench
**Location:** University of Oxford Botanic Gardens
**Submitted by:** Mark
**Website:** https://www.obga.ox.ac.uk/visit-garden

### Description
The real-world location of the bench where Will and Lyra meet at the end of the His Dark Materials trilogy.

The garden also features Lewis Caroll-themed sculptures, the site of the tree where J.R.R Tolkien would sit and write, and some interesting plants.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 197
**File:** `content/daytrip/eu/gb/will-lyras-bench.md`

Please review this venue submission and edit the content as needed before merging.