### PR TITLE
New: Fortress Bourtange from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/fortress-bourtange.md
+++ b/content/daytrip/eu/nl/fortress-bourtange.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/fortress-bourtange"
+date: "2025-06-09T09:31:21.167Z"
+poster: "Frederik Dekker"
+lat: "53.006726"
+lng: "7.192097"
+location: "Willem Lodewijkstraat 33, 9545 PA, Bourtange, The Netherlands"
+title: "Fortress Bourtange"
+external_url: https://www.bourtange.nl/
+---
+Museum village in the fortress of Bourtange. The fortress was built during the Dutch revolt against Spain. When the fortress lost its military purpose it became neglected, but has since then been completely restored to how it looked in 1742.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fortress Bourtange
**Location:** Willem Lodewijkstraat 33, 9545 PA, Bourtange, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.bourtange.nl/

### Description
Museum village in the fortress of Bourtange. The fortress was built during the Dutch revolt against Spain. When the fortress lost its military purpose it became neglected, but has since then been completely restored to how it looked in 1742.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 325
**File:** `content/daytrip/eu/nl/fortress-bourtange.md`

Please review this venue submission and edit the content as needed before merging.