### PR TITLE
New: Delta Park Neeltje Jans from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/delta-park-neeltje-jans.md
+++ b/content/daytrip/eu/nl/delta-park-neeltje-jans.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/delta-park-neeltje-jans"
+date: "2025-06-09T20:34:53.713Z"
+poster: "Frederik Dekker"
+lat: "51.636876"
+lng: "3.711662"
+location: "Faelweg 5, 4354 RB, Vrouwenpolder, The Netherlands"
+title: "Delta Park Neeltje Jans"
+external_url: https://www.neeltjejans.nl/en/
+---
+Located on an artificial island that served as a construction base during the construction of the Oosterschelde barrier, Neeltje Jans is now a visitor center and theme park centered on the Delta Works that protect the Netherlands form the sea. The construction of the Delta works started after the flooding of Zeeland in 1953. Besides exhibitions the park also has a playground, storm simulator and marine wildlife.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Delta Park Neeltje Jans
**Location:** Faelweg 5, 4354 RB, Vrouwenpolder, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.neeltjejans.nl/en/

### Description
Located on an artificial island that served as a construction base during the construction of the Oosterschelde barrier, Neeltje Jans is now a visitor center and theme park centered on the Delta Works that protect the Netherlands form the sea. The construction of the Delta works started after the flooding of Zeeland in 1953. Besides exhibitions the park also has a playground, storm simulator and marine wildlife.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 345
**File:** `content/daytrip/eu/nl/delta-park-neeltje-jans.md`

Please review this venue submission and edit the content as needed before merging.