### PR TITLE
New: National bike museum Velorama from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/national-bike-museum-velorama.md
+++ b/content/daytrip/eu/nl/national-bike-museum-velorama.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/national-bike-museum-velorama"
+date: "2025-06-09T06:05:41.876Z"
+poster: "Frederik Dekker"
+lat: "51.848587"
+lng: "5.869993"
+location: "Waalkade 107, 6511 XR, Nijmegen, The Netherlands"
+title: "National bike museum Velorama"
+external_url: https://velorama.nl/
+---
+In a country where cycling is the national form of transport there should be a bike museum, and there is: The national bike museum Velorama.
+
+Large collection of bikes from walking bikes to modern ones.


### PR DESCRIPTION
## New Venue Submission

**Venue:** National bike museum Velorama
**Location:** Waalkade 107, 6511 XR, Nijmegen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://velorama.nl/

### Description
In a country where cycling is the national form of transport there should be a bike museum, and there is: The national bike museum Velorama.

Large collection of bikes from walking bikes to modern ones.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 314
**File:** `content/daytrip/eu/nl/national-bike-museum-velorama.md`

Please review this venue submission and edit the content as needed before merging.