### PR TITLE
New: Omroepzendermuseum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/omroepzendermuseum.md
+++ b/content/daytrip/eu/nl/omroepzendermuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/omroepzendermuseum"
+date: "2025-06-08T11:27:36.893Z"
+poster: "Frederik Dekker"
+lat: "52.002846"
+lng: "5.044613"
+location: "Biezendijk 3, 3412 KB, Lopikerkapel, The Netherlands "
+title: "Omroepzendermuseum"
+external_url: https://www.omroepzendermuseum.nl/index.php/over-het-museum
+---
+Museum about the electro-technical techniques of broadcasting radio and TV signals


### PR DESCRIPTION
## New Venue Submission

**Venue:** Omroepzendermuseum
**Location:** Biezendijk 3, 3412 KB, Lopikerkapel, The Netherlands 
**Submitted by:** Frederik Dekker
**Website:** https://www.omroepzendermuseum.nl/index.php/over-het-museum

### Description
Museum about the electro-technical techniques of broadcasting radio and TV signals

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 300
**File:** `content/daytrip/eu/nl/omroepzendermuseum.md`

Please review this venue submission and edit the content as needed before merging.