### PR TITLE
New: Thomas W. Evand Dental Museum from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/thomas-w-evand-dental-museum.md
+++ b/content/daytrip/na/us/thomas-w-evand-dental-museum.md
@@ -1,0 +1,14 @@
+---
+slug: "daytrip/na/us/thomas-w-evand-dental-museum"
+date: "2025-06-04T16:16:44.795Z"
+poster: "Mark Dominus"
+lat: "39.952163"
+lng: "-75.203761"
+location: "Penn Dental School, Spruce Street, West Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19139, United States"
+title: "Thomas W. Evand Dental Museum"
+external_url: https://facilities.upenn.edu/maps/locations/evans-building
+---
+Thomas W. Evans, world-famous dentist and dentist to crowned heads of Europe, donated this land to the University of Pennsylvania on condition that they use it to found a School of Dentistry and a dental museum housing Dr. Evans' collection of dental memorabilia.
+
+The building also features a "frieze of dental tortures".
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Thomas W. Evand Dental Museum
**Location:** Penn Dental School, Spruce Street, West Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19139, United States
**Submitted by:** Mark Dominus
**Website:** https://facilities.upenn.edu/maps/locations/evans-building

### Description
Thomas W. Evans, world-famous dentist and dentist to crowned heads of Europe, donated this land to the University of Pennsylvania on condition that they use it to found a School of Dentistry and a dental museum housing Dr. Evans' collection of dental memorabilia.

The building also features a "frieze of dental tortures".



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 255
**File:** `content/daytrip/na/us/thomas-w-evand-dental-museum.md`

Please review this venue submission and edit the content as needed before merging.