### PR TITLE
New: Green's Windmill from Colin Beveridge.

### DIFF
--- a/content/daytrip/eu/gb/greens-windmill.md
+++ b/content/daytrip/eu/gb/greens-windmill.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/greens-windmill"
+date: "2025-06-02T08:55:58.047Z"
+poster: "Colin Beveridge"
+lat: "52.952098"
+lng: "-1.129386"
+location: "Green's Windmill, Belvoir Hill, Sneinton, Nottingham, East Midlands, England, NG2 4QB, United Kingdom"
+title: "Green's Windmill"
+external_url: https://www.greensmill.org.uk/
+---
+One of the UK's last working windmills (or at least, it will be when the sails are fixed), George Green Sr. was also the father of mathematician George Green. As well as a tour of the mill, there's a sensory garden small science centre which features Green's Theorem and several electromagnetism interactives. 
+
+Entry is free, and it's a good way to spend an hour or two in Nottingham.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Green's Windmill
**Location:** Green's Windmill, Belvoir Hill, Sneinton, Nottingham, East Midlands, England, NG2 4QB, United Kingdom
**Submitted by:** Colin Beveridge.
**Website:** https://www.greensmill.org.uk/

### Description
One of the UK's last working windmills (or at least, it will be when the sails are fixed), George Green Sr. was also the father of mathematician George Green. As well as a tour of the mill, there's a sensory garden small science centre which features Green's Theorem and several electromagnetism interactives. 

Entry is free, and it's a good way to spend an hour or two in Nottingham.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 209
**File:** `content/daytrip/eu/gb/greens-windmill.md`

Please review this venue submission and edit the content as needed before merging.