### PR TITLE
Fix: add poster names where it was missing

### DIFF
--- a/content/daytrip/eu/de/arithmeum.md
+++ b/content/daytrip/eu/de/arithmeum.md
@@ -6,5 +6,6 @@ lng: '7.104726'
 location: 'Lennéstr. 2, 53113 Bonn'
 title: 'Arithmeum'
 external_url: https://www.arithmeum.uni-bonn.de/en/arithmeum.html
+poster: "Aesdeef"
 ---
 A museum of calculation tools, with several replicas with instructions for you to try out.

--- a/content/daytrip/eu/de/historisch-technisches-museum-peenemnde.md
+++ b/content/daytrip/eu/de/historisch-technisches-museum-peenemnde.md
@@ -6,5 +6,6 @@ lng: '13.7689689'
 location: 'Im Kraftwerk, 17449 Peenemünde'
 title: 'Historisch-Technisches Museum Peenemünde'
 external_url: https://museum-peenemuende.de/
+poster: "pesco"
 ---
 Where Wernherr von Braun, during World War II, developed German rocket weapons that led directly into the US space program, ICBMs etc.

--- a/content/daytrip/eu/de/scheunenwindmhle-saalow.md
+++ b/content/daytrip/eu/de/scheunenwindmhle-saalow.md
@@ -6,6 +6,7 @@ lng: '13.378043'
 location: 'Scheunenwindmühle Saalow, Dorfaue Saalow, Saalow, Am Mellensee, Teltow-Fläming, Brandenburg, 15838, Deutschland'
 title: 'Scheunenwindmühle Saalow'
 external_url: https://scheunenwindmuehle.de/
+poster: "PizzaTreeIsland"
 ---
 A historic and one of a kind windmill built inside a barn. The barn doors open to reveal a wooden turbine that powers the milling mechanism. The windmill is maintained by volunteers.
 Tours for groups are available on special days and upon request. For more information see website. Wheelchair access is limited. 

--- a/content/daytrip/eu/fr/gudelon-castle.md
+++ b/content/daytrip/eu/fr/gudelon-castle.md
@@ -6,6 +6,7 @@ lng: '3.155556'
 location: 'D 955 89520 Treigny'
 title: 'Guédelon Castle'
 external_url: https://www.guedelon.fr
+poster: "NAB"
 ---
 Guédelon is a 13th-century castle being built from scratch in France using only medieval tools, techniques, and materials. It’s an experimental archaeology project where history, engineering and craftsmanship collide - there are no modern machines, just pure feudal tech.
 

--- a/content/daytrip/eu/gb/anthorn-radio-station.md
+++ b/content/daytrip/eu/gb/anthorn-radio-station.md
@@ -6,5 +6,6 @@ lng: '-3.278421'
 location: 'Bowness Common, Bowness, Anthorn, Cumberland, England, CA7 5AN'
 title: 'Anthorn Radio Station'
 external_url: https://www.npl.co.uk/msf-signal
+poster: "Cain Mosni aka Camopants"
 ---
 Anthorn is where the UK's atomic clock radio signal is broadcast from.

--- a/content/daytrip/eu/gb/baston-lodge.md
+++ b/content/daytrip/eu/gb/baston-lodge.md
@@ -6,5 +6,6 @@ lng: '0.553147'
 location: '1 Upper Maze Hill, St Leonards-on-Sea, Hastings, East Sussex'
 title: 'Baston Lodge; childhood home of Alan Turing'
 external_url: https://en.wikipedia.org/wiki/Baston_Lodge
+poster: "Cain Mosni aka Camopants"
 ---
 The house in which Alan Turing resided with his brother John as wards, while their parents were stationed abroad in the Indian Civil Service.

--- a/content/daytrip/eu/gb/bolton-steam-museum.md
+++ b/content/daytrip/eu/gb/bolton-steam-museum.md
@@ -6,5 +6,6 @@ lng: '-2.454833'
 location: 'Mornington Road, Off Chorley Old Road, Bolton, BL1 4EU'
 title: 'Bolton Steam Museum'
 external_url: https://www.nmes.org/index.html
+poster: "Hugo"
 ---
 A large collection of steam engines -- from giant three-storey machines, down to small barring engines (used to start the big ones). Open Wednesdays and Sundays, running the machines on electricity. Actually steaming three or four times a summer.

