### PR TITLE
New: Deutsches Panzermuseum from MarcN

### DIFF
--- a/content/daytrip/eu/de/deutsches-panzermuseum.md
+++ b/content/daytrip/eu/de/deutsches-panzermuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/deutsches-panzermuseum"
+date: "2025-06-02T15:03:08.191Z"
+poster: "MarcN"
+lat: "52.986669"
+lng: "10.108981"
+location: "Deutsches Panzermuseum, 33, Hans-Krüger-Straße, Munster, Heidekreis, Niedersachsen, 29633, Deutschland"
+title: "Deutsches Panzermuseum"
+external_url: https://daspanzermuseum.de/
+---
+The museum shows the history of German tanks from its beginnings in the 19th century until today. It claims neither to glorify violence nor to be an anti-war exhibition, but to take a differentiated view of the subject area. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Deutsches Panzermuseum
**Location:** Deutsches Panzermuseum, 33, Hans-Krüger-Straße, Munster, Heidekreis, Niedersachsen, 29633, Deutschland
**Submitted by:** MarcN
**Website:** https://daspanzermuseum.de/

### Description
The museum shows the history of German tanks from its beginnings in the 19th century until today. It claims neither to glorify violence nor to be an anti-war exhibition, but to take a differentiated view of the subject area. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 217
**File:** `content/daytrip/eu/de/deutsches-panzermuseum.md`

Please review this venue submission and edit the content as needed before merging.