### PR TITLE
New: Popeye Village from MarcN

### DIFF
--- a/content/daytrip/eu/mt/popeye-village.md
+++ b/content/daytrip/eu/mt/popeye-village.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/mt/popeye-village"
+date: "2025-06-06T18:41:58.776Z"
+poster: "MarcN"
+lat: "35.960837"
+lng: "14.340684"
+location: "Popeye Village, Triq tal-Prajjet, Il-Manikata, Il-Mellieħa, Tramuntana, MLH 1107, Malta"
+title: "Popeye Village"
+external_url: https://popeyemalta.com/
+---
+An amusement park built around the film set of the 1980 movie "Popeye" with Robin Williams and Shelley Duvall. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Popeye Village
**Location:** Popeye Village, Triq tal-Prajjet, Il-Manikata, Il-Mellieħa, Tramuntana, MLH 1107, Malta
**Submitted by:** MarcN
**Website:** https://popeyemalta.com/

### Description
An amusement park built around the film set of the 1980 movie "Popeye" with Robin Williams and Shelley Duvall. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 285
**File:** `content/daytrip/eu/mt/popeye-village.md`

Please review this venue submission and edit the content as needed before merging.