### PR TITLE
New: Veluwsche Stoomtrein Maatschappij from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/veluwsche-stoomtrein-maatschappij.md
+++ b/content/daytrip/eu/nl/veluwsche-stoomtrein-maatschappij.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/veluwsche-stoomtrein-maatschappij"
+date: "2025-06-09T12:25:55.522Z"
+poster: "Frederik Dekker"
+lat: "52.16002"
+lng: "5.986605"
+location: "Dorpstraat 140, 7361 AZ, Beekbergen, The Netherlands"
+title: "Veluwsche Stoomtrein Maatschappij"
+external_url: https://stoomtrein.org/en/
+---
+Steam train with historic station emplacement at Beekbergen. The steam train runs between Apeldoorn and Dieren. 
+
+The station has workshops, a turn table, offices and water and coal facilities.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Veluwsche Stoomtrein Maatschappij
**Location:** Dorpstraat 140, 7361 AZ, Beekbergen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://stoomtrein.org/en/

### Description
Steam train with historic station emplacement at Beekbergen. The steam train runs between Apeldoorn and Dieren. 

The station has workshops, a turn table, offices and water and coal facilities.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 328
**File:** `content/daytrip/eu/nl/veluwsche-stoomtrein-maatschappij.md`

Please review this venue submission and edit the content as needed before merging.