### PR TITLE
New: Heath Robinson Museum from Hugo

### DIFF
--- a/content/daytrip/eu/gb/heath-robinson-museum.md
+++ b/content/daytrip/eu/gb/heath-robinson-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/heath-robinson-museum"
+date: "2025-06-02T15:02:55.998Z"
+poster: "Hugo"
+lat: "51.592676"
+lng: "-0.386702"
+location: "Heath Robinson Museum, Pinner, Memorial Park, West End Lane, Pinner HA5 1AE."
+title: "Heath Robinson Museum"
+external_url: https://www.heathrobinsonmuseum.org
+---
+A surprisingly well-built and not at all held together with string museum, celebrating the life and art of William Heath Robinson.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Heath Robinson Museum
**Location:** Heath Robinson Museum, Pinner, Memorial Park, West End Lane, Pinner HA5 1AE.
**Submitted by:** Hugo
**Website:** https://www.heathrobinsonmuseum.org

### Description
A surprisingly well-built and not at all held together with string museum, celebrating the life and art of William Heath Robinson.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 216
**File:** `content/daytrip/eu/gb/heath-robinson-museum.md`

Please review this venue submission and edit the content as needed before merging.