### PR TITLE
New: Roche Abbey from Robin

### DIFF
--- a/content/daytrip/eu/gb/roche-abbey.md
+++ b/content/daytrip/eu/gb/roche-abbey.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/roche-abbey"
+date: "2025-06-08T11:29:22.925Z"
+poster: "Robin"
+lat: "53.402647"
+lng: "-1.184189"
+location: "Maltby, Rotherham, South Yorkshire, S66 8NW"
+title: "Roche Abbey"
+external_url: https://www.english-heritage.org.uk/visit/places/roche-abbey/
+---
+Mostly-ruined Cistercian abbey


### PR DESCRIPTION
## New Venue Submission

**Venue:** Roche Abbey
**Location:** Maltby, Rotherham, South Yorkshire, S66 8NW
**Submitted by:** Robin
**Website:** https://www.english-heritage.org.uk/visit/places/roche-abbey/

### Description
Mostly-ruined Cistercian abbey

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 308
**File:** `content/daytrip/eu/gb/roche-abbey.md`

Please review this venue submission and edit the content as needed before merging.