--- a/content/daytrip/eu/gb/british-lawnmower-museum.md
+++ b/content/daytrip/eu/gb/british-lawnmower-museum.md
@@ -6,6 +6,7 @@ lng: '-3.0054189'
 location: '106-114 Shakespeare St, Southport PR8 5AJ'
 title: 'British Lawnmower Museum'
 external_url: https://www.lawnmowerworld.co.uk/
+poster: "M6WIQ"
 ---
 The British Lawnmover Museum is one of the Worlds leading authorities on vintage lawnmowers and are now specialists in antique garden machinery, supplying parts, archive conservation of manuscript materials and valuing machines from all over the world. See 'Lawnmowers of the Rich and Famous' including Prince Charles and Princess Diana, Brian May, Nicholas Parsons, Eric Morcambe, Hilda Ogden, Alan Titchmarsh and many more.
 

--- a/content/daytrip/eu/gb/caen-hill-locks.md
+++ b/content/daytrip/eu/gb/caen-hill-locks.md
@@ -6,5 +6,6 @@ lng: '-2.033673'
 location: 'Canal & River Trust car park (P&D), The Locks, Rowde, Devizes, SN10 1RF'
 title: 'Caen Hill Locks'
 external_url: https://canalrivertrust.org.uk/canals-and-rivers/places-to-visit/caen-hill-locks
+poster: "Hugo"
 ---
 Also known as the Devizes Cascade, this sequence of 29 connected locks on the Kennet and Avon Canal is the longest sequence of locks in the UK. The steepest central section has 16 locks back-to-back, with reservoir ponds to preserve water as much as possible.

--- a/content/daytrip/eu/gb/carnglaze-caverns.md
+++ b/content/daytrip/eu/gb/carnglaze-caverns.md
@@ -6,5 +6,6 @@ lng: '-4.55658'
 location: 'Carnglaze Caverns, St Neot, Liskeard, Cornwall, PL14 6HQ'
 title: 'Carnglaze Caverns'
 external_url: https://www.carnglaze.com
+poster: "Hugo"
 ---
 A pair of artificial caves, made by mining slate. The upper cavern is used for events (concerts, weddings). The lower cavern has a lake (which is actually a flooded third cavern).

--- a/content/daytrip/eu/gb/chasewater-railway.md
+++ b/content/daytrip/eu/gb/chasewater-railway.md
@@ -6,5 +6,6 @@ lng: '-1.952949'
 location: 'Chasewater Country Park, Brownhills West Station, Pool Lane, Brownhills, Staffordshire, WS8 7NL'
 title: 'Chasewater Railway'
 external_url: https://www.chasewaterrailway.co.uk/
+poster: "theaardvark"
 ---
 A 4-mile heritage railway run by volunteers in the Chasewater Country Park. It has four stops, with two stations running a tea room, a cafe, a Model Railway and Gift Shop.

--- a/content/daytrip/eu/gb/chineham-incinerator.md
+++ b/content/daytrip/eu/gb/chineham-incinerator.md
@@ -6,6 +6,7 @@ lng: '-1.0398349'
 location: 'Whitmarsh Ln, Chineham, Basingstoke RG24 8LL, Hampshire, United Kingdom'
 title: 'Chineham Incinerator'
 external_url: https://www.hampshire.veolia.co.uk/energy-recovery/chineham
+poster: "Wimpy"
 ---
 # Chineham Energy Recovery Facility
 

--- a/content/daytrip/eu/gb/clifton-observatory.md
+++ b/content/daytrip/eu/gb/clifton-observatory.md
@@ -6,6 +6,7 @@ lng: '-2.626483'
 location: 'Litfield Place, Clifton, Bristol BS8 3LT'
 title: 'Clifton Observatory'
 external_url: https://cliftonobservatory.com
+poster: "Hugo"
 ---
 A camera obscura with views across the Bristol skyline, built in the tower of the old Bristol Observatory. Has displays of the history of the observatory, and a rooftop cafe with a spectacular view over Bristol and the Clifton Suspension Bridge.
 

--- a/content/daytrip/eu/gb/clifton-suspension-bridge.md
+++ b/content/daytrip/eu/gb/clifton-suspension-bridge.md
@@ -6,5 +6,6 @@ lng: '-2.628608'
 location: 'Bridge Road, Bristol'
 title: 'Clifton Suspension Bridge'
 external_url: https://cliftonbridge.org.uk
+poster: "Hugo"
 ---
 Suspension bridge designed by Isambard Kingdom Brunel, crossing the gorge of the river Avon. Tours of the bridge and of the underground works are available.

