### PR TITLE
New: Aflsuitdijk Wadden Center from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/aflsuitdijk-wadden-center.md
+++ b/content/daytrip/eu/nl/aflsuitdijk-wadden-center.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/aflsuitdijk-wadden-center"
+date: "2025-06-09T20:34:14.274Z"
+poster: "Frederik Dekker"
+lat: "53.07344"
+lng: "5.340085"
+location: "Afsluitdijk 1c, 8752 TP, Kornwerderzand, The Netherlands"
+title: "Aflsuitdijk Wadden Center"
+external_url: https://afsluitdijkwaddencenter.nl/
+---
+Visitor center for the Wadden sea, the IJsselmeer, fish migration river (passing under the dike) and the Afsluitdijk. Explains both the civil enginieering side of the Afsluitdijk and the ecological aspects of the Wadden sea and IJsselmeer.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Aflsuitdijk Wadden Center
**Location:** Afsluitdijk 1c, 8752 TP, Kornwerderzand, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://afsluitdijkwaddencenter.nl/

### Description
Visitor center for the Wadden sea, the IJsselmeer, fish migration river (passing under the dike) and the Afsluitdijk. Explains both the civil enginieering side of the Afsluitdijk and the ecological aspects of the Wadden sea and IJsselmeer.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 343
**File:** `content/daytrip/eu/nl/aflsuitdijk-wadden-center.md`

Please review this venue submission and edit the content as needed before merging.