### PR TITLE
New: Lumina Domestica (Lamp Museum) from plett

### DIFF
--- a/content/daytrip/eu/be/lumina-domestica-lamp-museum.md
+++ b/content/daytrip/eu/be/lumina-domestica-lamp-museum.md
@@ -1,0 +1,13 @@
+---
+slug: 'daytrip/eu/be/lumina-domestica-lamp-museum'
+date: '2025-06-01T21:23:36.820Z'
+poster: 'plett'
+lat: '51.210836'
+lng: '3.226408'
+location: 'Lumina, Sint-Jansstraat, Sint-Walburgakwartier, Brugge-Centrum, Brugge, Bruges, Brugge, West Flanders, 8000, Belgium'
+title: 'Lumina Domestica (Lamp Museum)'
+external_url: https://www.visitbruges.be/en/things-to-do/culture-and-heritage/lumina-domestica-lamp-museum
+---
+Upstairs from Choco-Story (a chocolate museum!) is Lumina Domestica - a museum which charts the history of man made lighting - from fires in caves through paraffin lamps to incandescent bulbs and LEDs.
+
+Entrance is through Choco-Story and a joint ticket can be purchased.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lumina Domestica (Lamp Museum)
**Location:** Lumina, Sint-Jansstraat, Sint-Walburgakwartier, Brugge-Centrum, Brugge, Bruges, Brugge, West Flanders, 8000, Belgium
**Submitted by:** plett
**Website:** https://www.visitbruges.be/en/things-to-do/culture-and-heritage/lumina-domestica-lamp-museum

### Description
Upstairs from Choco-Story (a chocolate museum!) is Lumina Domestica - a museum which charts the history of man made lighting - from fires in caves through paraffin lamps to incandescent bulbs and LEDs.

Entrance is through Choco-Story and a joint ticket can be purchased.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 201
**File:** `content/daytrip/eu/be/lumina-domestica-lamp-museum.md`

Please review this venue submission and edit the content as needed before merging.