### PR TITLE
New: Ben Franklin House from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/ben-franklin-house.md
+++ b/content/daytrip/na/us/ben-franklin-house.md
@@ -1,0 +1,14 @@
+---
+slug: "daytrip/na/us/ben-franklin-house"
+date: "2025-06-04T18:41:25.896Z"
+poster: "Mark Dominus"
+lat: "39.949369"
+lng: "-75.155166"
+location: "Ben Franklin House, 834, Chestnut Street, Washington Square West, Center City, Philadelphia, Philadelphia County, Pennsylvania, 19107, United States"
+title: "Ben Franklin House"
+external_url: https://www.nps.gov/inde/planyourvisit/franklincourtsites.htm
+---
+The site of the Philadelphia home of Benjamin Franklin and his family.  The house itself no longer stands, but there is an interesting urban archaeology exhibit about it.
+
+There is an associated Benjamin Franklin Museum and a printing office that demonstrates 18th-century printing techniques.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ben Franklin House
**Location:** Ben Franklin House, 834, Chestnut Street, Washington Square West, Center City, Philadelphia, Philadelphia County, Pennsylvania, 19107, United States
**Submitted by:** Mark Dominus
**Website:** https://www.nps.gov/inde/planyourvisit/franklincourtsites.htm

### Description
The site of the Philadelphia home of Benjamin Franklin and his family.  The house itself no longer stands, but there is an interesting urban archaeology exhibit about it.

There is an associated Benjamin Franklin Museum and a printing office that demonstrates 18th-century printing techniques.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 247
**File:** `content/daytrip/na/us/ben-franklin-house.md`

Please review this venue submission and edit the content as needed before merging.