### PR TITLE
New: ESO Supernova Planetarium and Visitor Center from PopeySentMeHere

### DIFF
--- a/content/daytrip/eu/de/eso-supernova-planetarium-and-visitor-center.md
+++ b/content/daytrip/eu/de/eso-supernova-planetarium-and-visitor-center.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/eu/de/eso-supernova-planetarium-and-visitor-center"
+date: "2025-06-07T13:36:45.559Z"
+poster: "PopeySentMeHere"
+lat: "48.1351"
+lng: "11.582"
+location: "Karl-Schwarzschild-Str. 2, 85748 Garching bei München, Germany"
+title: "ESO Supernova Planetarium and Visitor Center"
+external_url: https://supernova.eso.org
+---
+Visiotor center at the ESO Headquarters. Exhibition about astronomy open to the public and free, Planetarium show often sold out weeks in advance.
+
+Closed Moday/Tuesday and in case of special events (you can also hold conferences at this venue).
+
+A lot of information on the homepage, check details before you go.
+
+The have a room called "The Void". Screaming not allowed.


### PR DESCRIPTION
## New Venue Submission

**Venue:** ESO Supernova Planetarium and Visitor Center
**Location:** Karl-Schwarzschild-Str. 2, 85748 Garching bei München, Germany
**Submitted by:** PopeySentMeHere
**Website:** https://supernova.eso.org

### Description
Visiotor center at the ESO Headquarters. Exhibition about astronomy open to the public and free, Planetarium show often sold out weeks in advance.

Closed Moday/Tuesday and in case of special events (you can also hold conferences at this venue).

A lot of information on the homepage, check details before you go.

The have a room called "The Void". Screaming not allowed.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 290
**File:** `content/daytrip/eu/de/eso-supernova-planetarium-and-visitor-center.md`

Please review this venue submission and edit the content as needed before merging.