### PR TITLE
New: Zuiderzee Museum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/zuiderzee-museum.md
+++ b/content/daytrip/eu/nl/zuiderzee-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/zuiderzee-museum"
+date: "2025-06-09T18:12:55.864Z"
+poster: "Frederik Dekker"
+lat: "52.707088"
+lng: "5.297685"
+location: "Noorderwierdijk, 1601 LV, Enkhuizen, The Netherlands"
+title: "Zuiderzee Museum"
+external_url: https://www.zuiderzeemuseum.nl/
+---
+Museum about life at the shores of the Zuiderzee. In 1932 the great IJsselmeer barrier dam was constructed and the Zuiderzee was seperated form the Waddenzee. While the Zuiderzee was in open connection with the (salt) sea before, now it became a fresh water lake. The museum is about life before 1932 in the historic village, but also focusses on the current situation and future.
+
+Can be combined with the steam tram from Hoorn to Medemblik by taking the historic ferry "Friesland", which sails between Medemblik and Enkhuizen.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Zuiderzee Museum
**Location:** Noorderwierdijk, 1601 LV, Enkhuizen, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.zuiderzeemuseum.nl/

### Description
Museum about life at the shores of the Zuiderzee. In 1932 the great IJsselmeer barrier dam was constructed and the Zuiderzee was seperated form the Waddenzee. While the Zuiderzee was in open connection with the (salt) sea before, now it became a fresh water lake. The museum is about life before 1932 in the historic village, but also focusses on the current situation and future.

Can be combined with the steam tram from Hoorn to Medemblik by taking the historic ferry "Friesland", which sails between Medemblik and Enkhuizen.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 338
**File:** `content/daytrip/eu/nl/zuiderzee-museum.md`

Please review this venue submission and edit the content as needed before merging.