### PR TITLE
New: Grave of Jethro Tull from Hugo

### DIFF
--- a/content/daytrip/eu/gb/grave-of-jethro-tull.md
+++ b/content/daytrip/eu/gb/grave-of-jethro-tull.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/grave-of-jethro-tull"
+date: "2025-06-05T13:27:29.800Z"
+poster: "Hugo"
+lat: "51.508969"
+lng: "-1.119889"
+location: "St Bartholomew's Church, Lower Basildon, Berkshire"
+title: "Grave of Jethro Tull"
+external_url: https://en.wikipedia.org/wiki/Jethro_Tull_(agriculturist)
+---
+Not the prog rock band, but the original Jethro Tull -- the 18th century agronomist who invented the seed drill, and ushered in the British (aka the second) agricultural revolution.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Grave of Jethro Tull
**Location:** St Bartholomew's Church, Lower Basildon, Berkshire
**Submitted by:** Hugo
**Website:** https://en.wikipedia.org/wiki/Jethro_Tull_(agriculturist)

### Description
Not the prog rock band, but the original Jethro Tull -- the 18th century agronomist who invented the seed drill, and ushered in the British (aka the second) agricultural revolution.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 270
**File:** `content/daytrip/eu/gb/grave-of-jethro-tull.md`

Please review this venue submission and edit the content as needed before merging.