### PR TITLE
New: Museum village de Locht from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museum-village-de-locht.md
+++ b/content/daytrip/eu/nl/museum-village-de-locht.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-village-de-locht"
+date: "2025-06-08T11:28:32.251Z"
+poster: "Frederik Dekker"
+lat: "51.462551"
+lng: "6.090438"
+location: "Broekhuizerdijk 16d, 5962NM, Melderslo, The Netherlands"
+title: "Museum village de Locht"
+external_url: https://delocht.nl/
+---
+Museum village about how life was in Limburg in days long gone by.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum village de Locht
**Location:** Broekhuizerdijk 16d, 5962NM, Melderslo, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://delocht.nl/

### Description
Museum village about how life was in Limburg in days long gone by.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 304
**File:** `content/daytrip/eu/nl/museum-village-de-locht.md`

Please review this venue submission and edit the content as needed before merging.