### PR TITLE
New: Zed*80 from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/zed80.md
+++ b/content/daytrip/na/ca/zed80.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/ca/zed80"
+date: "2025-06-04T17:22:06.362Z"
+poster: "Paul Drye"
+lat: "43.676567"
+lng: "-79.356399"
+location: "185 Danforth Avenue, Toronto, Ontario, Canada"
+title: "Zed*80"
+external_url: https://www.zedeighty.com/
+---
+Pay once to enter and then free-play on 40 retro arcade and pinball machines. Food menu and drinks are available on site too. Adults-only after 8:00 PM but otherwise open to all.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Zed*80
**Location:** 185 Danforth Avenue, Toronto, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://www.zedeighty.com/

### Description
Pay once to enter and then free-play on 40 retro arcade and pinball machines. Food menu and drinks are available on site too. Adults-only after 8:00 PM but otherwise open to all.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 258
**File:** `content/daytrip/na/ca/zed80.md`

Please review this venue submission and edit the content as needed before merging.