### PR TITLE
New: Burial place of Emmy Noether from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/burial-place-of-emmy-noether.md
+++ b/content/daytrip/na/us/burial-place-of-emmy-noether.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/na/us/burial-place-of-emmy-noether"
+date: "2025-06-05T05:55:08.095Z"
+poster: "Mark Dominus"
+lat: "40.026918"
+lng: "-75.313936"
+location: "Old Library, North Merion Avenue, Rosemont, Lower Merion Township, Montgomery County, Pennsylvania, 19101, United States"
+title: "Burial place of Emmy Noether"
+external_url: https://www.findagrave.com/memorial/1245/emmy-noether
+---
+Mathematician Emmy Noether made seminal contributions to abstract algebra (ring theory) and mathematical physics (Noether's theorem).  In 1933 she fled Germany and took up a position at Bryn Mawr.  When she died, she was buried in the central courtyard of the old library, called "the Cloister".  A stone marks the location.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Burial place of Emmy Noether
**Location:** Old Library, North Merion Avenue, Rosemont, Lower Merion Township, Montgomery County, Pennsylvania, 19101, United States
**Submitted by:** Mark Dominus
**Website:** https://www.findagrave.com/memorial/1245/emmy-noether

### Description
Mathematician Emmy Noether made seminal contributions to abstract algebra (ring theory) and mathematical physics (Noether's theorem).  In 1933 she fled Germany and took up a position at Bryn Mawr.  When she died, she was buried in the central courtyard of the old library, called "the Cloister".  A stone marks the location.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 261
**File:** `content/daytrip/na/us/burial-place-of-emmy-noether.md`

Please review this venue submission and edit the content as needed before merging.