### PR TITLE
New: Maharajah's Well from Hugo

### DIFF
--- a/content/daytrip/eu/gb/maharajahs-well.md
+++ b/content/daytrip/eu/gb/maharajahs-well.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/maharajahs-well"
+date: "2025-06-05T05:58:20.102Z"
+poster: "Hugo"
+lat: "51.551477"
+lng: "-1.021251"
+location: "Main Street, Stoke Row, RG9 5QJ"
+title: "Maharajah's Well"
+external_url: http://www.maharajahswell.org.uk
+---
+In 1850, the Maharajah of Benares had a conversation with a son of the squire of Ipsden in Oxfordshire. He learned about the village of Stoke Row, which had no nearby source of fresh water.
+
+Some years later, the Maharajah was reminded of this story, and sent a foreign aid package in the form of funds to dig a well in Stoke Row. The well was completed in 1864, and now stands in its own grounds with a magnificent canopy over it.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Maharajah's Well
**Location:** Main Street, Stoke Row, RG9 5QJ
**Submitted by:** Hugo
**Website:** http://www.maharajahswell.org.uk

### Description
In 1850, the Maharajah of Benares had a conversation with a son of the squire of Ipsden in Oxfordshire. He learned about the village of Stoke Row, which had no nearby source of fresh water.

Some years later, the Maharajah was reminded of this story, and sent a foreign aid package in the form of funds to dig a well in Stoke Row. The well was completed in 1864, and now stands in its own grounds with a magnificent canopy over it.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 265
**File:** `content/daytrip/eu/gb/maharajahs-well.md`

Please review this venue submission and edit the content as needed before merging.