### PR TITLE
New: Forschungsflughafen Braunschweig-Wolfsburg from MarcN

### DIFF
--- a/content/daytrip/eu/de/forschungsflughafen-braunschweig-wolfsburg.md
+++ b/content/daytrip/eu/de/forschungsflughafen-braunschweig-wolfsburg.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/forschungsflughafen-braunschweig-wolfsburg"
+date: "2025-06-02T17:08:17.731Z"
+poster: "MarcN"
+lat: "52.31912"
+lng: "10.560094"
+location: "Forschungsflughafen Braunschweig-Wolfsburg, Pumpenweg, Waggum, Wabe-Schunter-Beberbach, Braunschweig, Niedersachsen, 38110, Deutschland"
+title: "Forschungsflughafen Braunschweig-Wolfsburg"
+external_url: https://www.fhbwe.de/
+---
+Research flights and, on a small scale, commercial aviation can be observed on the visitor terrace. At the weekend, it is mainly amateur pilots who take off and land here. There is also some catering available for non-aviation enthusiasts.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Forschungsflughafen Braunschweig-Wolfsburg
**Location:** Forschungsflughafen Braunschweig-Wolfsburg, Pumpenweg, Waggum, Wabe-Schunter-Beberbach, Braunschweig, Niedersachsen, 38110, Deutschland
**Submitted by:** MarcN
**Website:** https://www.fhbwe.de/

### Description
Research flights and, on a small scale, commercial aviation can be observed on the visitor terrace. At the weekend, it is mainly amateur pilots who take off and land here. There is also some catering available for non-aviation enthusiasts.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 221
**File:** `content/daytrip/eu/de/forschungsflughafen-braunschweig-wolfsburg.md`

Please review this venue submission and edit the content as needed before merging.