### PR TITLE
New: Beatles Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/beatles-museum.md
+++ b/content/daytrip/eu/nl/beatles-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/beatles-museum"
+date: "2025-06-08T11:26:29.567Z"
+poster: "Frederik Dekker"
+lat: "52.637257"
+lng: "4.749838"
+location: " Pettemerstraat 12A, 1823 CW, Alkmaar, The Netherlands"
+title: "Beatles Museum"
+external_url: https://www.beatlesmuseum.nl/
+---
+One of the largest Beatles museums in the world, but 3 more museums are located under the same roof: The Elvis museum, The seabroadcasting ships museum and the "From audio to video' Museum. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Beatles Museum
**Location:**  Pettemerstraat 12A, 1823 CW, Alkmaar, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.beatlesmuseum.nl/

### Description
One of the largest Beatles museums in the world, but 3 more museums are located under the same roof: The Elvis museum, The seabroadcasting ships museum and the "From audio to video' Museum. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 297
**File:** `content/daytrip/eu/nl/beatles-museum.md`

Please review this venue submission and edit the content as needed before merging.