### PR TITLE
New: The Coffin Works from MegaSlippers

### DIFF
--- a/content/daytrip/eu/gb/the-coffin-works.md
+++ b/content/daytrip/eu/gb/the-coffin-works.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/the-coffin-works"
+date: "2025-06-05T18:06:28.966Z"
+poster: "MegaSlippers"
+lat: "52.481985"
+lng: "-1.907426"
+location: "13-15 Fleet St, Birmingham B3 1JP"
+title: "The Coffin Works"
+external_url: https://www.coffinworks.org/
+---
+The preserved Newman Brothers coffin furniture factory.  
+
+The building is full of the equipment and stock that was used to stamp handles and sew burialware. The guides are very knowledgable and passionate the once booming industry.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Coffin Works
**Location:** 13-15 Fleet St, Birmingham B3 1JP
**Submitted by:** MegaSlippers
**Website:** https://www.coffinworks.org/

### Description
The preserved Newman Brothers coffin furniture factory.  

The building is full of the equipment and stock that was used to stamp handles and sew burialware. The guides are very knowledgable and passionate the once booming industry.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 274
**File:** `content/daytrip/eu/gb/the-coffin-works.md`

Please review this venue submission and edit the content as needed before merging.