### PR TITLE
New: Museum Speelklok from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museum-speelklok.md
+++ b/content/daytrip/eu/nl/museum-speelklok.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-speelklok"
+date: "2025-06-08T11:28:52.169Z"
+poster: "Frederik Dekker"
+lat: "52.090714"
+lng: "5.119404"
+location: "Steenweg 6, 3511 JP, Utrecht, The Netherlands"
+title: "Museum Speelklok"
+external_url: https://www.museumspeelklok.nl/en/
+---
+Museum about music making machines, from music boxes to organs.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum Speelklok
**Location:** Steenweg 6, 3511 JP, Utrecht, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.museumspeelklok.nl/en/

### Description
Museum about music making machines, from music boxes to organs.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 306
**File:** `content/daytrip/eu/nl/museum-speelklok.md`

Please review this venue submission and edit the content as needed before merging.