### PR TITLE
New: Ordnance Survey Grid Reference OV0000 from Hugo

### DIFF
--- a/content/daytrip/eu/gb/ordnance-survey-grid-reference-ov0000.md
+++ b/content/daytrip/eu/gb/ordnance-survey-grid-reference-ov0000.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/ordnance-survey-grid-reference-ov0000"
+date: "2025-06-07T13:36:09.434Z"
+poster: "Hugo"
+lat: "54.385679"
+lng: "-0.46166035"
+location: "Beast Cliff, North Yorkshire, UK"
+title: "Ordnance Survey Grid Reference OV0000"
+external_url: https://en.wikipedia.org/wiki/Beast_Cliff
+---
+The only part of the 100km square Ordnance Survey "OV" square with land in it (at low tide). Access to the beach is hazardous, so it's very difficult to reach the beach (and the OS grid location) itself.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ordnance Survey Grid Reference OV0000
**Location:** Beast Cliff, North Yorkshire, UK
**Submitted by:** Hugo
**Website:** https://en.wikipedia.org/wiki/Beast_Cliff

### Description
The only part of the 100km square Ordnance Survey "OV" square with land in it (at low tide). Access to the beach is hazardous, so it's very difficult to reach the beach (and the OS grid location) itself.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 289
**File:** `content/daytrip/eu/gb/ordnance-survey-grid-reference-ov0000.md`

Please review this venue submission and edit the content as needed before merging.