### PR TITLE
New: Ir. D.F. Woudagemaal from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/ir-df-woudagemaal.md
+++ b/content/daytrip/eu/nl/ir-df-woudagemaal.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/ir-df-woudagemaal"
+date: "2025-06-06T10:26:38.967Z"
+poster: "Frederik Dekker"
+lat: "52.846605"
+lng: "5.678537"
+location: "Gemaalweg 1, 8531 PS Lemmer, The Netherlands"
+title: "Ir. D.F. Woudagemaal"
+external_url: https://www.woudagemaal.com/
+---
+Water pumping station powered by steam. The Woudagemaal was built in 1920 and was used to pump water from the canals in Friesland in order to regulate the water level. Although nowadays it has been replaced by a newer pumping station it is still used a few times a year when the water is very high.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ir. D.F. Woudagemaal
**Location:** Gemaalweg 1, 8531 PS Lemmer, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.woudagemaal.com/

### Description
Water pumping station powered by steam. The Woudagemaal was built in 1920 and was used to pump water from the canals in Friesland in order to regulate the water level. Although nowadays it has been replaced by a newer pumping station it is still used a few times a year when the water is very high.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 277
**File:** `content/daytrip/eu/nl/ir-df-woudagemaal.md`

Please review this venue submission and edit the content as needed before merging.