### PR TITLE
New: Blåvandshuk Fyr from MarcN

### DIFF
--- a/content/daytrip/eu/dk/blvandshuk-fyr.md
+++ b/content/daytrip/eu/dk/blvandshuk-fyr.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/dk/blvandshuk-fyr"
+date: "2025-06-02T17:11:39.031Z"
+poster: "MarcN"
+lat: "55.557828"
+lng: "8.083255"
+location: "Blåvandshuk Fyr, Fyrvej, Blåvand, Varde Kommune, Region Süddänemark, 6857, Dänemark"
+title: "Blåvandshuk Fyr"
+external_url: https://vardemuseerne.dk/museum/blaavandshuk-fyr-4/
+---
+Lighthouse at Denmark's most westerly point. The lighthouse can be visited and from the top there is a beautiful view over the land and the sea. In the immediate vicinity there is an old bunker and the antenna of a DGPS transmitter. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Blåvandshuk Fyr
**Location:** Blåvandshuk Fyr, Fyrvej, Blåvand, Varde Kommune, Region Süddänemark, 6857, Dänemark
**Submitted by:** MarcN
**Website:** https://vardemuseerne.dk/museum/blaavandshuk-fyr-4/

### Description
Lighthouse at Denmark's most westerly point. The lighthouse can be visited and from the top there is a beautiful view over the land and the sea. In the immediate vicinity there is an old bunker and the antenna of a DGPS transmitter. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 228
**File:** `content/daytrip/eu/dk/blvandshuk-fyr.md`

Please review this venue submission and edit the content as needed before merging.