### PR TITLE
New: Saint Michael's Abbey from popey

### DIFF
--- a/content/daytrip/eu/gb/saint-michaels-abbey.md
+++ b/content/daytrip/eu/gb/saint-michaels-abbey.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/saint-michaels-abbey"
+date: "2025-06-02T06:27:23.695Z"
+poster: "popey"
+lat: "51.296671"
+lng: "-0.749677"
+location: "Saint Michael's Abbey, 280 Farnborough Rd Farnborough, Hampshire GU14 7NQ"
+title: "Saint Michael's Abbey"
+external_url: https://farnboroughabbey.org/
+---
+A working Benedictine abbey. Place of burial of Empress Eugenie, wife of Napoléon III.
+
+Every Saturday at 3 pm, there is a guided tour of the Abbey Church and the Imperial Crypt. There is no need to book in advance. The Abbey gates open automatically at 2.45 pm. The tour lasts about an hour and ends in the monastery shop.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Saint Michael's Abbey
**Location:** Saint Michael's Abbey, 280 Farnborough Rd Farnborough, Hampshire GU14 7NQ
**Submitted by:** popey
**Website:** https://farnboroughabbey.org/

### Description
A working Benedictine abbey. Place of burial of Empress Eugenie, wife of Napoléon III.

Every Saturday at 3 pm, there is a guided tour of the Abbey Church and the Imperial Crypt. There is no need to book in advance. The Abbey gates open automatically at 2.45 pm. The tour lasts about an hour and ends in the monastery shop.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 206
**File:** `content/daytrip/eu/gb/saint-michaels-abbey.md`

Please review this venue submission and edit the content as needed before merging.