--- a/content/daytrip/eu/gb/computer-game-museum.md
+++ b/content/daytrip/eu/gb/computer-game-museum.md
@@ -6,5 +6,6 @@ lng: '13.4419418'
 location: 'Karl-Marx-Allee 93A, 10243 Berlin'
 title: 'Computer Game Museum'
 external_url: https://www.computerspielemuseum.de/en/43-Homepage.htm
+poster: "Duncan"
 ---
 It is a museum about the history of computer gaming

--- a/content/daytrip/eu/gb/crofton-pumping-station.md
+++ b/content/daytrip/eu/gb/crofton-pumping-station.md
@@ -6,5 +6,6 @@ lng: '-1.625869'
 location: 'Crofton Beam Engines, Crofton, Marlborough, Wiltshire, SN8 3DW'
 title: 'Crofton Pumping Station'
 external_url: https://www.croftonbeamengines.org/about/
+poster: "Hugo"
 ---
 The oldest beam engine still in its original location -- made in 1812. Filling the top pound of the Kennet and Avon Canal, the engine still pumps water to the canal on steaming days.

--- a/content/daytrip/eu/gb/discovery-museum.md
+++ b/content/daytrip/eu/gb/discovery-museum.md
@@ -6,5 +6,6 @@ lng: '-1.624818'
 location: 'Blandford Square, Newcastle upon Tyne, NE1 4JA'
 title: 'Discovery Museum'
 external_url: https://www.northeastmuseums.org.uk/discoverymuseum
+poster: "Elleo"
 ---
 Museum focusing on science and the industrial history of the North.

--- a/content/daytrip/eu/gb/epsom-well-and-spa.md
+++ b/content/daytrip/eu/gb/epsom-well-and-spa.md
@@ -6,5 +6,6 @@ lng: '-0.290253'
 location: 'Well Way, EPSOM, KT18 7LW'
 title: 'Epsom Well and Spa'
 external_url: https://eehe.org.uk/31208/epsomspa/
+poster: "Cain Mosni aka Camopants"
 ---
 The original source of "Epsom Salts" (magnesium sulphate) extraction and spa treatment.

--- a/content/daytrip/eu/gb/imber-village.md
+++ b/content/daytrip/eu/gb/imber-village.md
@@ -6,6 +6,7 @@ lng: '-2.050667'
 location: 'Imber, Wiltshire, United Kingdom'
 title: 'Imber Village'
 external_url: https://www.imbervillage.co.uk
+poster: "Hugo"
 ---
 Placed right in the middle of Salisbury Plain, Imber was turned into a training centre for American troops in 1943. All of the inhabitants of the village were ejected with only a few weeks notice, and the village has remained uninhabited ever since. It is still used as a training ground for the British armed forces.
 

--- a/content/daytrip/eu/gb/leeds-industrial-museum.md
+++ b/content/daytrip/eu/gb/leeds-industrial-museum.md
@@ -6,5 +6,6 @@ lng: '-1.58288'
 location: 'Canal Road, Leeds, LS12 1QF'
 title: 'Leeds Industrial Museum'
 external_url: https://museumsandgalleries.leeds.gov.uk/pQKYcJ/leeds-industrial-museum/home
+poster: "Nav"
 ---
 Leeds Industrial Museum started life as a woollen mill, and you'll certainly find some impressive machinery related to spinning wool here, but the collections now its a museum go much further than that, covering engineering, railways, a steam engine to power the mill and cinema history (don't believe what anyone else says - it was invented in Leeds!)

--- a/content/daytrip/eu/gb/mathscity.md
+++ b/content/daytrip/eu/gb/mathscity.md
@@ -6,5 +6,6 @@ lat: '53.7968822'
 location: 'Upper Floor, Trinity, Shopping Centre, Leeds LS1 5AT'
 title: 'MathsCity'
 external_url: https://mathscity.co.uk/
+poster: "Katie Steckles"
 ---
 MathsCity is a hands-on maths activity centre, with puzzles, toys, a giant kaleidoscope and a human-sized bubble maker, as well as codebreaking activities, mathematical demonstrations and extra activities run during the holidays.

--- a/content/daytrip/eu/gb/millom-rock-park.md
+++ b/content/daytrip/eu/gb/millom-rock-park.md
@@ -6,5 +6,6 @@ lng: '-3.271689386293'
 location: 'Ghyll Scaur Quarry, The Hill, Millom LA18 5HB'
 title: 'Millom Rock Park'
 external_url: https://www.holcim.co.uk/about-us/millom-rock-park
