### PR TITLE
New: Horseshoe Curve from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/horseshoe-curve.md
+++ b/content/daytrip/na/us/horseshoe-curve.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/horseshoe-curve"
+date: "2025-06-04T16:27:53.289Z"
+poster: "Mark Dominus"
+lat: "40.497241"
+lng: "-78.486157"
+location: "Horseshoe Curve, Veterans Memorial Highway, Logan Township, Blair County, Pennsylvania, 16629, United States"
+title: "Horseshoe Curve"
+external_url: https://www.railroadcity.org/horseshoecurve
+---
+Trains crossing the Allegheny mountains go up one side of this narrow valley, turn 180 degrees, and then go up the other side, ascending 70 meters in the process.  Magnificent scenery, great train-watching and a marvel of 19th-century engineering that is still used many times a day.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Horseshoe Curve
**Location:** Horseshoe Curve, Veterans Memorial Highway, Logan Township, Blair County, Pennsylvania, 16629, United States
**Submitted by:** Mark Dominus
**Website:** https://www.railroadcity.org/horseshoecurve

### Description
Trains crossing the Allegheny mountains go up one side of this narrow valley, turn 180 degrees, and then go up the other side, ascending 70 meters in the process.  Magnificent scenery, great train-watching and a marvel of 19th-century engineering that is still used many times a day.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 249
**File:** `content/daytrip/na/us/horseshoe-curve.md`

Please review this venue submission and edit the content as needed before merging.