### PR TITLE
New: Hunebed Centre from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/hunebed-centre.md
+++ b/content/daytrip/eu/nl/hunebed-centre.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/hunebed-centre"
+date: "2025-06-09T06:06:50.805Z"
+poster: "Frederik Dekker"
+lat: "52.931387"
+lng: "6.798692"
+location: "Hunebedstraat 27 9531 JT Borger"
+title: "Hunebed Centre"
+external_url: https://www.hunebedcentrum.eu/en/
+---
+Museum park about Hunebeds (large stone burial monuments) and the prehistoric people that build them.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hunebed Centre
**Location:** Hunebedstraat 27 9531 JT Borger
**Submitted by:** Frederik Dekker
**Website:** https://www.hunebedcentrum.eu/en/

### Description
Museum park about Hunebeds (large stone burial monuments) and the prehistoric people that build them.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 316
**File:** `content/daytrip/eu/nl/hunebed-centre.md`

Please review this venue submission and edit the content as needed before merging.