### PR TITLE
New: Rotterdam Radio Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/rotterdam-radio-museum.md
+++ b/content/daytrip/eu/nl/rotterdam-radio-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/rotterdam-radio-museum"
+date: "2025-06-08T11:27:55.436Z"
+poster: "Frederik Dekker"
+lat: "51.942182"
+lng: "4.479697"
+location: "Ceintuurbaan 111, 3051 KA, Rotterdam,The Netherlands"
+title: "Rotterdam Radio Museum"
+external_url: https://www.correct.nl/pages/rotterdams-radio-museum
+---
+Museum in Rotterdam with a large collection of radio equipment


### PR DESCRIPTION
## New Venue Submission

**Venue:** Rotterdam Radio Museum
**Location:** Ceintuurbaan 111, 3051 KA, Rotterdam,The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.correct.nl/pages/rotterdams-radio-museum

### Description
Museum in Rotterdam with a large collection of radio equipment

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 301
**File:** `content/daytrip/eu/nl/rotterdam-radio-museum.md`

Please review this venue submission and edit the content as needed before merging.