### PR TITLE
New: Esher in het paleis from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/esher-in-het-paleis.md
+++ b/content/daytrip/eu/nl/esher-in-het-paleis.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/esher-in-het-paleis"
+date: "2025-06-09T06:06:14.193Z"
+poster: "Frederik Dekker"
+lat: "52.083406"
+lng: "4.314247"
+location: "Lange Voorhout 74, 2514 EH, Den Haag, The Netherlands"
+title: "Esher in het paleis"
+external_url: https://escherinhetpaleis.nl/en
+---
+Museum exhibiting the works of M.C. Escher, a Dutch artist famous for his use of repeating patterns and optical and spatial illusions.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Esher in het paleis
**Location:** Lange Voorhout 74, 2514 EH, Den Haag, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://escherinhetpaleis.nl/en

### Description
Museum exhibiting the works of M.C. Escher, a Dutch artist famous for his use of repeating patterns and optical and spatial illusions.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 315
**File:** `content/daytrip/eu/nl/esher-in-het-paleis.md`

Please review this venue submission and edit the content as needed before merging.