### PR TITLE
New: Potteries Museum and Art Gallery from Robin

### DIFF
--- a/content/daytrip/eu/gb/potteries-museum-and-art-gallery.md
+++ b/content/daytrip/eu/gb/potteries-museum-and-art-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/potteries-museum-and-art-gallery"
+date: "2025-06-02T10:10:54.948Z"
+poster: "Robin"
+lat: "53.022874"
+lng: "-2.178046"
+location: "Potteries Museum and Art Gallery, Bethesda Street, Joiner's Square, Hanley, Stoke-on-Trent, England, ST1 3DW, United Kingdom"
+title: "Potteries Museum and Art Gallery"
+external_url: https://www.stokemuseums.org.uk/pmag/
+---
+Interesting museum and art gallery. Museum has a large ceramics collection, a Spitfire, and the Staffordshire Hoard.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Potteries Museum and Art Gallery
**Location:** Potteries Museum and Art Gallery, Bethesda Street, Joiner's Square, Hanley, Stoke-on-Trent, England, ST1 3DW, United Kingdom
**Submitted by:** Robin
**Website:** https://www.stokemuseums.org.uk/pmag/

### Description
Interesting museum and art gallery. Museum has a large ceramics collection, a Spitfire, and the Staffordshire Hoard.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 210
**File:** `content/daytrip/eu/gb/potteries-museum-and-art-gallery.md`

Please review this venue submission and edit the content as needed before merging.