### PR TITLE
New: Drukkerijmuseum from Redmer

### DIFF
--- a/content/daytrip/eu/nl/drukkerijmuseum.md
+++ b/content/daytrip/eu/nl/drukkerijmuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/drukkerijmuseum"
+date: "2025-06-06T10:29:13.608Z"
+poster: "Redmer"
+lat: "51.577951"
+lng: "4.651142"
+location: "Drukkerijmuseum, Leeuwerik, Baai, Etten-Leur, Noord-Brabant, Nederland, 4872 PH, Nederland"
+title: "Drukkerijmuseum"
+external_url: https://www.nederlandsdrukkerijmuseum.eu
+---
+A lovely printing press museum, with enthusiastic volunteers and changing expositions. All printing presses are functional and might be demonstrated by a volunteer.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Drukkerijmuseum
**Location:** Drukkerijmuseum, Leeuwerik, Baai, Etten-Leur, Noord-Brabant, Nederland, 4872 PH, Nederland
**Submitted by:** Redmer
**Website:** https://www.nederlandsdrukkerijmuseum.eu

### Description
A lovely printing press museum, with enthusiastic volunteers and changing expositions. All printing presses are functional and might be demonstrated by a volunteer.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 281
**File:** `content/daytrip/eu/nl/drukkerijmuseum.md`

Please review this venue submission and edit the content as needed before merging.