### PR TITLE
New: Ribe Vikinge Center Museumsbutik from MarcN

### DIFF
--- a/content/daytrip/eu/dk/ribe-vikinge-center-museumsbutik.md
+++ b/content/daytrip/eu/dk/ribe-vikinge-center-museumsbutik.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/dk/ribe-vikinge-center-museumsbutik"
+date: "2025-06-02T17:08:58.190Z"
+poster: "MarcN"
+lat: "55.310695"
+lng: "8.768279"
+location: "Ribe Vikinge Center Museumsbutik, Lustrupvej, Lustrup, Damhuus, Esbjerg Kommune, Region Süddänemark, 6760, Dänemark"
+title: "Ribe Vikinge Center Museumsbutik"
+external_url: https://www.ribevikingecenter.dk/
+---
+Impressive replica of a Viking village with lots of activities for children. Very lively thanks to the many employees dressed in Viking clothing and carrying out typical activities. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ribe Vikinge Center Museumsbutik
**Location:** Ribe Vikinge Center Museumsbutik, Lustrupvej, Lustrup, Damhuus, Esbjerg Kommune, Region Süddänemark, 6760, Dänemark
**Submitted by:** MarcN
**Website:** https://www.ribevikingecenter.dk/

### Description
Impressive replica of a Viking village with lots of activities for children. Very lively thanks to the many employees dressed in Viking clothing and carrying out typical activities. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 225
**File:** `content/daytrip/eu/dk/ribe-vikinge-center-museumsbutik.md`

Please review this venue submission and edit the content as needed before merging.