### PR TITLE
New: Bunker Museum Terschelling from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/bunker-museum-terschelling.md
+++ b/content/daytrip/eu/nl/bunker-museum-terschelling.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/bunker-museum-terschelling"
+date: "2025-06-06T10:27:10.247Z"
+poster: "Frederik Dekker"
+lat: "53.369779"
+lng: "5.2302"
+location: "Tigerpad 5, 8881 GB, West-Terschelling, The Netherlands"
+title: "Bunker Museum Terschelling"
+external_url: https://www.bunkermuseumterschelling.nl/
+---
+In the second world war a German radar station and control center was located on the (occupied) island of Terschelling. In the control center the radar signals were processed and fighters were directed to intercept bombers bound for Germany. 
+
+In the bunker museum the control station has been rebuild and radar techniques from that time are explained.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bunker Museum Terschelling
**Location:** Tigerpad 5, 8881 GB, West-Terschelling, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.bunkermuseumterschelling.nl/

### Description
In the second world war a German radar station and control center was located on the (occupied) island of Terschelling. In the control center the radar signals were processed and fighters were directed to intercept bombers bound for Germany. 

In the bunker museum the control station has been rebuild and radar techniques from that time are explained.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 278
**File:** `content/daytrip/eu/nl/bunker-museum-terschelling.md`

Please review this venue submission and edit the content as needed before merging.