### PR TITLE
New: Novelty Automation from andypiper

### DIFF
--- a/content/daytrip/eu/gb/novelty-automation.md
+++ b/content/daytrip/eu/gb/novelty-automation.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/novelty-automation"
+date: "2025-06-02T23:05:39.409Z"
+poster: "andypiper"
+lat: "51.51976"
+lng: "-0.116525"
+location: "Novelty Automation, 1a, Princeton Street, Gray's Inn, Holborn, London Borough of Camden, London, Greater London, England, WC1R 4AX, United Kingdom"
+title: "Novelty Automation"
+external_url: https://www.novelty-automation.com/
+---
+A very fun collection of satirical automata and handcrafted arcade gaming installations.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Novelty Automation
**Location:** Novelty Automation, 1a, Princeton Street, Gray's Inn, Holborn, London Borough of Camden, London, Greater London, England, WC1R 4AX, United Kingdom
**Submitted by:** andypiper
**Website:** https://www.novelty-automation.com/

### Description
A very fun collection of satirical automata and handcrafted arcade gaming installations.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 237
**File:** `content/daytrip/eu/gb/novelty-automation.md`

Please review this venue submission and edit the content as needed before merging.