### PR TITLE
New: Banting House from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/banting-house.md
+++ b/content/daytrip/na/ca/banting-house.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/ca/banting-house"
+date: "2025-06-09T18:11:51.685Z"
+poster: "Paul Drye"
+lat: "42.990035"
+lng: "-81.231746"
+location: "442 Adelaide Street North, London, Ontario, Canada"
+title: "Banting House"
+external_url: https://bantinghousenhs.ca/
+---
+A small museum in the former home of Frederick Banting, one of the developers of insulin as a medicine for diabetes. As well as exploring on your own, a 45-minute guided tour of the exhibits is available,


### PR DESCRIPTION
## New Venue Submission

**Venue:** Banting House
**Location:** 442 Adelaide Street North, London, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://bantinghousenhs.ca/

### Description
A small museum in the former home of Frederick Banting, one of the developers of insulin as a medicine for diabetes. As well as exploring on your own, a 45-minute guided tour of the exhibits is available,

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 336
**File:** `content/daytrip/na/ca/banting-house.md`

Please review this venue submission and edit the content as needed before merging.