### PR TITLE
New: Cross Sound Ferry from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/cross-sound-ferry.md
+++ b/content/daytrip/na/us/cross-sound-ferry.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/na/us/cross-sound-ferry"
+date: "2025-06-04T18:41:42.206Z"
+poster: "Mark Dominus"
+lat: "41.356885"
+lng: "-72.093993"
+location: "Cross Sound Ferry, Ferry Street, Downtown New London Historic District, Downtown New London, New London, Southeastern Connecticut Planning Region, Connecticut, 06320, United States"
+title: "Cross Sound Ferry"
+external_url: https://www.dhs.gov/science-and-technology/plum-island-animal-disease-center
+---
+This ferry from New London, CT or Orient Point on Long Island is just a ferry.
+
+The nerdy draw is that it passes by Plum Island, home of the Plum Island Animal Disease Center, also called "Anthrax Island".  It was featured in the movie "Silence of the Lambs" as the place where they might keep Hannibal Lecter if they were to ever let him out of his prison cell.
+
+The island itself is off-limits to the public.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cross Sound Ferry
**Location:** Cross Sound Ferry, Ferry Street, Downtown New London Historic District, Downtown New London, New London, Southeastern Connecticut Planning Region, Connecticut, 06320, United States
**Submitted by:** Mark Dominus
**Website:** https://www.dhs.gov/science-and-technology/plum-island-animal-disease-center

### Description
This ferry from New London, CT or Orient Point on Long Island is just a ferry.

The nerdy draw is that it passes by Plum Island, home of the Plum Island Animal Disease Center, also called "Anthrax Island".  It was featured in the movie "Silence of the Lambs" as the place where they might keep Hannibal Lecter if they were to ever let him out of his prison cell.

The island itself is off-limits to the public.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 252
**File:** `content/daytrip/na/us/cross-sound-ferry.md`

Please review this venue submission and edit the content as needed before merging.