### PR TITLE
New: Amberley Museum and Heritage Centre from plett

### DIFF
--- a/content/daytrip/eu/gb/amberley-museum-and-heritage-centre.md
+++ b/content/daytrip/eu/gb/amberley-museum-and-heritage-centre.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/amberley-museum-and-heritage-centre'
+date: '2025-06-02T04:04:50.826Z'
+poster: 'plett'
+lat: '50.899254'
+lng: '-0.537708'
+location: 'Amberley Museum and Heritage Centre, New Barn Road, Amberley, Horsham, West Sussex, England, BN18 9LT, United Kingdom'
+title: 'Amberley Museum and Heritage Centre'
+external_url: https://www.amberleymuseum.co.uk/
+---
+A museum located in a disused chalk quarry. As well as old chalk kilns, they have collected a lot of equipment and buildings from around the country and have things like a 1950s fire station complete with fire engines, a 1930s roadside cafe, a working 1940s telephone exchange which visitors can operate, a room full of printing presses and a level crossing signal box.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Amberley Museum and Heritage Centre
**Location:** Amberley Museum and Heritage Centre, New Barn Road, Amberley, Horsham, West Sussex, England, BN18 9LT, United Kingdom
**Submitted by:** plett
**Website:** https://www.amberleymuseum.co.uk/

### Description
A museum located in a disused chalk quarry. As well as old chalk kilns, they have collected a lot of equipment and buildings from around the country and have things like a 1950s fire station complete with fire engines, a 1930s roadside cafe, a working 1940s telephone exchange which visitors can operate, a room full of printing presses and a level crossing signal box.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 204
**File:** `content/daytrip/eu/gb/amberley-museum-and-heritage-centre.md`

Please review this venue submission and edit the content as needed before merging.