### PR TITLE
New: Chance & Counters from Stuart Langridge

### DIFF
--- a/content/daytrip/eu/gb/chance-counters.md
+++ b/content/daytrip/eu/gb/chance-counters.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/chance-counters"
+date: "2025-06-09T19:19:29.673Z"
+poster: "Stuart Langridge"
+lat: "52.475458"
+lng: "-1.884368"
+location: "Chance & Counters, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom"
+title: "Chance & Counters"
+external_url: https://www.chanceandcounters.com/birmingham/
+---
+Board game cafe with a whole wall's selection of games to play.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Chance & Counters
**Location:** Chance & Counters, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom
**Submitted by:** Stuart Langridge
**Website:** https://www.chanceandcounters.com/birmingham/

### Description
Board game cafe with a whole wall's selection of games to play.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 339
**File:** `content/daytrip/eu/gb/chance-counters.md`

Please review this venue submission and edit the content as needed before merging.