### PR TITLE
New: Plantin-Moretus Museum from Redmer

### DIFF
--- a/content/daytrip/eu/be/plantin-moretus-museum.md
+++ b/content/daytrip/eu/be/plantin-moretus-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/be/plantin-moretus-museum"
+date: "2025-06-06T18:40:41.436Z"
+poster: "Redmer"
+lat: "51.218496"
+lng: "4.39816"
+location: "Vrijdagmarkt 22, Antwerpen, 2000, België"
+title: "Plantin-Moretus Museum"
+external_url: https://museumplantinmoretus.be
+---
+The printer Plantin moved to this building in 1576, and the museum houses the world’s oldest printing presses and a complete Renaissance printing workshop. Great place if you're interested in the technological foundations of modern knowledge dissemination.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Plantin-Moretus Museum
**Location:** Vrijdagmarkt 22, Antwerpen, 2000, België
**Submitted by:** Redmer
**Website:** https://museumplantinmoretus.be

### Description
The printer Plantin moved to this building in 1576, and the museum houses the world’s oldest printing presses and a complete Renaissance printing workshop. Great place if you're interested in the technological foundations of modern knowledge dissemination.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 282
**File:** `content/daytrip/eu/be/plantin-moretus-museum.md`

Please review this venue submission and edit the content as needed before merging.