### PR TITLE
New: Museum Wierdenland from MartenK

### DIFF
--- a/content/daytrip/eu/nl/museum-wierdenland.md
+++ b/content/daytrip/eu/nl/museum-wierdenland.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-wierdenland"
+date: "2025-06-07T13:38:13.182Z"
+poster: "MartenK"
+lat: "53.308424"
+lng: "6.440507"
+location: "Museum Wierdenland, van Swinderenweg, Het Schoor, Ezinge, Westerkwartier, Groningen, Nederland, 9891 AD, Nederland"
+title: "Museum Wierdenland"
+external_url: https://wierdenland.nl/
+---
+Everything there is to know about "terps" (artificial dwelling mounds, used in northern Europe), including archeology and geology of the area.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum Wierdenland
**Location:** Museum Wierdenland, van Swinderenweg, Het Schoor, Ezinge, Westerkwartier, Groningen, Nederland, 9891 AD, Nederland
**Submitted by:** MartenK
**Website:** https://wierdenland.nl/

### Description
Everything there is to know about "terps" (artificial dwelling mounds, used in northern Europe), including archeology and geology of the area.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 292
**File:** `content/daytrip/eu/nl/museum-wierdenland.md`

Please review this venue submission and edit the content as needed before merging.