### PR TITLE
New: Mistaken Point Ecological Reserve from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/mistaken-point-ecological-reserve.md
+++ b/content/daytrip/na/ca/mistaken-point-ecological-reserve.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/ca/mistaken-point-ecological-reserve"
+date: "2025-06-04T08:53:35.401Z"
+poster: "Paul Drye"
+lat: "46.71248"
+lng: "-53.257771"
+location: "NL-10, Portugal Cove South, NL A0A 1S0"
+title: "Mistaken Point Ecological Reserve"
+external_url: https://www.gov.nl.ca/ecc/natural-areas/wer/r-mpe/
+---
+A UNESCO World Heritage Site containing some of the most unusual fossils in the world. It preserves life from the Ediacaran biota, the oldest multicellular life on the Earth. The creatures here are possibly even without descendants in the modern era, going completely extinct before plants and animals as a class took their shot at growing big. Or maybe they're just really odd plants and animals, it's all still being studied. They're that weird.
+
+Note that the site is of major scientific interest and they are EXTREMELY SERIOUS about protecting the fossils there. You can only enter the site as part of a guided tour from the Information Centre in the nearby town of Portugal Cove South. They recommend booking in advance.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Mistaken Point Ecological Reserve
**Location:** NL-10, Portugal Cove South, NL A0A 1S0
**Submitted by:** Paul Drye
**Website:** https://www.gov.nl.ca/ecc/natural-areas/wer/r-mpe/

### Description
A UNESCO World Heritage Site containing some of the most unusual fossils in the world. It preserves life from the Ediacaran biota, the oldest multicellular life on the Earth. The creatures here are possibly even without descendants in the modern era, going completely extinct before plants and animals as a class took their shot at growing big. Or maybe they're just really odd plants and animals, it's all still being studied. They're that weird.

Note that the site is of major scientific interest and they are EXTREMELY SERIOUS about protecting the fossils there. You can only enter the site as part of a guided tour from the Information Centre in the nearby town of Portugal Cove South. They recommend booking in advance.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 243
**File:** `content/daytrip/na/ca/mistaken-point-ecological-reserve.md`

Please review this venue submission and edit the content as needed before merging.