### PR TITLE
New: Braunschweiger Dom from MarcN

### DIFF
--- a/content/daytrip/eu/de/braunschweiger-dom.md
+++ b/content/daytrip/eu/de/braunschweiger-dom.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/braunschweiger-dom"
+date: "2025-06-02T17:12:01.071Z"
+poster: "MarcN"
+lat: "52.264432"
+lng: "10.523533"
+location: "Braunschweiger Dom, Burgplatz, Mitte, Braunschweig, Niedersachsen, 38100, Deutschland"
+title: "Braunschweiger Dom"
+external_url: https://www.braunschweigerdom.de/krypta
+---
+Under the altar area of the cathedral is the crypt, which contains the remains of several dukes as well as Henry the Lion and his wife Mathilde. The crypt is accessible for a small fee. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Braunschweiger Dom
**Location:** Braunschweiger Dom, Burgplatz, Mitte, Braunschweig, Niedersachsen, 38100, Deutschland
**Submitted by:** MarcN
**Website:** https://www.braunschweigerdom.de/krypta

### Description
Under the altar area of the cathedral is the crypt, which contains the remains of several dukes as well as Henry the Lion and his wife Mathilde. The crypt is accessible for a small fee. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 230
**File:** `content/daytrip/eu/de/braunschweiger-dom.md`

Please review this venue submission and edit the content as needed before merging.