### PR TITLE
New: St. Pauli-Elbtunnel from MarcN

### DIFF
--- a/content/daytrip/eu/de/st-pauli-elbtunnel.md
+++ b/content/daytrip/eu/de/st-pauli-elbtunnel.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/st-pauli-elbtunnel"
+date: "2025-06-02T15:01:43.629Z"
+poster: "MarcN"
+lat: "53.54587"
+lng: "9.9666"
+location: "St. Pauli-Elbtunnel, Bei den St. Pauli-Landungsbrücken, St. Pauli, Hamburg-Mitte, Hamburg, 20359, Deutschland"
+title: "St. Pauli-Elbtunnel"
+external_url: https://en.m.wikipedia.org/wiki/Elbe_Tunnel_(1911)
+---
+The old Elbe Tunnel is an impressive structure which can be used free of charge to cross below the river Elbe. Riding the huge elevators which were used for vehicles until a few years ago is a small adventure. Alternatively it is possible to use the stairs. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** St. Pauli-Elbtunnel
**Location:** St. Pauli-Elbtunnel, Bei den St. Pauli-Landungsbrücken, St. Pauli, Hamburg-Mitte, Hamburg, 20359, Deutschland
**Submitted by:** MarcN
**Website:** https://en.m.wikipedia.org/wiki/Elbe_Tunnel_(1911)

### Description
The old Elbe Tunnel is an impressive structure which can be used free of charge to cross below the river Elbe. Riding the huge elevators which were used for vehicles until a few years ago is a small adventure. Alternatively it is possible to use the stairs. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 212
**File:** `content/daytrip/eu/de/st-pauli-elbtunnel.md`

Please review this venue submission and edit the content as needed before merging.