### PR TITLE
New: Space Expo Noordwijk from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/space-expo-noordwijk.md
+++ b/content/daytrip/eu/nl/space-expo-noordwijk.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/space-expo-noordwijk"
+date: "2025-06-09T12:27:20.703Z"
+poster: "Frederik Dekker"
+lat: "52.215234"
+lng: "4.420602"
+location: "Keplerlaan 3, 2201 AZ, Noordwijk, The Netherlands"
+title: "Space Expo Noordwijk"
+external_url: https://www.space-expo.nl/en
+---
+Space museum. The museum is located next to the European Space Agency's ESTEC space and technology centre. 
+
+Mainly about space exploration from a European perspective.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Space Expo Noordwijk
**Location:** Keplerlaan 3, 2201 AZ, Noordwijk, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.space-expo.nl/en

### Description
Space museum. The museum is located next to the European Space Agency's ESTEC space and technology centre. 

Mainly about space exploration from a European perspective.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 332
**File:** `content/daytrip/eu/nl/space-expo-noordwijk.md`

Please review this venue submission and edit the content as needed before merging.