### PR TITLE
New: Dark Sky Park "De Boschplaat" from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/dark-sky-park-de-boschplaat.md
+++ b/content/daytrip/eu/nl/dark-sky-park-de-boschplaat.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/nl/dark-sky-park-de-boschplaat"
+date: "2025-06-09T19:21:16.399Z"
+poster: "Frederik Dekker"
+lat: "53.408461"
+lng: "5.394373"
+location: "Dwarsdijk, Oosterend (FRL), 8897 HE, The Netherlands"
+title: "Dark Sky Park "De Boschplaat""
+external_url: https://darkskyterschelling.nl/
+---
+Due to its high population density, the Netherlands has a lot of light pollution and the night sky is not very well visible in most places. The Boschplaat nature reserve however is as far away from human settlement as you can get in the Netherlands. Here you can see the stars and the milky way so well that it is officially recognized as a dark sky park. The nature reserve is open 24 h/day.
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dark Sky Park "De Boschplaat"
**Location:** Dwarsdijk, Oosterend (FRL), 8897 HE, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://darkskyterschelling.nl/

### Description
Due to its high population density, the Netherlands has a lot of light pollution and the night sky is not very well visible in most places. The Boschplaat nature reserve however is as far away from human settlement as you can get in the Netherlands. Here you can see the stars and the milky way so well that it is officially recognized as a dark sky park. The nature reserve is open 24 h/day.



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 341
**File:** `content/daytrip/eu/nl/dark-sky-park-de-boschplaat.md`

Please review this venue submission and edit the content as needed before merging.