### PR TITLE
New: Hubschraubermuseum from MarcN

### DIFF
--- a/content/daytrip/eu/de/hubschraubermuseum.md
+++ b/content/daytrip/eu/de/hubschraubermuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/hubschraubermuseum"
+date: "2025-06-02T15:02:19.460Z"
+poster: "MarcN"
+lat: "52.261478"
+lng: "9.047005"
+location: "Hubschraubermuseum, 6, Sablé-Platz, Bückeburg, Landkreis Schaumburg, Niedersachsen, 31675, Deutschland"
+title: "Hubschraubermuseum"
+external_url: https://www.hubschraubermuseum.de/
+---
+Phantastic collection of helicopters and exhibition on the history of rotary wing aircrafts.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hubschraubermuseum
**Location:** Hubschraubermuseum, 6, Sablé-Platz, Bückeburg, Landkreis Schaumburg, Niedersachsen, 31675, Deutschland
**Submitted by:** MarcN
**Website:** https://www.hubschraubermuseum.de/

### Description
Phantastic collection of helicopters and exhibition on the history of rotary wing aircrafts.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 214
**File:** `content/daytrip/eu/de/hubschraubermuseum.md`

Please review this venue submission and edit the content as needed before merging.