### PR TITLE
New: Tändsticksmuseet from MarcN

### DIFF
--- a/content/daytrip/eu/se/tndsticksmuseet.md
+++ b/content/daytrip/eu/se/tndsticksmuseet.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/se/tndsticksmuseet"
+date: "2025-06-06T18:41:33.922Z"
+poster: "MarcN"
+lat: "57.784658"
+lng: "14.159598"
+location: "Tändsticksmuseet, Tändsticksgränd, Tändsticksområdet, Väster, Jönköping, Jönköpings kommun, Provinz Jönköping, 553 15, Schweden"
+title: "Tändsticksmuseet"
+external_url: https://matchmuseum.jonkoping.se/
+---
+The match museum is housed in Jönköping's first match factory. The museum highlights the people that worked in the factory and how the factory functioned.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tändsticksmuseet
**Location:** Tändsticksmuseet, Tändsticksgränd, Tändsticksområdet, Väster, Jönköping, Jönköpings kommun, Provinz Jönköping, 553 15, Schweden
**Submitted by:** MarcN
**Website:** https://matchmuseum.jonkoping.se/

### Description
The match museum is housed in Jönköping's first match factory. The museum highlights the people that worked in the factory and how the factory functioned.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 284
**File:** `content/daytrip/eu/se/tndsticksmuseet.md`

Please review this venue submission and edit the content as needed before merging.