+poster: "Sarah Dal"
 ---
 Samples of rock types and displays on quarrying around a large gravel area. 

--- a/content/daytrip/eu/gb/montrose-basing-wildlife-centre.md
+++ b/content/daytrip/eu/gb/montrose-basing-wildlife-centre.md
@@ -6,5 +6,6 @@ lng: '-2.490549'
 location: 'Rossie Braes, Angus DD10 9TA'
 title: 'Montrose Basing Wildlife Centre'
 external_url: https://scottishwildlifetrust.org.uk/reserve/montrose-basin/
+poster: "localnaturelover"
 ---
 A visitor centre with amazing views over the Basin and decent coffee. Montrose Basin is wildlife paradise. You can see osprey, seals, waders and thousands of migrating geese. The day the migrating geese leave is a natural spectacle, and is often televised! 

--- a/content/daytrip/eu/gb/museum-of-computing.md
+++ b/content/daytrip/eu/gb/museum-of-computing.md
@@ -6,5 +6,6 @@ lng: '-1.781169'
 location: '6-7 Theatre Sq, Swindon SN1 1QN'
 title: 'Museum of Computing'
 external_url: https://www.museumofcomputing.org.uk
+poster: "Hugo"
 ---
 A collection of mostly '80s and '90s era computing devices, with a hands-on section of consoles and 8-bit micros that visitors can play with.

--- a/content/daytrip/eu/gb/old-sarum.md
+++ b/content/daytrip/eu/gb/old-sarum.md
@@ -6,5 +6,6 @@ lng: '-1.800256'
 location: 'Castle Road, Salisbury, Wiltshire, SP1 3SD'
 title: 'Old Sarum'
 external_url: https://www.english-heritage.org.uk/visit/places/old-sarum/
+poster: "Hugo"
 ---
 Old Sarum is the remains of a major town, in use from 400 BCE to 1220 CE. In the 13th century, the town migrated down the hill to the new location of Salisbury, which had a new cathedral, and by 1220, Old Sarum was abandoned. The site has the remains of the Norman castle, the church, and the town walls.

--- a/content/daytrip/eu/gb/orford-ness.md
+++ b/content/daytrip/eu/gb/orford-ness.md
@@ -6,5 +6,6 @@ lng: '1.556797'
 location: 'Quay Street, Orford, Suffolk, IP12 2NU'
 title: 'Orford Ness'
 external_url: https://www.nationaltrust.org.uk/visit/suffolk/orford-ness-national-nature-reserve
+poster: "Floppy"
 ---
 An ex Ministry of Defence testing ground for weapons testing, radar, and atomic weapons development. Includes old bunkers, abandoned weapons labs, and lovely coastal scenery. Access by boat, check ahead for opening times.

--- a/content/daytrip/eu/gb/rendlesham-ufo-landing-site.md
+++ b/content/daytrip/eu/gb/rendlesham-ufo-landing-site.md
@@ -6,5 +6,6 @@ lng: '1.448779'
 location: 'Rendlesham Forest, Tangham, Woodbridge, IP12 3NF'
 title: 'Rendlesham UFO Landing Site'
 external_url: https://www.forestryengland.uk/rendlesham-forest/ufo-trail-rendlesham-forest
+poster: "Floppy"
 ---
 A short woodland walk to a sculpture commemorating the Rendlesham UFO Incident in 1980.

--- a/content/daytrip/eu/gb/riverside-museum.md
+++ b/content/daytrip/eu/gb/riverside-museum.md
@@ -6,5 +6,6 @@ lng: '-4.305589'
 location: '100 Pointhouse Rd, Glasgow G3 8RS'
 title: 'Riverside Museum'
 external_url: https://www.glasgowlife.org.uk/museums/venues/riverside-museum
+poster: "Alicolliar"
 ---
 Modern transport museum, mostly focused on Glasgow/Scotland, featuring vehicles from throughout the 20th century.

--- a/content/daytrip/eu/gb/stonehenge.md
+++ b/content/daytrip/eu/gb/stonehenge.md
@@ -6,5 +6,6 @@ lng: '-1.859952'
 location: 'Near Amesbury, Wiltshire, SP4 7DE'
 title: 'Stonehenge'
 external_url: https://www.english-heritage.org.uk/visit/places/stonehenge/
+poster: "Hugo"
 ---
 *The* prehistoric stone circle.

