### PR TITLE
New: Diamond Willow Amethyst Mine from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/diamond-willow-amethyst-mine.md
+++ b/content/daytrip/na/ca/diamond-willow-amethyst-mine.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/ca/diamond-willow-amethyst-mine"
+date: "2025-06-04T16:51:46.525Z"
+poster: "Paul Drye"
+lat: "48.682999"
+lng: "-88.664324"
+location: "Rd 5 N, Pearl P0T 2M0 ON Canada"
+title: "Diamond Willow Amethyst Mine"
+external_url: https://diamondwillowamethyst.com/
+---
+An open-air quarry that was a commercial amethyst mine until 2007. It is now a tourist site where you can rent a bucket then pick through the rubble for your own gems. There's also a store if you prefer to just buy some, as well as a gallery of their nicer finds.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Diamond Willow Amethyst Mine
**Location:** Rd 5 N, Pearl P0T 2M0 ON Canada
**Submitted by:** Paul Drye
**Website:** https://diamondwillowamethyst.com/

### Description
An open-air quarry that was a commercial amethyst mine until 2007. It is now a tourist site where you can rent a bucket then pick through the rubble for your own gems. There's also a store if you prefer to just buy some, as well as a gallery of their nicer finds.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 257
**File:** `content/daytrip/na/ca/diamond-willow-amethyst-mine.md`

Please review this venue submission and edit the content as needed before merging.