### PR TITLE
New: Ziegeleipark Mildenberg from MarcN

### DIFF
--- a/content/daytrip/eu/de/ziegeleipark-mildenberg.md
+++ b/content/daytrip/eu/de/ziegeleipark-mildenberg.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/ziegeleipark-mildenberg"
+date: "2025-06-06T18:42:17.423Z"
+poster: "MarcN"
+lat: "53.033877"
+lng: "13.306415"
+location: "Ziegeleipark, Ziegelei, Mildenberg, Zehdenick, Oberhavel, Brandenburg, 16792, Deutschland"
+title: "Ziegeleipark Mildenberg"
+external_url: https://www.ziegeleipark.de/
+---
+The Mildenberg Brick Work Park has exhibitions on the local brick industry. It has working brickworks, ring kilns, narrow-gauge field railways and a stationary steam engine. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ziegeleipark Mildenberg
**Location:** Ziegeleipark, Ziegelei, Mildenberg, Zehdenick, Oberhavel, Brandenburg, 16792, Deutschland
**Submitted by:** MarcN
**Website:** https://www.ziegeleipark.de/

### Description
The Mildenberg Brick Work Park has exhibitions on the local brick industry. It has working brickworks, ring kilns, narrow-gauge field railways and a stationary steam engine. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 286
**File:** `content/daytrip/eu/de/ziegeleipark-mildenberg.md`

Please review this venue submission and edit the content as needed before merging.