### PR TITLE
New:  Museumstoomtram Hoorn-Medemblik from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/-museumstoomtram-hoorn-medemblik.md
+++ b/content/daytrip/eu/nl/-museumstoomtram-hoorn-medemblik.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/-museumstoomtram-hoorn-medemblik"
+date: "2025-06-09T12:28:10.586Z"
+poster: "Frederik Dekker"
+lat: "52.645609"
+lng: "5.054601"
+location: "Van Dedemstraat 8, 1624 NN, Hoorn, The Netherlands"
+title: " Museumstoomtram Hoorn-Medemblik"
+external_url: https://www.stoomtram.nl/en/
+---
+Historic steam tram that runs between Hoorn and Medemblik with historic stations along the way.
+
+Can be combined with a visit to the Zuiderzee museum by taking the historic ferry "Friesland" from Medemblik to Enkhuizen (or the other way around)


### PR DESCRIPTION
## New Venue Submission

**Venue:**  Museumstoomtram Hoorn-Medemblik
**Location:** Van Dedemstraat 8, 1624 NN, Hoorn, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.stoomtram.nl/en/

### Description
Historic steam tram that runs between Hoorn and Medemblik with historic stations along the way.

Can be combined with a visit to the Zuiderzee museum by taking the historic ferry "Friesland" from Medemblik to Enkhuizen (or the other way around)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 333
**File:** `content/daytrip/eu/nl/-museumstoomtram-hoorn-medemblik.md`

Please review this venue submission and edit the content as needed before merging.