### PR TITLE
New: American Helicopter Museum & Education Center from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/american-helicopter-museum-education-center.md
+++ b/content/daytrip/na/us/american-helicopter-museum-education-center.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/american-helicopter-museum-education-center"
+date: "2025-06-04T16:27:19.357Z"
+poster: "Mark Dominus"
+lat: "39.991906"
+lng: "-75.578836"
+location: "American Helicopter Museum & Education Center, 1220, American Boulevard, West Goshen Township, Chester County, Pennsylvania, 19380, United States"
+title: "American Helicopter Museum & Education Center"
+external_url: https://www.helicoptermuseum.org/
+---
+More helicopters than you can shake a stick at.
+
+Some memorable ones include human-powered designs and helicopters made from commercially-sold built-it-yourself helicopter kits for hobbyists.


### PR DESCRIPTION
## New Venue Submission

**Venue:** American Helicopter Museum & Education Center
**Location:** American Helicopter Museum & Education Center, 1220, American Boulevard, West Goshen Township, Chester County, Pennsylvania, 19380, United States
**Submitted by:** Mark Dominus
**Website:** https://www.helicoptermuseum.org/

### Description
More helicopters than you can shake a stick at.

Some memorable ones include human-powered designs and helicopters made from commercially-sold built-it-yourself helicopter kits for hobbyists.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 250
**File:** `content/daytrip/na/us/american-helicopter-museum-education-center.md`

Please review this venue submission and edit the content as needed before merging.