### PR TITLE
New: Lokpark Braunschweig from MarcN

### DIFF
--- a/content/daytrip/eu/de/lokpark-braunschweig.md
+++ b/content/daytrip/eu/de/lokpark-braunschweig.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/lokpark-braunschweig"
+date: "2025-06-02T17:11:13.474Z"
+poster: "MarcN"
+lat: "52.24408"
+lng: "10.545968"
+location: "Lokpark Braunschweig, 3, Schwartzkopffstraße, Bebelhof, Mitte, Braunschweig, Niedersachsen, 38126, Deutschland"
+title: "Lokpark Braunschweig"
+external_url: https://www.lokpark.de/
+---
+An old railway site that is used as an event venue, but also by an association that restores old steam locomotives. The site is only open to the public on certain days. Information can be found on the website. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lokpark Braunschweig
**Location:** Lokpark Braunschweig, 3, Schwartzkopffstraße, Bebelhof, Mitte, Braunschweig, Niedersachsen, 38126, Deutschland
**Submitted by:** MarcN
**Website:** https://www.lokpark.de/

### Description
An old railway site that is used as an event venue, but also by an association that restores old steam locomotives. The site is only open to the public on certain days. Information can be found on the website. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 226
**File:** `content/daytrip/eu/de/lokpark-braunschweig.md`

Please review this venue submission and edit the content as needed before merging.