### PR TITLE
New: Schiffshebewerk Scharnebeck from MarcN

### DIFF
--- a/content/daytrip/eu/de/schiffshebewerk-scharnebeck.md
+++ b/content/daytrip/eu/de/schiffshebewerk-scharnebeck.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/schiffshebewerk-scharnebeck"
+date: "2025-06-02T17:08:08.153Z"
+poster: "MarcN"
+lat: "53.291964"
+lng: "10.488334"
+location: "Schiffshebewerk Scharnebeck, 44, Adendorfer Straße, Scharnebeck, Samtgemeinde Scharnebeck, Lüneburg, Niedersachsen, 21379, Deutschland"
+title: "Schiffshebewerk Scharnebeck"
+external_url: https://schiffshebewerk-scharnebeck.de/
+---
+The ship's hoist moves ships over a height of 38 metres. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Schiffshebewerk Scharnebeck
**Location:** Schiffshebewerk Scharnebeck, 44, Adendorfer Straße, Scharnebeck, Samtgemeinde Scharnebeck, Lüneburg, Niedersachsen, 21379, Deutschland
**Submitted by:** MarcN
**Website:** https://schiffshebewerk-scharnebeck.de/

### Description
The ship's hoist moves ships over a height of 38 metres. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 220
**File:** `content/daytrip/eu/de/schiffshebewerk-scharnebeck.md`

Please review this venue submission and edit the content as needed before merging.