### PR TITLE
New: Vikingeskibsmuseet (Viking Ship Museum), Roskilde  from plett

### DIFF
--- a/content/daytrip/eu/dk/vikingeskibsmuseet-viking-ship-museum-roskilde-.md
+++ b/content/daytrip/eu/dk/vikingeskibsmuseet-viking-ship-museum-roskilde-.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/dk/vikingeskibsmuseet-viking-ship-museum-roskilde-'
+date: '2025-06-02T04:05:53.904Z'
+poster: 'plett'
+lat: '55.65064'
+lng: '12.079224'
+location: 'Museumsøen, Strandengen, Sankt Agnes Huse, Roskilde, Roskilde Municipality, Region Zealand, 4000, Denmark'
+title: 'Vikingeskibsmuseet (Viking Ship Museum), Roskilde '
+external_url: https://www.vikingeskibsmuseet.dk/
+---
+A museum of viking seafaring ships. Contains five boats from the 11th century which it is believed were skuttled to prevent invasion of a nearby waterway.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Vikingeskibsmuseet (Viking Ship Museum), Roskilde 
**Location:** Museumsøen, Strandengen, Sankt Agnes Huse, Roskilde, Roskilde Municipality, Region Zealand, 4000, Denmark
**Submitted by:** plett
**Website:** https://www.vikingeskibsmuseet.dk/

### Description
A museum of viking seafaring ships. Contains five boats from the 11th century which it is believed were skuttled to prevent invasion of a nearby waterway.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 205
**File:** `content/daytrip/eu/dk/vikingeskibsmuseet-viking-ship-museum-roskilde-.md`

Please review this venue submission and edit the content as needed before merging.