### PR TITLE
New: World Soil Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/world-soil-museum.md
+++ b/content/daytrip/eu/nl/world-soil-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/world-soil-museum"
+date: "2025-06-08T11:28:41.155Z"
+poster: "Frederik Dekker"
+lat: "51.987394"
+lng: "5.666403"
+location: "Droevendaalsesteeg 3, 6708 PB, Wageningen, The Netherlands"
+title: "World Soil Museum"
+external_url: https://wsm.isric.org/
+---
+Museum about soil types and profiles around the world.


### PR DESCRIPTION
## New Venue Submission

**Venue:** World Soil Museum
**Location:** Droevendaalsesteeg 3, 6708 PB, Wageningen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://wsm.isric.org/

### Description
Museum about soil types and profiles around the world.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 305
**File:** `content/daytrip/eu/nl/world-soil-museum.md`

Please review this venue submission and edit the content as needed before merging.