### PR TITLE
New: RCP Garden of Medicinal Plants from Paul Drye

### DIFF
--- a/content/daytrip/eu/gb/rcp-garden-of-medicinal-plants.md
+++ b/content/daytrip/eu/gb/rcp-garden-of-medicinal-plants.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/rcp-garden-of-medicinal-plants"
+date: "2025-06-05T18:06:00.600Z"
+poster: "Paul Drye"
+lat: "51.525624"
+lng: "-0.144882"
+location: "11 St Andrews Place, London, United Kingdom"
+title: "RCP Garden of Medicinal Plants"
+external_url: https://www.rcp.ac.uk/about-us/rcp-garden-of-medicinal-plants/
+---
+Part of the larger Royal College of Physicians Museum, the garden is devoted to plants that were believed to have medicinal value in ancient and medieval times. Open every weekday from 9:00 to 5:00 if you want to explore on your own, while a physician-guided tour is available on the first Wednesday of each month at 2 PM.


### PR DESCRIPTION
## New Venue Submission

**Venue:** RCP Garden of Medicinal Plants
**Location:** 11 St Andrews Place, London, United Kingdom
**Submitted by:** Paul Drye
**Website:** https://www.rcp.ac.uk/about-us/rcp-garden-of-medicinal-plants/

### Description
Part of the larger Royal College of Physicians Museum, the garden is devoted to plants that were believed to have medicinal value in ancient and medieval times. Open every weekday from 9:00 to 5:00 if you want to explore on your own, while a physician-guided tour is available on the first Wednesday of each month at 2 PM.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 273
**File:** `content/daytrip/eu/gb/rcp-garden-of-medicinal-plants.md`

Please review this venue submission and edit the content as needed before merging.