### PR TITLE
New: Project HARP Space Gun from Paul Drye

### DIFF
--- a/content/daytrip/sa/bb/project-harp-space-gun.md
+++ b/content/daytrip/sa/bb/project-harp-space-gun.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/sa/bb/project-harp-space-gun"
+date: "2025-06-05T18:00:46.366Z"
+poster: "Paul Drye"
+lat: "13.074671"
+lng: "-59.477577"
+location: "Charnocks, Christ Church, Barbados"
+title: "Project HARP Space Gun"
+external_url: https://en.wikipedia.org/wiki/Project_HARP
+---
+In the 1960s a Canadian engineer named Gerald Bull had a vision of launching satellites into orbit using an enormous gun. While the project was never completed, a smaller gun about the size of a battleship's artillery was built to test suborbital flights. From its site in Barbados they got as high as 181 kilometers, well into space.
+
+This is the rusted remains of that gun, located down on the beach near Barbados' international airport.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Project HARP Space Gun
**Location:** Charnocks, Christ Church, Barbados
**Submitted by:** Paul Drye
**Website:** https://en.wikipedia.org/wiki/Project_HARP

### Description
In the 1960s a Canadian engineer named Gerald Bull had a vision of launching satellites into orbit using an enormous gun. While the project was never completed, a smaller gun about the size of a battleship's artillery was built to test suborbital flights. From its site in Barbados they got as high as 181 kilometers, well into space.

This is the rusted remains of that gun, located down on the beach near Barbados' international airport.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 272
**File:** `content/daytrip/sa/bb/project-harp-space-gun.md`

Please review this venue submission and edit the content as needed before merging.