### PR TITLE
New: Hawley Common from popey

### DIFF
--- a/content/daytrip/eu/gb/hawley-common.md
+++ b/content/daytrip/eu/gb/hawley-common.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/hawley-common"
+date: "2025-06-02T06:54:53.758Z"
+poster: "popey"
+lat: "51.31635"
+lng: "-0.793772"
+location: "Hawley Common, Hawley, Hart, Hampshire, England, GU17 9HU, United Kingdom"
+title: "Hawley Common"
+external_url: https://www.hawleylake.org.uk/
+---
+Hawley Common is a woodland space used by walkers, dog walkers, cyclists, and sailors. At the centre is Hawley Lake, which the linked sailing club uses. The lake is very pleasant to walk around, and through the surrounding woods.
+
+The 3rd Royal School of Military Engineering (RSME) group at "Hawley Hard" also uses the lake for bridge-building exercises.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hawley Common
**Location:** Hawley Common, Hawley, Hart, Hampshire, England, GU17 9HU, United Kingdom
**Submitted by:** popey
**Website:** https://www.hawleylake.org.uk/

### Description
Hawley Common is a woodland space used by walkers, dog walkers, cyclists, and sailors. 

At the centre is Hawley Lake, which the linked sailing club uses. The lake is also sometimes used for exercises by 3rd Royal School of Military Engineering (RSME) group at "Hawley Hard".

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 207
**File:** `content/daytrip/eu/gb/hawley-common.md`

Please review this venue submission and edit the content as needed before merging.