### PR TITLE
New: Saint John's Co-Cathedral from Stuart Langridge

### DIFF
--- a/content/daytrip/eu/mt/saint-johns-co-cathedral.md
+++ b/content/daytrip/eu/mt/saint-johns-co-cathedral.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/mt/saint-johns-co-cathedral"
+date: "2025-06-05T08:56:39.549Z"
+poster: "Stuart Langridge"
+lat: "35.897695"
+lng: "14.512631"
+location: "Saint John's Co-Cathedral, Triq San Ġwann, Strada Rjali, Valletta, South Eastern Region, VLT 1113, Malta"
+title: "Saint John's Co-Cathedral"
+external_url: https://www.stjohnscocathedral.com/
+---
+Imposing but not too remarkable on the outside. Catastrophically over-ornamented on the inside. St John’s really needs to be seen or you won’t believe it. Really. It’s extremely ornate, filled with gilt ornamentation, statues, a floor made entirely of marble tombstones throughout, and two original Caravaggio paintings. See if you can find the stone of Mattia Preti, who did a good chunk of the interior artwork (tip: in the entrance to the sacristy.) 
+Advice: get there early. You can buy tickets online to skip the queue, but if you arrive at 9.30 then the queue is only a few people and the interior is much less crowded. Towards midday the queue to get in fills half the square outside.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Saint John's Co-Cathedral
**Location:** Saint John's Co-Cathedral, Triq San Ġwann, Strada Rjali, Valletta, South Eastern Region, VLT 1113, Malta
**Submitted by:** Stuart Langridge
**Website:** https://www.stjohnscocathedral.com/

### Description
Imposing but not too remarkable on the outside. Catastrophically over-ornamented on the inside. St John’s really needs to be seen or you won’t believe it. Really. It’s extremely ornate, filled with gilt ornamentation, statues, a floor made entirely of marble tombstones throughout, and two original Caravaggio paintings. See if you can find the stone of Mattia Preti, who did a good chunk of the interior artwork (tip: in the entrance to the sacristy.) 
Advice: get there early. You can buy tickets online to skip the queue, but if you arrive at 9.30 then the queue is only a few people and the interior is much less crowded. Towards midday the queue to get in fills half the square outside.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 267
**File:** `content/daytrip/eu/mt/saint-johns-co-cathedral.md`

Please review this venue submission and edit the content as needed before merging.