### PR TITLE
New: Bus stop F  (Woodside Park Avenue, southbound) from Cain Mosni aka Camopants

### DIFF
--- a/content/daytrip/eu/gb/bus-stop-f-woodside-park-avenue-southbound.md
+++ b/content/daytrip/eu/gb/bus-stop-f-woodside-park-avenue-southbound.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/bus-stop-f-woodside-park-avenue-southbound"
+date: "2025-06-09T06:09:36.452Z"
+poster: "Cain Mosni aka Camopants"
+lat: "51.5832"
+lng: "3.0e-05"
+location: "Wood Street, Walthamstow"
+title: "Bus stop F  (Woodside Park Avenue, southbound)"
+external_url: https://beta-naptan.dft.gov.uk/download/
+---
+One of three bus stops in the UK (all of them in London) closest to the Prime Meridian.  To the precision recorded in NaPTAN data (5 decimal places) they are all 2.07m east of the meridian.
+
+There is one record even closer (1.38m west), in Surrey, but on private school grounds.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bus stop F  (Woodside Park Avenue, southbound)
**Location:** Wood Street, Walthamstow
**Submitted by:** Cain Mosni aka Camopants
**Website:** https://beta-naptan.dft.gov.uk/download/

### Description
One of three bus stops in the UK (all of them in London) closest to the Prime Meridian.  To the precision recorded in NaPTAN data (5 decimal places) they are all 2.07m east of the meridian.

There is one record even closer (1.38m west), in Surrey, but on private school grounds.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 318
**File:** `content/daytrip/eu/gb/bus-stop-f-woodside-park-avenue-southbound.md`

Please review this venue submission and edit the content as needed before merging.