### PR TITLE
New: Historische Scheepswerf Wolthuis from MartenK

### DIFF
--- a/content/daytrip/eu/nl/historische-scheepswerf-wolthuis.md
+++ b/content/daytrip/eu/nl/historische-scheepswerf-wolthuis.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/historische-scheepswerf-wolthuis"
+date: "2025-06-07T13:37:00.261Z"
+poster: "MartenK"
+lat: "53.163731"
+lng: "6.796462"
+location: "308, Noorderstraat, Kleinemeer, Sappemeer, Midden-Groningen, Groningen, Nederland, 9611 AT, Nederland"
+title: "Historische Scheepswerf Wolthuis"
+external_url: https://www.historischescheepswerf.nl/
+---
+This historic shipyard is now a very complete museum showing and demonstrating various (historic) techniques used to build ships, including wood working, smithing, hole punching, riveting, lifting, etc. The yard is still in function for restoration of (historic) ships, making it an active site.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Historische Scheepswerf Wolthuis
**Location:** 308, Noorderstraat, Kleinemeer, Sappemeer, Midden-Groningen, Groningen, Nederland, 9611 AT, Nederland
**Submitted by:** MartenK
**Website:** https://www.historischescheepswerf.nl/

### Description
This historic shipyard is now a very complete museum showing and demonstrating various (historic) techniques used to build ships, including wood working, smithing, hole punching, riveting, lifting, etc. The yard is still in function for restoration of (historic) ships, making it an active site.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 291
**File:** `content/daytrip/eu/nl/historische-scheepswerf-wolthuis.md`

Please review this venue submission and edit the content as needed before merging.