### PR TITLE
New: Porthcurno Telegraph Museum from plett

### DIFF
--- a/content/daytrip/eu/gb/porthcurno-telegraph-museum.md
+++ b/content/daytrip/eu/gb/porthcurno-telegraph-museum.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/gb/porthcurno-telegraph-museum'
+date: '2025-06-01T21:22:02.763Z'
+poster: 'plett'
+lat: '50.046744'
+lng: '-5.654957'
+location: 'Porthcurno Telegraph Museum, Penzance, Porthcurno, Cornwall, England, TR19 6JX, United Kingdom'
+title: 'Porthcurno Telegraph Museum'
+external_url: https://pkporthcurno.com/
+---
+Porthcurno is the landing site for the first undersea telegraph cable and the Telegraph Museum shows the history of undersea cable communications from there to modern fibre optics.
+
+Also an underground WW2 communications bunker and a beautiful beach for the family you're dragging along with you.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Porthcurno Telegraph Museum
**Location:** Porthcurno Telegraph Museum, Penzance, Porthcurno, Cornwall, England, TR19 6JX, United Kingdom
**Submitted by:** plett
**Website:** https://pkporthcurno.com/

### Description
Porthcurno is the landing site for the first undersea telegraph cable and the Telegraph Museum shows the history of undersea cable communications from there to modern fibre optics.

Also an underground WW2 communications bunker and a beautiful beach for the family you're dragging along with you.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 200
**File:** `content/daytrip/eu/gb/porthcurno-telegraph-museum.md`

Please review this venue submission and edit the content as needed before merging.