### PR TITLE
New: Vale of Rheidol from Robyn Vaughan Williams 

### DIFF
--- a/content/daytrip/eu/gb/vale-of-rheidol.md
+++ b/content/daytrip/eu/gb/vale-of-rheidol.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/vale-of-rheidol"
+date: "2025-06-05T20:21:04.814Z"
+poster: "Robyn Vaughan Williams "
+lat: "52.41137"
+lng: "-4.07867"
+location: "Park Avenue, Aberystwyth, Ceredigion, Wales, SY23 1PD, United Kingdom"
+title: "Vale of Rheidol"
+external_url: https://www.rheidolrailway.co.uk
+---
+Train museum and vintage train line to devil's bridge


### PR DESCRIPTION
## New Venue Submission

**Venue:** Vale of Rheidol
**Location:** Park Avenue, Aberystwyth, Ceredigion, Wales, SY23 1PD, United Kingdom
**Submitted by:** Robyn Vaughan Williams 
**Website:** https://www.rheidolrailway.co.uk

### Description
Train museum and vintage train line to devil's bridge

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 275
**File:** `content/daytrip/eu/gb/vale-of-rheidol.md`

Please review this venue submission and edit the content as needed before merging.