### PR TITLE
New: Uffington White Horse and Castle from Hugo

### DIFF
--- a/content/daytrip/eu/gb/uffington-white-horse-and-castle.md
+++ b/content/daytrip/eu/gb/uffington-white-horse-and-castle.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/uffington-white-horse-and-castle"
+date: "2025-06-03T10:58:10.252Z"
+poster: "Hugo"
+lat: "51.577752"
+lng: "-1.56659317"
+location: "Dragon Hill Road, Uffington, Oxfordshire, SN7 7UK, UK"
+title: "Uffington White Horse and Castle"
+external_url: https://www.nationaltrust.org.uk/visit/oxfordshire-buckinghamshire-berkshire/white-horse-hill
+---
+The oldest chalk-cut figure in the UK, and an Iron-age hill fort, with spectacular views north across the landscape.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Uffington White Horse and Castle
**Location:** Dragon Hill Road, Uffington, Oxfordshire, SN7 7UK, UK
**Submitted by:** Hugo
**Website:** https://add.nerdydaytrips.org

### Description
The oldest chalk-cut figure in the UK, and an Iron-age hill fort, with spectacular views north across the landscape.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 241
**File:** `content/daytrip/eu/gb/uffington-white-horse-and-castle.md`

Please review this venue submission and edit the content as needed before merging.