### PR TITLE
New: Portlantis from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/portlantis.md
+++ b/content/daytrip/eu/nl/portlantis.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/portlantis"
+date: "2025-06-09T12:26:41.921Z"
+poster: "Frederik Dekker"
+lat: "51.935475"
+lng: "3.977904"
+location: " Prinses Máximaweg 301, 3199 KG, Rotterdam, the Netherlands"
+title: "Portlantis"
+external_url: https://www.portofrotterdam.com/en/portlantis
+---
+Visitor centre for the port of Rotterdam, the biggest port in Europe. The centre shows all activities going on in the port including the efforts to reclaim the Maasvlakte form the Northsea


### PR DESCRIPTION
## New Venue Submission

**Venue:** Portlantis
**Location:**  Prinses Máximaweg 301, 3199 KG, Rotterdam, the Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.portofrotterdam.com/en/portlantis

### Description
Visitor centre for the port of Rotterdam, the biggest port in Europe. The centre shows all activities going on in the port including the efforts to reclaim the Maasvlakte form the Northsea

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 330
**File:** `content/daytrip/eu/nl/portlantis.md`

Please review this venue submission and edit the content as needed before merging.