### PR TITLE
New: NQ64 Arcade Bar from Stuart Langridge

### DIFF
--- a/content/daytrip/eu/gb/nq64-arcade-bar.md
+++ b/content/daytrip/eu/gb/nq64-arcade-bar.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/nq64-arcade-bar"
+date: "2025-06-09T19:19:41.313Z"
+poster: "Stuart Langridge"
+lat: "52.475398"
+lng: "-1.884421"
+location: "NQ64 Arcade Bar, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom"
+title: "NQ64 Arcade Bar"
+external_url: https://nq64.co.uk/birmingham/
+---
+A bar full of arcade machines both new and old, and a whole bunch of wired up consoles as well.


### PR DESCRIPTION
## New Venue Submission

**Venue:** NQ64 Arcade Bar
**Location:** NQ64 Arcade Bar, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom
**Submitted by:** Stuart Langridge
**Website:** https://nq64.co.uk/birmingham/

### Description
A bar full of arcade machines both new and old, and a whole bunch of wired up consoles as well.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 340
**File:** `content/daytrip/eu/gb/nq64-arcade-bar.md`

Please review this venue submission and edit the content as needed before merging.