### PR TITLE
New: NEMO science museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/nemo-science-museum.md
+++ b/content/daytrip/eu/nl/nemo-science-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/nemo-science-museum"
+date: "2025-06-09T06:05:23.108Z"
+poster: "Frederik Dekker"
+lat: "52.37385"
+lng: "4.912106"
+location: "Oosterdok 2, 1011 VX, Amsterdam, The Netherlands"
+title: "NEMO science museum"
+external_url: https://www.nemosciencemuseum.nl/en/
+---
+Hands on museum on science and technology. Also a nice rooftop terrace.


### PR DESCRIPTION
## New Venue Submission

**Venue:** NEMO science museum
**Location:** Oosterdok 2, 1011 VX, Amsterdam, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.nemosciencemuseum.nl/en/

### Description
Hands on museum on science and technology. Also a nice rooftop terrace.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 313
**File:** `content/daytrip/eu/nl/nemo-science-museum.md`

Please review this venue submission and edit the content as needed before merging.