### PR TITLE
New: Dwigeloo Radiotelescope from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/dwigeloo-radiotelescope.md
+++ b/content/daytrip/eu/nl/dwigeloo-radiotelescope.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/dwigeloo-radiotelescope"
+date: "2025-06-06T10:27:45.140Z"
+poster: "Frederik Dekker"
+lat: "52.812115"
+lng: "6.396339"
+location: "Oude Hoogeveensedijk 4, 7991 PD, Dwingeloo, The Netherlands"
+title: "Dwigeloo Radiotelescope"
+external_url: https://www.camras.nl/en/
+---
+Radio telescope from 1956. At that time the largest radio telescope in the world. It was used until 1998 and has now been taken over by volunteers who still use and maintain it.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dwigeloo Radiotelescope
**Location:** Oude Hoogeveensedijk 4, 7991 PD, Dwingeloo, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.camras.nl/en/

### Description
Radio telescope from 1956. At that time the largest radio telescope in the world. It was used until 1998 and has now been taken over by volunteers who still use and maintain it.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 279
**File:** `content/daytrip/eu/nl/dwigeloo-radiotelescope.md`

Please review this venue submission and edit the content as needed before merging.