### PR TITLE
New: National Maritime Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/national-maritime-museum.md
+++ b/content/daytrip/eu/nl/national-maritime-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/national-maritime-museum"
+date: "2025-06-09T09:30:24.377Z"
+poster: "Frederik Dekker"
+lat: "52.371643"
+lng: "4.914805"
+location: "Kattenburgerplein 1, 1018 KK, Amsterdam, The Netherlands"
+title: "National Maritime Museum"
+external_url: https://www.hetscheepvaartmuseum.com/
+---
+Located in a former naval storehouse, the national maritime museum shows 500 years of Dutch maritime history. This includes a life sized replica of a Dutch East Indiaman. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Maritime Museum
**Location:** Kattenburgerplein 1, 1018 KK, Amsterdam, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.hetscheepvaartmuseum.com/

### Description
Located in a former naval storehouse, the national maritime museum shows 500 years of Dutch maritime history. This includes a life sized replica of a Dutch East Indiaman. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 321
**File:** `content/daytrip/eu/nl/national-maritime-museum.md`

Please review this venue submission and edit the content as needed before merging.