### PR TITLE
New: Eramosa Karst from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/eramosa-karst.md
+++ b/content/daytrip/na/ca/eramosa-karst.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/ca/eramosa-karst"
+date: "2025-06-04T08:51:28.132Z"
+poster: "Paul Drye"
+lat: "43.187106"
+lng: "-79.811938"
+location: "Orange Trail, Trinity, Hamilton, Golden Horseshoe, Ontario, L8J 0K5, Canada"
+title: "Eramosa Karst"
+external_url: https://conservationhamilton.ca/conservation-areas/eramosa-karst/
+---
+Walking trails through a large area of karst terrain -- which is to say, limestone that's been eroded away by into a large number of sinkholes, shallow amphitheatres, small caves, and underground streams. There are several trails here which collectively cover most of the interesting ones.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Eramosa Karst
**Location:** Orange Trail, Trinity, Hamilton, Golden Horseshoe, Ontario, L8J 0K5, Canada
**Submitted by:** Paul Drye
**Website:** https://conservationhamilton.ca/conservation-areas/eramosa-karst/

### Description
Walking trails through a large area of karst terrain -- which is to say, limestone that's been eroded away by into a large number of sinkholes, shallow amphitheatres, small caves, and underground streams. There are several trails here which collectively cover most of the interesting ones.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 242
**File:** `content/daytrip/na/ca/eramosa-karst.md`

Please review this venue submission and edit the content as needed before merging.