### PR TITLE
New: Museum "de Proefkolonie' Frederiksoord from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museum-de-proefkolonie-frederiksoord.md
+++ b/content/daytrip/eu/nl/museum-de-proefkolonie-frederiksoord.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-de-proefkolonie-frederiksoord"
+date: "2025-06-09T09:31:12.221Z"
+poster: "Frederik Dekker"
+lat: "52.844655"
+lng: "6.189004"
+location: "Major van Swietenlaan 1a, 8382 CE, Frederiksoord, The Netherlands"
+title: "Museum "de Proefkolonie' Frederiksoord"
+external_url: https://proefkolonie.nl/en/
+---
+In the 19th century the Netherlands were relatively poor, especially in the city's there were a lot of people who could not sustain themselves. The voluntary peat bog colonies were set up so that people could be re-educated to a sober, hard-working lifestyle on the countryside. This museum tells the story about the colonies and its people.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum "de Proefkolonie' Frederiksoord
**Location:** Major van Swietenlaan 1a, 8382 CE, Frederiksoord, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://proefkolonie.nl/en/

### Description
In the 19th century the Netherlands were relatively poor, especially in the city's there were a lot of people who could not sustain themselves. The voluntary peat bog colonies were set up so that people could be re-educated to a sober, hard-working lifestyle on the countryside. This museum tells the story about the colonies and its people.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 324
**File:** `content/daytrip/eu/nl/museum-de-proefkolonie-frederiksoord.md`

Please review this venue submission and edit the content as needed before merging.