### PR TITLE
New: Beeld & Geluid (in English: Sound & Vision) from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/beeld-geluid-in-english-sound-vision.md
+++ b/content/daytrip/eu/nl/beeld-geluid-in-english-sound-vision.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/beeld-geluid-in-english-sound-vision"
+date: "2025-06-08T11:26:10.066Z"
+poster: "Frederik Dekker"
+lat: "52.235336"
+lng: "5.173144"
+location: "Media Parkboulevard 1, 1217 WE, Hilversum, The Netherlands"
+title: "Beeld & Geluid (in English: Sound & Vision)"
+external_url: https://www.beeldengeluid.nl/en
+---
+Sound & Vision is the institute for media culture; an inspiring, creative and accessible meeting place for private individuals and professionals.
+
+Interactive museum about Dutch Media, from the start of radio/television until today.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Beeld & Geluid (in English: Sound & Vision)
**Location:** Media Parkboulevard 1, 1217 WE, Hilversum, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.beeldengeluid.nl/en

### Description
Sound & Vision is the institute for media culture; an inspiring, creative and accessible meeting place for private individuals and professionals.

Interactive museum about Dutch Media, from the start of radio/television until today.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 296
**File:** `content/daytrip/eu/nl/beeld-geluid-in-english-sound-vision.md`

Please review this venue submission and edit the content as needed before merging.