### PR TITLE
New: National Canal Museum / D&L Headquarters from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/national-canal-museum-dl-headquarters.md
+++ b/content/daytrip/na/us/national-canal-museum-dl-headquarters.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/national-canal-museum-dl-headquarters"
+date: "2025-06-05T05:57:52.167Z"
+poster: "Mark Dominus"
+lat: "40.661919"
+lng: "-75.239333"
+location: "National Canal Museum / D&L Headquarters, D&L Trail - National Canal Museum Spur, Easton, Northampton County, Pennsylvania, 18042, United States"
+title: "National Canal Museum / D&L Headquarters"
+external_url: https://canals.org/
+---
+Hands-on collection of canal-related artifacts. Mule-drawn canal boat rides.


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Canal Museum / D&L Headquarters
**Location:** National Canal Museum / D&L Headquarters, D&L Trail - National Canal Museum Spur, Easton, Northampton County, Pennsylvania, 18042, United States
**Submitted by:** Mark Dominus
**Website:** https://canals.org/

### Description
Hands-on collection of canal-related artifacts. Mule-drawn canal boat rides.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 264
**File:** `content/daytrip/na/us/national-canal-museum-dl-headquarters.md`

Please review this venue submission and edit the content as needed before merging.