### PR TITLE
New: Cable Car Museum from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/cable-car-museum.md
+++ b/content/daytrip/na/us/cable-car-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/cable-car-museum"
+date: "2025-06-09T06:03:50.697Z"
+poster: "Mark Dominus"
+lat: "37.79476"
+lng: "-122.411853"
+location: "Cable Car Powerhouse and Barn, 1201, Mason Street, Nob Hill, San Francisco, California, 94108, United States"
+title: "Cable Car Museum"
+external_url: https://www.cablecarmuseum.org/info.html
+---
+San Francisco cable cars have an unusual drive mechanism to go up and down the steep hills.  A cable runs under the street, down the steep hill to the bottom, around a pulley, and back up to the powerhouse at the top.  When the cable car wants to ascend, it clamps onto the cable and the engine at the top of the hill pulls it up.
+
+You can see the powerhouse with its engines and giant wheels what have pulled cable cars up and down the hills for 150 years.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cable Car Museum
**Location:** Cable Car Powerhouse and Barn, 1201, Mason Street, Nob Hill, San Francisco, California, 94108, United States
**Submitted by:** Mark Dominus
**Website:** https://www.cablecarmuseum.org/info.html

### Description
San Francisco cable cars have an unusual drive mechanism to go up and down the steep hills.  A cable runs under the street, down the steep hill to the bottom, around a pulley, and back up to the powerhouse at the top.  When the cable car wants to ascend, it clamps onto the cable and the engine at the top of the hill pulls it up.

You can see the powerhouse with its engines and giant wheels what have pulled cable cars up and down the hills for 150 years.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 310
**File:** `content/daytrip/na/us/cable-car-museum.md`

Please review this venue submission and edit the content as needed before merging.