### PR TITLE
New: United States Mint from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/united-states-mint.md
+++ b/content/daytrip/na/us/united-states-mint.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/united-states-mint"
+date: "2025-06-03T04:41:19.268Z"
+poster: "Mark Dominus"
+lat: "39.953329"
+lng: "-75.147423"
+location: "United States Mint, 151, North Independence Mall East, Center City, Chinatown, Philadelphia, Philadelphia County, Pennsylvania, 19106, United States"
+title: "United States Mint"
+external_url: https://www.usmint.gov/
+---
+Most U.S. coins are made here.  There is a small museum about money and how it is made, but the good part is watching the coin-pressing floor from the overhead gallery.


### PR DESCRIPTION
## New Venue Submission

**Venue:** United States Mint
**Location:** United States Mint, 151, North Independence Mall East, Center City, Chinatown, Philadelphia, Philadelphia County, Pennsylvania, 19106, United States
**Submitted by:** Mark Dominus
**Website:** https://www.usmint.gov/

### Description
Most U.S. coins are made here.  There is a small museum about money and how it is made, but the good part is watching the coin-pressing floor from the overhead gallery.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 239
**File:** `content/daytrip/na/us/united-states-mint.md`

Please review this venue submission and edit the content as needed before merging.