### PR TITLE
New: Teufelsberg  from Ayor

### DIFF
--- a/content/daytrip/eu/de/teufelsberg-.md
+++ b/content/daytrip/eu/de/teufelsberg-.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/teufelsberg-"
+date: "2025-06-06T10:28:31.746Z"
+poster: "Ayor"
+lat: "52.496176"
+lng: "13.239334"
+location: "10, Teufelsseechaussee, Grunewald, Charlottenburg-Wilmersdorf, Berlijn, 14193, Duitsland"
+title: "Teufelsberg "
+external_url: https://www.teufelsberg-berlin.de/
+---
+Old cold war allied listening station. The station was used to monitor Soviet and Eastern Bloc communications and gather important information on the activities of Warsaw Pact countries. After being decommissioned in 1992, the site lays empty for years. It is now a gallery for street art, and the buildings have been granted monumental status.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Teufelsberg 
**Location:** 10, Teufelsseechaussee, Grunewald, Charlottenburg-Wilmersdorf, Berlijn, 14193, Duitsland
**Submitted by:** Ayor
**Website:** https://www.teufelsberg-berlin.de/

### Description
Old cold war allied listening station. The station was used to monitor Soviet and Eastern Bloc communications and gather important information on the activities of Warsaw Pact countries. After being decommissioned in 1992, the site lays empty for years. It is now a gallery for street art, and the buildings have been granted monumental status.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 280
**File:** `content/daytrip/eu/de/teufelsberg-.md`

Please review this venue submission and edit the content as needed before merging.