### PR TITLE
New: Four Seasons Total Landscaping from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/four-seasons-total-landscaping.md
+++ b/content/daytrip/na/us/four-seasons-total-landscaping.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/four-seasons-total-landscaping"
+date: "2025-06-05T05:56:17.335Z"
+poster: "Mark Dominus"
+lat: "40.026321"
+lng: "-75.03016"
+location: "Four Seasons Total Landscaping, 7347, State Road, Northeast Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19136, United States"
+title: "Four Seasons Total Landscaping"
+external_url: https://www.npr.org/2020/11/11/933635970/from-obscure-to-sold-out-the-story-of-four-seasons-total-landscaping-in-just-4-d
+---
+During the 2020 Presidential election, the Trump campaign told Rudy Giuliani to book a press conference at the Four Seasons Hotel.  A mistake was made and the conference was instead held in the back parking lot of this Northeast Philadelphia garden and landscaping service.
+
+When you're done, it's a five-minute walk to Sweet Lucy's Smokehouse for lunch.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Four Seasons Total Landscaping
**Location:** Four Seasons Total Landscaping, 7347, State Road, Northeast Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19136, United States
**Submitted by:** Mark Dominus
**Website:** https://www.npr.org/2020/11/11/933635970/from-obscure-to-sold-out-the-story-of-four-seasons-total-landscaping-in-just-4-d

### Description
During the 2020 Presidential election, the Trump campaign told Rudy Giuliani to book a press conference at the Four Seasons Hotel.  A mistake was made and the conference was instead held in the back parking lot of this Northeast Philadelphia garden and landscaping service.

When you're done, it's a five-minute walk to Sweet Lucy's Smokehouse for lunch.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 262
**File:** `content/daytrip/na/us/four-seasons-total-landscaping.md`

Please review this venue submission and edit the content as needed before merging.