### PR TITLE
New: Gevangenismuseum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/gevangenismuseum.md
+++ b/content/daytrip/eu/nl/gevangenismuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/gevangenismuseum"
+date: "2025-06-09T09:31:02.608Z"
+poster: "Frederik Dekker"
+lat: "53.041245"
+lng: "6.390352"
+location: "Oude Gracht 1, 9341 AA, Veenhuizen, The Netherlands"
+title: "Gevangenismuseum"
+external_url: https://gevangenismuseum.nl/
+---
+Prison museum about the consequences of unwanted behaviour. About crime and punishment, but also about the re-education of poor people from the west of the Netherlands in the peat bog colonies in the north-east of the country 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Gevangenismuseum
**Location:** Oude Gracht 1, 9341 AA, Veenhuizen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://gevangenismuseum.nl/

### Description
Prison museum about the consequences of unwanted behaviour. About crime and punishment, but also about the re-education of poor people from the west of the Netherlands in the peat bog colonies in the north-east of the country 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 323
**File:** `content/daytrip/eu/nl/gevangenismuseum.md`

Please review this venue submission and edit the content as needed before merging.