### PR TITLE
New: Emperor Norton's grave from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/emperor-nortons-grave.md
+++ b/content/daytrip/na/us/emperor-nortons-grave.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/emperor-nortons-grave"
+date: "2025-06-04T18:41:49.926Z"
+poster: "Mark Dominus"
+lat: "37.680623"
+lng: "-122.46655"
+location: "Woodlawn Memorial Park, 1000, El Camino Real, Colma, San Mateo County, California, 94014, United States"
+title: "Emperor Norton's grave"
+external_url: https://en.wikipedia.org/wiki/Emperor_Norton
+---
+Final resting place of Norton I, Emperor of the United States.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Emperor Norton's grave
**Location:** Woodlawn Memorial Park, 1000, El Camino Real, Colma, San Mateo County, California, 94014, United States
**Submitted by:** Mark Dominus
**Website:** https://en.wikipedia.org/wiki/Emperor_Norton

### Description
Final resting place of Norton I, Emperor of the United States.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 253
**File:** `content/daytrip/na/us/emperor-nortons-grave.md`

Please review this venue submission and edit the content as needed before merging.