### PR TITLE
New: Waterloopbos from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/waterloopbos.md
+++ b/content/daytrip/eu/nl/waterloopbos.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/nl/waterloopbos"
+date: "2025-06-08T11:26:58.722Z"
+poster: "Frederik Dekker"
+lat: "52.675401"
+lng: "5.915033"
+location: "Voorsterweg 34, 8316 PT, Marknesse, The Netherlands"
+title: "Waterloopbos"
+external_url: https://www.natuurmonumenten.nl/natuurgebieden/waterloopbos
+---
+The national monument Waterloopbos is an area where the Dutch have learned to work with water, waves and current. It used to be a laboratory where research was conducted in order to construct civil works to protect The Netherlands (and other countries) from the sea and to engage in land reclamation. When computers took over this research the area was reclaimed by nature, but the ruins of the test sites can still be found.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Waterloopbos
**Location:** Voorsterweg 34, 8316 PT, Marknesse, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.natuurmonumenten.nl/natuurgebieden/waterloopbos

### Description
The national monument Waterloopbos is an area where the Dutch have learned to work with water, waves and current. It used to be a laboratory where research was conducted in order to construct civil works to protect The Netherlands (and other countries) from the sea and to engage in land reclamation. When computers took over this research the area was reclaimed by nature, but the ruins of the test sites can still be found.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 298
**File:** `content/daytrip/eu/nl/waterloopbos.md`

Please review this venue submission and edit the content as needed before merging.