### PR TITLE
New: Highclere Castle from popey

### DIFF
--- a/content/daytrip/eu/gb/highclere-castle.md
+++ b/content/daytrip/eu/gb/highclere-castle.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/highclere-castle"
+date: "2025-06-02T18:25:51.993Z"
+poster: "popey"
+lat: "51.326603"
+lng: "-1.360513"
+location: "Highclere Castle, Limetree Avenue, Highclere, Basingstoke and Deane, Hampshire, England, RG20 9RL, United Kingdom"
+title: "Highclere Castle"
+external_url: https://www.highclerecastle.co.uk/
+---
+Downton Abbey filming location.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Highclere Castle
**Location:** Highclere Castle, Limetree Avenue, Highclere, Basingstoke and Deane, Hampshire, England, RG20 9RL, United Kingdom
**Submitted by:** popey
**Website:** https://www.highclerecastle.co.uk/

### Description
Downton Abbey filming location.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 233
**File:** `content/daytrip/eu/gb/highclere-castle.md`

Please review this venue submission and edit the content as needed before merging.