### PR TITLE
New: National Emergency Services Museum from GlennF

### DIFF
--- a/content/daytrip/eu/gb/national-emergency-services-museum.md
+++ b/content/daytrip/eu/gb/national-emergency-services-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/national-emergency-services-museum"
+date: "2025-06-09T12:26:59.357Z"
+poster: "GlennF"
+lat: "53.3855"
+lng: "-1.471011"
+location: "National Emergency Services Museum The Old Police/Fire Station West Bar Sheffield S3 8PT"
+title: "National Emergency Services Museum"
+external_url: https://www.visitnesm.org.uk
+---
+The National Emergency Services Museum in Sheffield is this really cool spot housed in a gorgeous old Victorian building that used to be an actual police, fire, and ambulance station. They've got about 30 vintage emergency vehicles spread across three floors, plus loads of old medical kit, firefighting gear, and even a massive 47-foot lifeboat - and the best part is it's all hands-on and interactive rather than just stuff behind glass. It's open Wednesday through Sunday and honestly way more interesting than you'd expect, whether you're into the history side of things or just love checking out old vehicles, plus they do school trips and you can even hire the place out for events if you want somewhere a bit different.


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Emergency Services Museum
**Location:** National Emergency Services Museum The Old Police/Fire Station West Bar Sheffield S3 8PT
**Submitted by:** GlennF
**Website:** https://www.visitnesm.org.uk

### Description
The National Emergency Services Museum in Sheffield is this really cool spot housed in a gorgeous old Victorian building that used to be an actual police, fire, and ambulance station. They've got about 30 vintage emergency vehicles spread across three floors, plus loads of old medical kit, firefighting gear, and even a massive 47-foot lifeboat - and the best part is it's all hands-on and interactive rather than just stuff behind glass. It's open Wednesday through Sunday and honestly way more interesting than you'd expect, whether you're into the history side of things or just love checking out old vehicles, plus they do school trips and you can even hire the place out for events if you want somewhere a bit different.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 331
**File:** `content/daytrip/eu/gb/national-emergency-services-museum.md`

Please review this venue submission and edit the content as needed before merging.