### PR TITLE
New: Fan Bay Deep Shelter from plett

### DIFF
--- a/content/daytrip/eu/gb/fan-bay-deep-shelter.md
+++ b/content/daytrip/eu/gb/fan-bay-deep-shelter.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/fan-bay-deep-shelter'
+date: '2025-06-01T21:48:48.264Z'
+poster: 'plett'
+lat: '51.136367'
+lng: '1.360484'
+location: 'Fan Bay Deep Shelter, Upper Road, West Cliffe, St. Margaret's at Cliffe, Dover, Kent, England, CT15 6HY, United Kingdom'
+title: 'Fan Bay Deep Shelter'
+external_url: https://www.nationaltrust.org.uk/visit/kent/the-white-cliffs-of-dover/the-fan-bay-deep-shelter-project-at-the-white-cliffs-of-dover
+---
+With a hardhat and a head torch, descend down 125 steps for a guided tour around the WW2 era tunnels which were home to the soldiers manning the cross-channel guns above.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fan Bay Deep Shelter
**Location:** Fan Bay Deep Shelter, Upper Road, West Cliffe, St. Margaret's at Cliffe, Dover, Kent, England, CT15 6HY, United Kingdom
**Submitted by:** plett
**Website:** https://www.nationaltrust.org.uk/visit/kent/the-white-cliffs-of-dover/the-fan-bay-deep-shelter-project-at-the-white-cliffs-of-dover

### Description
With a hardhat and a head torch, descend down 125 steps for a guided tour around the WW2 era tunnels which were home to the soldiers manning the cross-channel guns above.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 203
**File:** `content/daytrip/eu/gb/fan-bay-deep-shelter.md`

Please review this venue submission and edit the content as needed before merging.