### PR TITLE
Add toggle button for clustering markers

### DIFF
--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -620,3 +620,28 @@ main#content:has(> article) {
 .center {
   text-align: center;
 }
+
+.cluster-toggle-btn {
+  position: absolute;
+  top: 70px; /* Position below the locate button */
+  right: 16px;
+  z-index: 1000;
+  background: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3.5em;
+  transition: background 0.2s;
+}
+.cluster-toggle-btn:hover, .cluster-toggle-btn:focus {
+  background: #f0f0f0;
+}
+.cluster-toggle-btn.active {
+  background: #e0f0ff; /* Light blue background when active */
+}

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -15,6 +15,7 @@
 <div class="map-container">
   <div id="map">
     <button id="locate-btn" class="locate-btn" title="Find my location">📍</button>
+    <button id="cluster-toggle-btn" class="cluster-toggle-btn" title="Toggle marker clustering">🔍</button>
   </div>
   <div class="sidebar" id="sidebar">
     <button id="sidebar-toggle" class="sidebar-toggle-btn" title="Toggle Sidebar">
@@ -58,6 +59,7 @@
 </style>
 
 <script>
+var allMarkers = [];
 async function loadMarkers(L, map) {
     fetch("./daytrip/index.json")
         .then(r => r.json())
@@ -69,14 +71,16 @@ async function loadMarkers(L, map) {
             }
 
             venues.data.forEach(v => {
-                L.marker({lon: v.lng, lat: v.lat}).bindPopup(`<a href="${v.permalink}">${v.name}</a>`).addTo(cluster);
+                const marker = L.marker({lon: v.lng, lat: v.lat}).bindPopup(`<a href="${v.permalink}">${v.name}</a>`);
+                marker.addTo(cluster);
+                allMarkers.push(marker); // Store marker reference
+                
                 console.log({jumpToSlug, p: v.permalink, eq: jumpToSlug == v.permalink})
                 if (jumpToSlug && jumpToSlug == v.permalink) {
                     console.log("Fly, my pretties")
                     map.flyTo([v.lat, v.lng], 19);
                 }
             })
-
         })
 }
 
@@ -187,5 +191,25 @@ map.on('locationerror', function(e) {
     alert('Could not get your location: ' + e.message);
 });
 
+// Cluster toggle functionality
+const clusterToggleBtn = document.getElementById('cluster-toggle-btn');
+let clusteringEnabled = true;
+
+clusterToggleBtn.addEventListener('click', function() {
+    if (clusteringEnabled) {
+        // Disable clustering
+        map.removeLayer(cluster);
+        allMarkers.forEach(marker => marker.addTo(map));
+        clusterToggleBtn.classList.add('active');
+        clusterToggleBtn.title = "Enable marker clustering";
+    } else {
+        // Enable clustering
+        allMarkers.forEach(marker => map.removeLayer(marker));
+        map.addLayer(cluster);
+        clusterToggleBtn.classList.remove('active');
+        clusterToggleBtn.title = "Disable marker clustering";
+    }
+    clusteringEnabled = !clusteringEnabled;
+});
 </script>
 {{ end }}


### PR DESCRIPTION
This adds a toggle button in the top right of the main map to switch off/on clustering. So, rather than coloured blobs with numbers in, you'll see every marker. Here's what that looks like in screenshot form:

### Clustering on - the default

<img width="1349" alt="Screenshot 2025-06-02 at 08 44 02" src="https://github.com/user-attachments/assets/548962a8-59cc-4517-bdb8-d09c64d35e55" />

### Clustering off

<img width="1349" alt="Screenshot 2025-06-02 at 08 44 14" src="https://github.com/user-attachments/assets/3348378c-3f2d-4fa7-915b-3a8236354072" />

