### PR TITLE
New: Kazemattenmuseum Kornwerderzand from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/kazemattenmuseum-kornwerderzand.md
+++ b/content/daytrip/eu/nl/kazemattenmuseum-kornwerderzand.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/kazemattenmuseum-kornwerderzand"
+date: "2025-06-09T20:34:30.866Z"
+poster: "Frederik Dekker"
+lat: "53.073364"
+lng: "5.333841"
+location: "Afsluitdijk 1c, 8752 TP, Kornwerderzand, The Netherlands"
+title: "Kazemattenmuseum Kornwerderzand"
+external_url: https://www.kazemattenmuseum.nl/en/
+---
+When the Afsluitdijk was built in 1932 it was not only a dam, but also an extra route invaders could take to reach Holland and Amsterdam. So they also built fortifications. In may 1940 when the Germans invaded these fortifications held out until the Netherlands were forced to surrender.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Kazemattenmuseum Kornwerderzand
**Location:** Afsluitdijk 1c, 8752 TP, Kornwerderzand, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.kazemattenmuseum.nl/en/

### Description
When the Afsluitdijk was built in 1932 it was not only a dam, but also an extra route invaders could take to reach Holland and Amsterdam. So they also built fortifications. In may 1940 when the Germans invaded these fortifications held out until the Netherlands were forced to surrender.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 344
**File:** `content/daytrip/eu/nl/kazemattenmuseum-kornwerderzand.md`

Please review this venue submission and edit the content as needed before merging.