### PR TITLE
New: Spyway Dinosaur Footprints from plett

### DIFF
--- a/content/daytrip/eu/gb/spyway-dinosaur-footprints.md
+++ b/content/daytrip/eu/gb/spyway-dinosaur-footprints.md
@@ -8,4 +8,4 @@ location: "Spyway Dinosaur Footprints, Priest's Way, Langton Matravers, Worth Ma
 title: 'Spyway Dinosaur Footprints'
 external_url: https://dorset-nl.org.uk/location/spyway/
 ---
-Over 100 dinosaur footprint tracks preserved in what was the shore of a lagoon 140 million years ago, but is now a flat sheet of rock. No barriers, you can walk right up and compar the size of your foot to the footprint left by a 50 tonne brachiosaur.
+Over 100 dinosaur footprint tracks have been preserved in what was the shore of a lagoon 140 million years ago but is now a flat sheet of rock. There are no barriers; you can walk right up and compare the size of your foot to the footprint left by a 50-tonne brachiosaur.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Spyway Dinosaur Footprints
**Location:** Spyway Dinosaur Footprints, Priest's Way, Langton Matravers, Worth Matravers, Dorset, England, BH19 3LB, United Kingdom
**Submitted by:** plett
**Website:** https://dorset-nl.org.uk/location/spyway/

### Description
Over 100 dinosaur footprint tracks preserved in what was the shore of a lagoon 140 million years ago, but is now a flat sheet of rock. No barriers, you can walk right up and compar the size of your foot to the footprint left by a 50 tonne brachiosaur.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 202
**File:** `content/daytrip/eu/gb/spyway-dinosaur-footprints.md`

Please review this venue submission and edit the content as needed before merging.