### PR TITLE
New: Diamond Light Source from Hugo

### DIFF
--- a/content/daytrip/eu/gb/diamond-light-source.md
+++ b/content/daytrip/eu/gb/diamond-light-source.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/diamond-light-source"
+date: "2025-06-02T15:03:18.111Z"
+poster: "Hugo"
+lat: "51.57435"
+lng: "-1.3108916"
+location: "Diamond House, Harwell Science & Innovation Campus, Didcot, Oxfordshire, OX11 0DE"
+title: "Diamond Light Source"
+external_url: https://www.diamond.ac.uk/Public/VisitUs.html
+---
+Diamond is the UK national synchrotron facility, producing (very) bright light from infra-red all the way to X-rays.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Diamond Light Source
**Location:** Diamond House, Harwell Science & Innovation Campus, Didcot, Oxfordshire, OX11 0DE
**Submitted by:** Hugo
**Website:** https://www.diamond.ac.uk/Public/VisitUs.html

### Description
Diamond is the UK national synchrotron facility, producing (very) bright light from infra-red all the way to X-rays.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 218
**File:** `content/daytrip/eu/gb/diamond-light-source.md`

Please review this venue submission and edit the content as needed before merging.