### PR TITLE
New: Museum Schokland from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museum-schokland.md
+++ b/content/daytrip/eu/nl/museum-schokland.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-schokland"
+date: "2025-06-08T11:24:58.201Z"
+poster: "Frederik Dekker"
+lat: "52.634563"
+lng: "5.777639"
+location: "Middelbuurt 3, 8319 AB Schokland, The Netherlands"
+title: "Museum Schokland"
+external_url: https://www.museumschokland.nl/en/
+---
+Visitor Centre of Schokland, an island in the Zuiderzee that was inhabited until 1859. Because of coastal erosion the island became smaller and smaller and eventually had to be evacuated. When the Noordoostpolder was reclaimed in the 1940's the (former) island became surrounded by land.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum Schokland
**Location:** Middelbuurt 3, 8319 AB Schokland, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.museumschokland.nl/en/

### Description
Visitor Centre of Schokland, an island in the Zuiderzee that was inhabited until 1859. Because of coastal erosion the island became smaller and smaller and eventually had to be evacuated. When the Noordoostpolder was reclaimed in the 1940's the (former) island became surrounded by land.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 293
**File:** `content/daytrip/eu/nl/museum-schokland.md`

Please review this venue submission and edit the content as needed before merging.