### PR TITLE
New: Frisian Museum of Natural History from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/frisian-museum-of-natural-history.md
+++ b/content/daytrip/eu/nl/frisian-museum-of-natural-history.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/frisian-museum-of-natural-history"
+date: "2025-06-09T09:30:40.402Z"
+poster: "Frederik Dekker"
+lat: "53.204143"
+lng: "5.795953"
+location: "Schoenmakersperk 2, 8911 EM, Leeuwarden, The Netherlands"
+title: "Frisian Museum of Natural History"
+external_url: https://natuurmuseumfryslan.nl/en/
+---
+Kids proof museum with a focus on nature in the province of Friesland. Includes the complete skeleton of a sperm whale.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Frisian Museum of Natural History
**Location:** Schoenmakersperk 2, 8911 EM, Leeuwarden, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://natuurmuseumfryslan.nl/en/

### Description
Kids proof museum with a focus on nature in the province of Friesland. Includes the complete skeleton of a sperm whale.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 322
**File:** `content/daytrip/eu/nl/frisian-museum-of-natural-history.md`

Please review this venue submission and edit the content as needed before merging.