### PR TITLE
New: National Hangeul Museum from Mark Dominus

### DIFF
--- a/content/daytrip/as/kr/national-hangeul-museum.md
+++ b/content/daytrip/as/kr/national-hangeul-museum.md
@@ -1,0 +1,14 @@
+---
+slug: "daytrip/as/kr/national-hangeul-museum"
+date: "2025-06-06T06:26:10.144Z"
+poster: "Mark Dominus"
+lat: "37.52115"
+lng: "126.980937"
+location: "National Hangeul Museum, 139, Seobinggo-ro, Yongsan-dong 6-ga, Seobinggo-dong, Yongsan-gu, Seoul, 04428, South Korea"
+title: "National Hangeul Museum"
+external_url: https://www.hangeul.go.kr/en
+---
+One of Korea's proudest cultural achievements is Hangeul, the 24-letter alphabet used to write the Korean language.  Prior to its invention in 1443, there simply was no Korean written language.
+
+This museum is devoted to Hangeul and its invention.  Most notable in the collection is a rare surviving copy of Hunmin Jeongeum, the original user's guide for Hangeul.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Hangeul Museum
**Location:** National Hangeul Museum, 139, Seobinggo-ro, Yongsan-dong 6-ga, Seobinggo-dong, Yongsan-gu, Seoul, 04428, South Korea
**Submitted by:** Mark Dominus
**Website:** https://www.hangeul.go.kr/en

### Description
One of Korea's proudest cultural achievements is Hangeul, the 24-letter alphabet used to write the Korean language.  Prior to its invention in 1443, there simply was no Korean written language.

This museum is devoted to Hangeul and its invention.  Most notable in the collection is a rare surviving copy of Hunmin Jeongeum, the original user's guide for Hangeul.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 276
**File:** `content/daytrip/as/kr/national-hangeul-museum.md`

Please review this venue submission and edit the content as needed before merging.