### PR TITLE
New: Wagner Free Institute of Science from Mike Cramer

### DIFF
--- a/content/daytrip/na/us/wagner-free-institute-of-science.md
+++ b/content/daytrip/na/us/wagner-free-institute-of-science.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/wagner-free-institute-of-science"
+date: "2025-06-09T20:46:43.100Z"
+poster: "Mike Cramer"
+lat: "39.980586"
+lng: "-75.162864"
+location: "Wagner Free Institute of Science, 1700, West Montgomery Avenue, Sharswood, North Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19121, United States"
+title: "Wagner Free Institute of Science"
+external_url: https://www.wagnerfreeinstitute.org/
+---
+A well preserved 19th century science museum filled with fossils, taxidermy, gems and bones. Free to visit. Occasional lectures and events. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wagner Free Institute of Science
**Location:** Wagner Free Institute of Science, 1700, West Montgomery Avenue, Sharswood, North Philadelphia, Philadelphia, Philadelphia County, Pennsylvania, 19121, United States
**Submitted by:** Mike Cramer
**Website:** https://www.wagnerfreeinstitute.org/

### Description
A well preserved 19th century science museum filled with fossils, taxidermy, gems and bones. Free to visit. Occasional lectures and events. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 346
**File:** `content/daytrip/na/us/wagner-free-institute-of-science.md`

Please review this venue submission and edit the content as needed before merging.