### PR TITLE
New: Mütter Museum from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/mtter-museum.md
+++ b/content/daytrip/na/us/mtter-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/mtter-museum"
+date: "2025-06-03T04:42:36.709Z"
+poster: "Mark Dominus"
+lat: "39.953275"
+lng: "-75.176547"
+location: "Mütter Museum, 19, South 22nd Street, Center City, Rittenhouse Square, Philadelphia, Philadelphia County, Pennsylvania, 19103, United States"
+title: "Mütter Museum"
+external_url: https://muttermuseum.org/
+---
+19th-cenruty style museum of medical oddities and curiosities.  Includes: a life cast of Chang and Eng Bunker, the original Siamese Twins; a collection of objects retrieved from patients' throats by Chevalier Jackson, called "The father of endoscopy"; the cancerous tumor secretly removed from Grover Cleveland's mouth; the "Soap Lady", a corpse that was transmuted into soap; collections of antique surgical equipment, and many other equally bizarre items; collections 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Mütter Museum
**Location:** Mütter Museum, 19, South 22nd Street, Center City, Rittenhouse Square, Philadelphia, Philadelphia County, Pennsylvania, 19103, United States
**Submitted by:** Mark Dominus
**Website:** https://muttermuseum.org/

### Description
19th-cenruty style museum of medical oddities and curiosities.  Includes: a life cast of Chang and Eng Bunker, the original Siamese Twins; a collection of objects retrieved from patients' throats by Chevalier Jackson, called "The father of endoscopy"; the cancerous tumor secretly removed from Grover Cleveland's mouth; the "Soap Lady", a corpse that was transmuted into soap; collections of antique surgical equipment, and many other equally bizarre items; collections 


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 240
**File:** `content/daytrip/na/us/mtter-museum.md`

Please review this venue submission and edit the content as needed before merging.