### PR TITLE
New: Jagdmuseum Wulff from MarcN

### DIFF
--- a/content/daytrip/eu/de/jagdmuseum-wulff.md
+++ b/content/daytrip/eu/de/jagdmuseum-wulff.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/jagdmuseum-wulff"
+date: "2025-06-02T17:08:26.265Z"
+poster: "MarcN"
+lat: "52.68443"
+lng: "10.584104"
+location: "Jagdmuseum Wulff, Hässelmühler Straße, Oerrel, Dedelstorf, Samtgemeinde Hankensbüttel, Gifhorn, Niedersachsen, 29386, Deutschland"
+title: "Jagdmuseum Wulff"
+external_url: https://www.jagdmuseum-wulff.de/
+---
+A museum about hunting in Europe is quite a niche. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Jagdmuseum Wulff
**Location:** Jagdmuseum Wulff, Hässelmühler Straße, Oerrel, Dedelstorf, Samtgemeinde Hankensbüttel, Gifhorn, Niedersachsen, 29386, Deutschland
**Submitted by:** MarcN
**Website:** https://www.jagdmuseum-wulff.de/

### Description
A museum about hunting in Europe is quite a niche. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 222
**File:** `content/daytrip/eu/de/jagdmuseum-wulff.md`

Please review this venue submission and edit the content as needed before merging.