### PR TITLE
New: Dark Sky Park "Lauwersmeer" from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/dark-sky-park-lauwersmeer.md
+++ b/content/daytrip/eu/nl/dark-sky-park-lauwersmeer.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/dark-sky-park-lauwersmeer"
+date: "2025-06-09T19:21:36.555Z"
+poster: "Frederik Dekker"
+lat: "53.385068"
+lng: "6.236018"
+location: "De Rug 1, 9976 VT, Lauwersoog, The Netherlands"
+title: "Dark Sky Park "Lauwersmeer""
+external_url: https://www.np-lauwersmeer.nl/het-lauwersmeer/dark-sky-park/
+---
+One of the darkest places in the Netherlands, in the Lauwersmeer nature reserve it is still possible to take a good look at the night sky including the milky way.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dark Sky Park "Lauwersmeer"
**Location:** De Rug 1, 9976 VT, Lauwersoog, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.np-lauwersmeer.nl/het-lauwersmeer/dark-sky-park/

### Description
One of the darkest places in the Netherlands, in the Lauwersmeer nature reserve it is still possible to take a good look at the night sky including the milky way.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 342
**File:** `content/daytrip/eu/nl/dark-sky-park-lauwersmeer.md`

Please review this venue submission and edit the content as needed before merging.