### PR TITLE
New: Knokke Station from MarcN

### DIFF
--- a/content/daytrip/eu/be/knokke-station.md
+++ b/content/daytrip/eu/be/knokke-station.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/be/knokke-station"
+date: "2025-06-02T17:12:31.597Z"
+poster: "MarcN"
+lat: "51.341653"
+lng: "3.28479"
+location: "Knokke Station, Koningslaan, Albertstrand, Knokke, Knokke-Heist, 8300, Belgium"
+title: "Knokke Station"
+external_url: https://www.delijn.be/en/content/kusttram/
+---
+Knokke Satation is the start (or end) point of the Coastal Tram (Kusttram) which runs along the entire Belgian coast. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Knokke Station
**Location:** Knokke Station, Koningslaan, Albertstrand, Knokke, Knokke-Heist, 8300, Belgium
**Submitted by:** MarcN
**Website:** https://www.delijn.be/en/content/kusttram/

### Description
Knokke Satation is the start (or end) point of the Coastal Tram (Kusttram) which runs along the entire Belgian coast. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 232
**File:** `content/daytrip/eu/be/knokke-station.md`

Please review this venue submission and edit the content as needed before merging.