### PR TITLE
Ignore DS_Store files in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/
 .hugo_build.lock
 .venv
 *~
+**/.DS_Store


### PR DESCRIPTION
Made the mistake of working with images on a Mac. Ended up with some `.DS_Store` files scattered through the repo, which this ignores.