### PR TITLE
New: Fortress Island Pampus from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/fortress-island-pampus.md
+++ b/content/daytrip/eu/nl/fortress-island-pampus.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/fortress-island-pampus"
+date: "2025-06-08T11:28:06.148Z"
+poster: "Frederik Dekker"
+lat: "52.3645"
+lng: "5.068817"
+location: "Forteiland Pampus, 1398 PX Muiden, The Netherlands"
+title: "Fortress Island Pampus"
+external_url: https://www.pampus.nl/
+---
+Pampus is a historic fortress, built to protect Amsterdam. It is located on a man-made island. The fortress can be explored, but is also a showcase of running fossil-free.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fortress Island Pampus
**Location:** Forteiland Pampus, 1398 PX Muiden, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.pampus.nl/

### Description
Pampus is a historic fortress, built to protect Amsterdam. It is located on a man-made island. The fortress can be explored, but is also a showcase of running fossil-free.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 302
**File:** `content/daytrip/eu/nl/fortress-island-pampus.md`

Please review this venue submission and edit the content as needed before merging.