### PR TITLE
New: Observatoire de l’Astroblème de Charlevoix from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/observatoire-de-lastroblme-de-charlevoix.md
+++ b/content/daytrip/na/ca/observatoire-de-lastroblme-de-charlevoix.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/ca/observatoire-de-lastroblme-de-charlevoix"
+date: "2025-06-04T17:27:59.370Z"
+poster: "Paul Drye"
+lat: "47.614125"
+lng: "-70.169161"
+location: "Côte Bellevue, Pointe-au-Pic, La Malbaie, Charlevoix-Est, Quebec, Canada"
+title: "Observatoire de l’Astroblème de Charlevoix"
+external_url: https://astroblemecharlevoix.org/index.php/en/accueil-english/
+---
+An interpretive centre devoted to the Charlevoix impact structure, a mostly buried 50-kilometer wide crater forming the surrounding area. As well as the interactive show they put on there's a hiking experience to see some of the crater's geology exposed at the surface (oddly paired with a guided tour of local weir fishing history) and evening stargazing.
+
+The central peak of the crater, disguised as a low mountain with the town of Les Éboulements on it, can also be visited if you drive about 20 kilometers to the southwest,


### PR DESCRIPTION
## New Venue Submission

**Venue:** Observatoire de l’Astroblème de Charlevoix
**Location:** Côte Bellevue, Pointe-au-Pic, La Malbaie, Charlevoix-Est, Quebec, Canada
**Submitted by:** Paul Drye
**Website:** https://astroblemecharlevoix.org/index.php/en/accueil-english/

### Description
An interpretive centre devoted to the Charlevoix impact structure, a mostly buried 50-kilometer wide crater forming the surrounding area. As well as the interactive show they put on there's a hiking experience to see some of the crater's geology exposed at the surface (oddly paired with a guided tour of local weir fishing history) and evening stargazing.

The central peak of the crater, disguised as a low mountain with the town of Les Éboulements on it, can also be visited if you drive about 20 kilometers to the southwest,

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 259
**File:** `content/daytrip/na/ca/observatoire-de-lastroblme-de-charlevoix.md`

Please review this venue submission and edit the content as needed before merging.