### PR TITLE
New: Cruquius Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/cruquius-museum.md
+++ b/content/daytrip/eu/nl/cruquius-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/cruquius-museum"
+date: "2025-06-09T06:04:59.173Z"
+poster: "Frederik Dekker"
+lat: "52.338191"
+lng: "4.638366"
+location: "Cruquiusdijk 27, 2142 ER Cruquius, The Netherlands"
+title: "Cruquius Museum"
+external_url: https://cruquius-museum.nl/en
+---
+19th century steam powered water pumping station. The pumping stationed was used to pump dry the Haarlemmermeer polder. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cruquius Museum
**Location:** Cruquiusdijk 27, 2142 ER Cruquius, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://cruquius-museum.nl/en

### Description
19th century steam powered water pumping station. The pumping stationed was used to pump dry the Haarlemmermeer polder. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 312
**File:** `content/daytrip/eu/nl/cruquius-museum.md`

Please review this venue submission and edit the content as needed before merging.