### PR TITLE
New: Internal Fire - Museum of Power from plett

### DIFF
--- a/content/daytrip/eu/gb/internal-fire-museum-of-power.md
+++ b/content/daytrip/eu/gb/internal-fire-museum-of-power.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/internal-fire-museum-of-power'
+date: '2025-06-01T21:21:00.632Z'
+poster: 'plett'
+lat: '52.119902'
+lng: '-4.491324'
+location: 'Internal Fire - Museum of Power, A487, Penbryn, Sarnau, Ceredigion, Wales, SA44 6QU, United Kingdom'
+title: 'Internal Fire - Museum of Power'
+external_url: https://www.internalfire.com
+---
+All sorts of operational engines. From steam, to petrol and diesel to a jet turbine. Engines are always running while the museum is open.
+
+If engines aren't enough, there are also telephone exchanges with extensions dotted around the site which you can call between, vintage radio equipment and a marine HF radio which licenced amateurs can operate.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Internal Fire - Museum of Power
**Location:** Internal Fire - Museum of Power, A487, Penbryn, Sarnau, Ceredigion, Wales, SA44 6QU, United Kingdom
**Submitted by:** plett
**Website:** https://www.internalfire.com

### Description
All sorts of operational engines. From steam, to petrol and diesel to a jet turbine. Engines are always running while the museum is open.

If engines aren't enough, there are also telephone exchanges with extensions dotted around the site which you can call between, vintage radio equipment and a marine HF radio which licenced amateurs can operate.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 199
**File:** `content/daytrip/eu/gb/internal-fire-museum-of-power.md`

Please review this venue submission and edit the content as needed before merging.