### PR TITLE
New: Railroad Museum of Pennsylvania from Mark Dominus

### DIFF
--- a/content/daytrip/na/us/railroad-museum-of-pennsylvania.md
+++ b/content/daytrip/na/us/railroad-museum-of-pennsylvania.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/na/us/railroad-museum-of-pennsylvania"
+date: "2025-06-09T06:09:58.194Z"
+poster: "Mark Dominus"
+lat: "39.982337"
+lng: "-76.160204"
+location: "Railroad Museum of Pennsylvania, 300, Gap Road, Strasburg, Lancaster County, Pennsylvania, 17579, United States"
+title: "Railroad Museum of Pennsylvania"
+external_url: https://www.strasburgrailroad.com/
+---
+The collection includes many antique train cars that you can walk around and sit down in, but the big draw is that you can take a real steam train ride in a renovated period train, walk into the dining car, and eat pie while you watch the Lancaster County scenery go by.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Railroad Museum of Pennsylvania
**Location:** Railroad Museum of Pennsylvania, 300, Gap Road, Strasburg, Lancaster County, Pennsylvania, 17579, United States
**Submitted by:** Mark Dominus
**Website:** https://www.strasburgrailroad.com/

### Description
The collection includes many antique train cars that you can walk around and sit down in, but the big draw is that you can take a real steam train ride in a renovated period train, walk into the dining car, and eat pie while you watch the Lancaster County scenery go by.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 320
**File:** `content/daytrip/na/us/railroad-museum-of-pennsylvania.md`

Please review this venue submission and edit the content as needed before merging.