### PR TITLE
New: Brösarp from magnus

### DIFF
--- a/content/daytrip/eu/se/brsarp.md
+++ b/content/daytrip/eu/se/brsarp.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/eu/se/brsarp"
+date: "2025-06-09T18:11:33.116Z"
+poster: "magnus"
+lat: "55.734971"
+lng: "14.125427"
+location: "Brösarp, 3, Brösarps stationsväg, Brösarp, Simrishamns kommun, Skåne län, 273 55, Sverige"
+title: "Brösarp"
+external_url: https://angtaget.se/
+---
+Since 1971, steam trains have been chugging along Sweden's most beautiful railway between Brösarp and S:t Olof on Österlen. We take you around Brösarp's hills, along the clear blue waters of Hanöbukten, the ripe fields, and through the deep beech forests. The Museum Association Skånska Järnvägar preserves and develops the museum railway on Österlen and showcases a time period when people traveled on wooden benches, the station master was the king of the community, and the locomotive driver was every child's idol.
+
+The Museum Association Skånska Järnvägar was formed in the autumn of 1969, moved to Brösarp in the spring of 1971, and started steam train traffic to S:t Olof the same summer. All work on the railway is done on a voluntary basis and is completely unpaid.
+
+The journey takes approximately 1.5 hours, which includes a 30-minute break in Sankt Olof. During the break, there is an ice cream kiosk open, and toilets are also available.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Brösarp
**Location:** Brösarp, 3, Brösarps stationsväg, Brösarp, Simrishamns kommun, Skåne län, 273 55, Sverige
**Submitted by:** magnus
**Website:** https://angtaget.se/

### Description
Since 1971, steam trains have been chugging along Sweden's most beautiful railway between Brösarp and S:t Olof on Österlen. We take you around Brösarp's hills, along the clear blue waters of Hanöbukten, the ripe fields, and through the deep beech forests. The Museum Association Skånska Järnvägar preserves and develops the museum railway on Österlen and showcases a time period when people traveled on wooden benches, the station master was the king of the community, and the locomotive driver was every child's idol.

The Museum Association Skånska Järnvägar was formed in the autumn of 1969, moved to Brösarp in the spring of 1971, and started steam train traffic to S:t Olof the same summer. All work on the railway is done on a voluntary basis and is completely unpaid.

The journey takes approximately 1.5 hours, which includes a 30-minute break in Sankt Olof. During the break, there is an ice cream kiosk open, and toilets are also available.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 335
**File:** `content/daytrip/eu/se/brsarp.md`

Please review this venue submission and edit the content as needed before merging.