### PR TITLE
New: Maeslantkering storm surge barrier from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/maeslantkering-storm-surge-barrier.md
+++ b/content/daytrip/eu/nl/maeslantkering-storm-surge-barrier.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/maeslantkering-storm-surge-barrier"
+date: "2025-06-09T12:25:12.640Z"
+poster: "Frederik Dekker"
+lat: "51.956748"
+lng: "4.166908"
+location: "Maeslantkeringweg 139, 3151 ZZ, Hoek van Holland, The Netherlands"
+title: "Maeslantkering storm surge barrier"
+external_url: https://www.maeslantkering.nl/home
+---
+Storm surge barrier that protects Rotterdam and a large part of South-Holland against the Northsea. Since the river could not be obstructed for shipping, two giant doors had to be built that float until they almost reach each other and are then sunk to the river bottom. This way the river is almost comleteley closed.
+
+Tip: try to visit when they perform a test closure (once a year)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Maeslantkering storm surge barrier
**Location:** Maeslantkeringweg 139, 3151 ZZ, Hoek van Holland, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.maeslantkering.nl/home

### Description
Storm surge barrier that protects Rotterdam and a large part of South-Holland against the Northsea. Since the river could not be obstructed for shipping, two giant doors had to be built that float until they almost reach each other and are then sunk to the river bottom. This way the river is almost comleteley closed.

Tip: try to visit when they perform a test closure (once a year)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 326
**File:** `content/daytrip/eu/nl/maeslantkering-storm-surge-barrier.md`

Please review this venue submission and edit the content as needed before merging.