### PR TITLE
New: Farnborough Air Science Trust Museum from popey

### DIFF
--- a/content/daytrip/eu/gb/farnborough-air-science-trust-museum.md
+++ b/content/daytrip/eu/gb/farnborough-air-science-trust-museum.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/eu/gb/farnborough-air-science-trust-museum"
+date: "2025-06-02T18:26:04.239Z"
+poster: "popey"
+lat: "51.282228"
+lng: "-0.753651"
+location: "Farnborough Air Science Trust Museum, Farnborough Road, Farnborough, Rushmoor, Hampshire, England, GU14 6TL, United Kingdom"
+title: "Farnborough Air Science Trust Museum"
+external_url: https://airsciences.org.uk/about-fast/
+---
+FAST (Farnborough Air Sciences Trust) is a volunteer-run charity museum that's been showcasing Farnborough's aviation heritage since 1993. 
+
+Housed in a 1908 building that once served as headquarters for the Royal Engineers Balloon School, overlooking Farnborough Airfield where you can watch modern aircraft while exploring historic gems like Sir Frank Whittle's early jet engines and Concorde research models. 
+
+They have half a million artefacts in their collection and displays rotating, it's a proper treasure trove of British aviation history that punches well above its weight for a volunteer-led operation. 
+
+Plus, they've got the Queen's Award for Voluntary Service, which is basically the aviation equivalent of getting a gold star from your nan!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Farnborough Air Science Trust Museum
**Location:** Farnborough Air Science Trust Museum, Farnborough Road, Farnborough, Rushmoor, Hampshire, England, GU14 6TL, United Kingdom
**Submitted by:** popey
**Website:** https://airsciences.org.uk/about-fast/

### Description
FAST (Farnborough Air Sciences Trust) is a volunteer-run charity museum that's been showcasing Farnborough's aviation heritage since 1993. 

Housed in a 1908 building that once served as headquarters for the Royal Engineers Balloon School, overlooking Farnborough Airfield where you can watch modern aircraft while exploring historic gems like Sir Frank Whittle's early jet engines and Concorde research models. 

They have half a million artefacts in their collection and displays rotating, it's a proper treasure trove of British aviation history that punches well above its weight for a volunteer-led operation. 

Plus, they've got the Queen's Award for Voluntary Service, which is basically the aviation equivalent of getting a gold star from your nan!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 234
**File:** `content/daytrip/eu/gb/farnborough-air-science-trust-museum.md`

Please review this venue submission and edit the content as needed before merging.