### PR TITLE
New: TfL bus stop WD (Larkshall Crescent, southbound) from Cain Mosni aka Camopants

### DIFF
--- a/content/daytrip/eu/gb/tfl-bus-stop-wd-larkshall-crescent-southbound.md
+++ b/content/daytrip/eu/gb/tfl-bus-stop-wd-larkshall-crescent-southbound.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/tfl-bus-stop-wd-larkshall-crescent-southbound"
+date: "2025-06-09T06:09:21.278Z"
+poster: "Cain Mosni aka Camopants"
+lat: "51.61546"
+lng: "3.0e-05"
+location: "Larkshall Road"
+title: "TfL bus stop WD (Larkshall Crescent, southbound)"
+external_url: https://beta-naptan.dft.gov.uk/download/
+---
+One of three bus stops in the UK (all of them in London) closest to the Prime Meridian.  To the precision recorded in NaPTAN data (5 decimal places) they are all 2.07m west of the meridian.
+
+There is one record even closer (1.38m east), in Surrey, but on private school grounds.


### PR DESCRIPTION
## New Venue Submission

**Venue:** TfL bus stop WD (Larkshall Crescent, southbound)
**Location:** Larkshall Road
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://beta-naptan.dft.gov.uk/download/

### Description
One of three bus stops in the UK (all of them in London) closest to the Prime Meridian.  To the precision recorded in NaPTAN data (5 decimal places) they are all 2.07m west of the meridian.

There is one record even closer (1.38m east), in Surrey, but on private school grounds.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 317
**File:** `content/daytrip/eu/gb/tfl-bus-stop-wd-larkshall-crescent-southbound.md`

Please review this venue submission and edit the content as needed before merging.