### PR TITLE
New: ZeitHaus from MarcN

### DIFF
--- a/content/daytrip/eu/de/zeithaus.md
+++ b/content/daytrip/eu/de/zeithaus.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/zeithaus"
+date: "2025-06-02T17:08:38.962Z"
+poster: "MarcN"
+lat: "52.431807"
+lng: "10.790833"
+location: "ZeitHaus, Stadtbrücke, Stadtmitte, Wolfsburg, Niedersachsen, 38440, Deutschland"
+title: "ZeitHaus"
+external_url: https://www.autostadt.de/erkunden/zeithaus
+---
+A car exhibition about the history of automobility with a focus on Volkswagen and other Group brands. However, classic cars from other manufacturers are also on display. The museum is only accessible to visitors to the Autostadt. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** ZeitHaus
**Location:** ZeitHaus, Stadtbrücke, Stadtmitte, Wolfsburg, Niedersachsen, 38440, Deutschland
**Submitted by:** MarcN
**Website:** https://www.autostadt.de/erkunden/zeithaus

### Description
A car exhibition about the history of automobility with a focus on Volkswagen and other Group brands. However, classic cars from other manufacturers are also on display. The museum is only accessible to visitors to the Autostadt. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 223
**File:** `content/daytrip/eu/de/zeithaus.md`

Please review this venue submission and edit the content as needed before merging.