### PR TITLE
New: American Philosophical Society from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/american-philosophical-society.md
+++ b/content/daytrip/na/us/american-philosophical-society.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/american-philosophical-society"
+date: "2025-06-04T18:40:52.808Z"
+poster: "Mark Dominus"
+lat: "39.948628"
+lng: "-75.149381"
+location: "American Philosophical Society, 104, South 5th Street, Society Hill, Center City, Philadelphia, Philadelphia County, Pennsylvania, 19106, United States"
+title: "American Philosophical Society"
+external_url: https://www.amphilsoc.org/
+---
+Rotating exhibits of scientific and historical artifacts from the Society's collections.  One time I went and they were exhibiting the apparatus used by Benjamin Franklin for his electrical experiments.


### PR DESCRIPTION
## New Venue Submission

**Venue:** American Philosophical Society
**Location:** American Philosophical Society, 104, South 5th Street, Society Hill, Center City, Philadelphia, Philadelphia County, Pennsylvania, 19106, United States
**Submitted by:** Mark Dominus
**Website:** https://www.amphilsoc.org/

### Description
Rotating exhibits of scientific and historical artifacts from the Society's collections.  One time I went and they were exhibiting the apparatus used by Benjamin Franklin for his electrical experiments.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 246
**File:** `content/daytrip/na/us/american-philosophical-society.md`

Please review this venue submission and edit the content as needed before merging.