### PR TITLE
New: Misselhorn Art Gallery from Paul Drye

### DIFF
--- a/content/daytrip/na/us/misselhorn-art-gallery.md
+++ b/content/daytrip/na/us/misselhorn-art-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/misselhorn-art-gallery"
+date: "2025-06-09T18:12:18.362Z"
+poster: "Paul Drye"
+lat: "38.120258"
+lng: "-89.707683"
+location: "West 2nd Street, Sparta, Illinois, United States"
+title: "Misselhorn Art Gallery"
+external_url: https://www.greatriverroad.com/sparta
+---
+A small art gallery named for a local artist, it is of Nerdy Interest for its display of items related to the 1967 Academy Award-winning movie In the Heat of the Night. It was filmed here in Sparta, Illinois and the museum's building (a former railway stop) was even one of the filming sites.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Misselhorn Art Gallery
**Location:** West 2nd Street, Sparta, Illinois, United States
**Submitted by:** Paul Drye
**Website:** https://www.greatriverroad.com/sparta

### Description
A small art gallery named for a local artist, it is of Nerdy Interest for its display of items related to the 1967 Academy Award-winning movie In the Heat of the Night. It was filmed here in Sparta, Illinois and the museum's building (a former railway stop) was even one of the filming sites.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 337
**File:** `content/daytrip/na/us/misselhorn-art-gallery.md`

Please review this venue submission and edit the content as needed before merging.