### PR TITLE
New: Historische Scheepswerf Wolthuis (Historic Shipyard Wolthuis) from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/historische-scheepswerf-wolthuis-historic-shipyard-wolthuis.md
+++ b/content/daytrip/eu/nl/historische-scheepswerf-wolthuis-historic-shipyard-wolthuis.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/historische-scheepswerf-wolthuis-historic-shipyard-wolthuis"
+date: "2025-06-08T11:25:18.576Z"
+poster: "Frederik Dekker"
+lat: "53.163829"
+lng: "6.796353"
+location: "Noorderstraat 308, 9611 AT Sappemeer, The Netherlands"
+title: "Historische Scheepswerf Wolthuis (Historic Shipyard Wolthuis)"
+external_url: https://www.historischescheepswerf.nl/
+---
+Historic Shipyard in the province of Groningen. Groningen has a longstanding history of shipbuilding. Most shipyards were located along canals, making it necessarry to launch ships sideways. In 1983 the canal along which shipyard Wolthuis (one of the oldest in Groningen) was located was closed and the shipyard was turned into a museum.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Historische Scheepswerf Wolthuis (Historic Shipyard Wolthuis)
**Location:** Noorderstraat 308, 9611 AT Sappemeer, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.historischescheepswerf.nl/

### Description
Historic Shipyard in the province of Groningen. Groningen has a longstanding history of shipbuilding. Most shipyards were located along canals, making it necessarry to launch ships sideways. In 1983 the canal along which shipyard Wolthuis (one of the oldest in Groningen) was located was closed and the shipyard was turned into a museum.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 294
**File:** `content/daytrip/eu/nl/historische-scheepswerf-wolthuis-historic-shipyard-wolthuis.md`

Please review this venue submission and edit the content as needed before merging.