--- a/content/daytrip/eu/gb/stott-park-bobbin-mill.md
+++ b/content/daytrip/eu/gb/stott-park-bobbin-mill.md
@@ -6,5 +6,6 @@ lng: '-2.96529528522713'
 location: 'Finsthwaite, Ulverston, Cumbria, LA12 8AX '
 title: 'Stott Park Bobbin Mill'
 external_url: https://www.english-heritage.org.uk/visit/places/stott-park-bobbin-mill/
+poster: "Sarah Dal"
 ---
 An original bobbin mill with working machinery from the 1870s. Incredibly, was in operation using this machinery right up until the 1960s. Book a guided tour to view the mill, including firing up the machines, and you can freely explore the acres of woodland surrounding it.

--- a/content/daytrip/eu/gb/the-eden-project.md
+++ b/content/daytrip/eu/gb/the-eden-project.md
@@ -6,5 +6,6 @@ lng: '-4.74472'
 location: 'Eden Project, Bodelva, Cornwall, PL24 2SG'
 title: 'The Eden Project'
 external_url: https://www.edenproject.com
+poster: "Hugo"
 ---
 Extensive gardens, in the bowl of an old quarry. A connected series of enclosed domes ("biomes") hold large collections of plants from other climates -- rainforest and the Mediterranean. There is also a permanent exhibit, "Invisible Worlds", about things that are outside the range of our own senses -- too big, too small, too fast, too far away.

--- a/content/daytrip/eu/gb/the-mad-museum-mechanical-art-and-design.md
+++ b/content/daytrip/eu/gb/the-mad-museum-mechanical-art-and-design.md
@@ -6,6 +6,7 @@ lng: '-1.706931'
 location: 'Henley Street, Stratford-upon-Avon, Warwickshire. CV37 6PT.'
 title: 'The MAD Museum (Mechanical Art and Design)'
 external_url: https://themadmuseum.co.uk
+poster: "NAB"
 ---
 The MAD Museum (Mechanical Art and Design) is a wonderfully eccentric attraction located in the heart of Stratford-upon-Avon. 
 

--- a/content/daytrip/eu/gb/the-national-museum-of-computing.md
+++ b/content/daytrip/eu/gb/the-national-museum-of-computing.md
@@ -6,5 +6,6 @@ lng: '-0.743578'
 location: 'The National Museum of Computing, Block H, Bletchley Park, Milton Keynes MK3 6DS'
 title: 'The National Museum of Computing'
 external_url: https://www.tnmoc.org/
+poster: "Neil"
 ---
 Collection of computers, calculators and similar technology throughout the ages, including rebuilds of WWII era codebreaking machines.

--- a/content/daytrip/eu/gb/the-national-videogame-museum.md
+++ b/content/daytrip/eu/gb/the-national-videogame-museum.md
@@ -6,5 +6,6 @@ lng: '-1.465752'
 location: 'Castle House, Angel St, Sheffield City Centre, Sheffield S3 8LN'
 title: 'The National Videogame Museum'
 external_url: https://thenvm.org
+poster: "Fish"
 ---
 A collection of old and new video games, including some cool experimental ones. If you're just browsing expect to spend a couple of hours, if you want to spend time with friends competing on Dance Dance Revolution or Donkey Kong Racing or the like, maybe longer. There's also cabinets full of gaming memorabilia and historical items.

--- a/content/daytrip/eu/gb/the-uks-most-inland-point.md
+++ b/content/daytrip/eu/gb/the-uks-most-inland-point.md
@@ -6,5 +6,6 @@ lng: '-1.620011'
 location: 'Swadlingcote, Derbyshire'
 title: "The UK's most inland point"
 external_url: http://news.bbc.co.uk/1/hi/england/derbyshire/3090539.stm
+poster: "Cain Mosni aka Camopants"
 ---
 Don't pester the farm residents, but this point is the furthest one can get from the sea in all directions - the most inland point - in Great Britain, approximately 70 miles from The Wash.

--- a/content/daytrip/eu/gb/woodhorn-museum.md
+++ b/content/daytrip/eu/gb/woodhorn-museum.md
@@ -6,5 +6,6 @@ lng: '-1.547012'
 location: 'Woodhorn Museum, Queen Elizabeth II Country Park, Ashington, Northumberland NE63 9YF'
 title: 'Woodhorn Museum'
 external_url: https://museumsnorthumberland.org.uk/woodhorn-museum/
