### PR TITLE
New: Melkwegpad (Milky Way Path) from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/melkwegpad-milky-way-path.md
+++ b/content/daytrip/eu/nl/melkwegpad-milky-way-path.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/melkwegpad-milky-way-path"
+date: "2025-06-08T11:25:37.745Z"
+poster: "Frederik Dekker"
+lat: "52.921318"
+lng: "6.571627"
+location: "Oosthalen 8, 9414 TG, Hooghalen, The Netherlands"
+title: "Melkwegpad (Milky Way Path)"
+external_url: https://www.opensciencedrenthe.nl/hubs/het-melkwegpad
+---
+Walking route where the distance between planets are scaled. For each planet there is a puzzle (not sure if the puzzle is available in English). The route ends at the radio telescopes of Astron.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Melkwegpad (Milky Way Path)
**Location:** Oosthalen 8, 9414 TG, Hooghalen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.opensciencedrenthe.nl/hubs/het-melkwegpad

### Description
Walking route where the distance between planets are scaled. For each planet there is a puzzle (not sure if the puzzle is available in English). The route ends at the radio telescopes of Astron.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 295
**File:** `content/daytrip/eu/nl/melkwegpad-milky-way-path.md`

Please review this venue submission and edit the content as needed before merging.