### PR TITLE
New: Nationaal Smalspoormuseum Stoomtrein Katwijk Leiden  from Sander

### DIFF
--- a/content/daytrip/eu/nl/nationaal-smalspoormuseum-stoomtrein-katwijk-leiden-.md
+++ b/content/daytrip/eu/nl/nationaal-smalspoormuseum-stoomtrein-katwijk-leiden-.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/nationaal-smalspoormuseum-stoomtrein-katwijk-leiden-"
+date: "2025-06-07T08:02:10.945Z"
+poster: "Sander"
+lat: "52.159505"
+lng: "4.443832"
+location: "Jan Pellenbargweg 1 Valkenburg ZH"
+title: "Nationaal Smalspoormuseum Stoomtrein Katwijk Leiden "
+external_url: https://stoomtreinkatwijkleiden.nl/
+---
+Prachtig museum inclusief iedere openingsdag ritten met stoomtrein. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Nationaal Smalspoormuseum Stoomtrein Katwijk Leiden 
**Location:** Jan Pellenbargweg 1 Valkenburg ZH
**Submitted by:** Sander
**Website:** https://stoomtreinkatwijkleiden.nl/

### Description
Prachtig museum inclusief iedere openingsdag ritten met stoomtrein. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 288
**File:** `content/daytrip/eu/nl/nationaal-smalspoormuseum-stoomtrein-katwijk-leiden-.md`

Please review this venue submission and edit the content as needed before merging.