+poster: "Sarah Dal"
 ---
 A mining museum at a former colliery, one of the last deep pits to operate in the UK. As well as the industrial history of the region, the site also has an excellent programme of arts and events, hosts the County Archives, and nearby Woodhorn Colliery Railway through the Country Park is currently in restoration (as of May 2025)

--- a/content/daytrip/eu/gb/woolwich-foot-tunnel.md
+++ b/content/daytrip/eu/gb/woolwich-foot-tunnel.md
@@ -6,5 +6,6 @@ lng: '0.062313'
 location: 'Glass Yard, Woolwich, London'
 title: 'Woolwich foot tunnel'
 external_url: https://www.royalgreenwich.gov.uk/parking-transport-and-streets/travel-foot-bike-or-public-transport/check-status-foot-tunnels-and
+poster: "Cain Mosni aka Camopants"
 ---
 Opened in 1912, the Woolwich Foot Tunnel remains the longest pedestrian tunnel under the River Thames at slightly over half a kilometre end to end.  Access is near the Woolwich Ferry piers on the north and south banks of the river.

--- a/content/daytrip/eu/hu/hungarian-electrotechnical-museum.md
+++ b/content/daytrip/eu/hu/hungarian-electrotechnical-museum.md
@@ -6,5 +6,6 @@ lng: '19.062851'
 location: '1075 Budapest, Kazinczy utca 21.'
 title: 'Hungarian Electrotechnical Museum'
 external_url: https://welovebudapest.com/hely/elektrotechnikai-muzeum
+poster: "Hugo"
 ---
 A collection of everything related to the discovery and use of electricity in Hungary. They have several working demos of static electricity generators, and a huge (and fascinating) collection of electricity meters.

--- a/content/daytrip/eu/nl/home-computer-museum.md
+++ b/content/daytrip/eu/nl/home-computer-museum.md
@@ -6,5 +6,6 @@ lng: '5.65806'
 location: 'Noord Koninginnewal 28, Helmond, NL'
 title: 'Home computer museum'
 external_url: https://www.homecomputermuseum.nl/
+poster: "GolezTrol"
 ---
 Interactive museum of home computers from the 1970's, 80's and 90's. Many exotic models, many in working condition, and a lot that you can actually try out and use to program some lines of BASIC, or play games from Pacman to Unreal Tournament.

--- a/content/daytrip/na/us/computer-history-museum.md
+++ b/content/daytrip/na/us/computer-history-museum.md
@@ -6,6 +6,7 @@ lng: '-122.07745'
 location: '1401 N Shoreline Blvd, Mountain View, CA 94043, United States'
 title: 'Computer History Museum'
 external_url: https://computerhistory.org/
+poster: "JohnD"
 ---
 A large and fascinating museum absolutely bursting with tech, right in the heart of Silicon Valley.
 

--- a/content/daytrip/na/us/system-source-computer-museum.md
+++ b/content/daytrip/na/us/system-source-computer-museum.md
@@ -6,5 +6,6 @@ lng: '-76.663263'
 location: '338 Clubhouse Road, Hunt Valley, MD'
 title: 'System Source Computer Museum'
 external_url: https://museum.syssrc.com/
+poster: "Topaz"
 ---
 Huge selection of computing history, video gaming, and radio artifacts. Regular swap meets and repair days.

--- a/content/daytrip/na/us/the-monterey-bay-aquarium.md
+++ b/content/daytrip/na/us/the-monterey-bay-aquarium.md
@@ -6,6 +6,7 @@ lng: '-121.901797'
 location: '886 Cannery Row, Monterey, CA 93940, United States'
 title: 'The Monterey Bay Aquarium'
 external_url: https://www.montereybayaquarium.org/
+poster: "JohnD"
 ---
 A world class aquarium in its own right, Star Trek fans will recognise this as the location of the Cetacean Institute from Star Trek IV: The Voyage Home.
 

--- a/content/daytrip/zz/gd/parque-de-las-ciencias-andaluca.md
+++ b/content/daytrip/zz/gd/parque-de-las-ciencias-andaluca.md
@@ -6,5 +6,6 @@ lng: '-3.605801'
 location: 'Av. de la Ciencia, s/n, Ronda, 18006 Granada'
 title: 'Parque de las Ciencias Andalucía'
 external_url: https://www.parqueciencias.com
+poster: "Hugo"
 ---
 Small but well-formed science museum. Includes the Biodome, with exhibits of animals living in constructed habitats.


### PR DESCRIPTION
There were 42 sites submitted on/before May 29th, which erroneously had no poster in the front matter.. This PR adds them back in.

This fixes #98 