### PR TITLE
New: Paju Book City Letterpress Museum from Mark Dominus

### DIFF
--- a/content/daytrip/as/kr/paju-book-city-letterpress-museum.md
+++ b/content/daytrip/as/kr/paju-book-city-letterpress-museum.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/as/kr/paju-book-city-letterpress-museum"
+date: "2025-06-04T16:28:41.499Z"
+poster: "Mark Dominus"
+lat: "37.708185"
+lng: "126.686668"
+location: "145 Hoedong-gil, Munbal-dong, Paju-si, Gyeonggi-do, South Korea"
+title: "Paju Book City Letterpress Museum"
+external_url: http://www.letterpressmuseum.co.kr/
+---
+Museum of Korean printing technology and history.  Includes:
+* Collection of Korean, Japanese, and Chinese-language typewriters
+* History of Korean samizdat practices during the Japanese occupation
+* Large collection of Korean and Chinese moveable type
+* History of Korean printing
+* Demonstrations
+* Gift shop


### PR DESCRIPTION
## New Venue Submission

**Venue:** Paju Book City Letterpress Museum
**Location:** 145 Hoedong-gil, Munbal-dong, Paju-si, Gyeonggi-do, South Korea
**Submitted by:** Mark Dominus
**Website:** http://www.letterpressmuseum.co.kr/

### Description
Museum of Korean printing technology and history.  Includes:
* Collection of Korean, Japanese, and Chinese-language typewriters
* History of Korean samizdat practices during the Japanese occupation
* Large collection of Korean and Chinese moveable type
* History of Korean printing
* Demonstrations
* Gift shop

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 248
**File:** `content/daytrip/as/kr/paju-book-city-letterpress-museum.md`

Please review this venue submission and edit the content as needed before merging.