### PR TITLE
New: Hovercraft Museum from Paul Drye

### DIFF
--- a/content/daytrip/eu/gb/hovercraft-museum.md
+++ b/content/daytrip/eu/gb/hovercraft-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/hovercraft-museum"
+date: "2025-06-04T16:43:58.484Z"
+poster: "Paul Drye"
+lat: "50.807908"
+lng: "-1.209773"
+location: "Building 40, Daedalus Site, Argus Gate, Chalk Lane, Lee-on-Solent, England"
+title: "Hovercraft Museum"
+external_url: https://hovercraft-museum.org/
+---
+Over 60 retired hovercraft are here, including ones used for passenger service to the Isle of Wight and cross-Channel to France. The museum has the world's largest document archives, open to the public by prior arrangement, and a large collection of model hovercraft too.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hovercraft Museum
**Location:** Building 40, Daedalus Site, Argus Gate, Chalk Lane, Lee-on-Solent, England
**Submitted by:** Paul Drye
**Website:** https://hovercraft-museum.org/

### Description
Over 60 retired hovercraft are here, including ones used for passenger service to the Isle of Wight and cross-Channel to France. The museum has the world's largest document archives, open to the public by prior arrangement, and a large collection of model hovercraft too.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 256
**File:** `content/daytrip/eu/gb/hovercraft-museum.md`

Please review this venue submission and edit the content as needed before merging.