### PR TITLE
New: Flipper- und Arcademuseum from MarcN

### DIFF
--- a/content/daytrip/eu/de/flipper-und-arcademuseum.md
+++ b/content/daytrip/eu/de/flipper-und-arcademuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/flipper-und-arcademuseum"
+date: "2025-06-02T15:02:07.338Z"
+poster: "MarcN"
+lat: "50.052967"
+lng: "8.968596"
+location: "Flipper- und Arcademuseum, 6, Wilhelm-Leuschner-Straße, Seligenstadt, Landkreis Offenbach, Hessen, 63500, Deutschland"
+title: "Flipper- und Arcademuseum"
+external_url: https://www.flipperundarcade.de/
+---
+A pinball and arcade machine museum. The museum is run on a voluntary basis and is not open every day. The opening days are listed on the homepage. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Flipper- und Arcademuseum
**Location:** Flipper- und Arcademuseum, 6, Wilhelm-Leuschner-Straße, Seligenstadt, Landkreis Offenbach, Hessen, 63500, Deutschland
**Submitted by:** MarcN
**Website:** https://www.flipperundarcade.de/

### Description
A pinball and arcade machine museum. The museum is run on a voluntary basis and is not open every day. The opening days are listed on the homepage. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 213
**File:** `content/daytrip/eu/de/flipper-und-arcademuseum.md`

Please review this venue submission and edit the content as needed before merging.