### PR TITLE
New: The Castletown D-day centre from SimonB

### DIFF
--- a/content/daytrip/eu/gb/the-castletown-d-day-centre.md
+++ b/content/daytrip/eu/gb/the-castletown-d-day-centre.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/the-castletown-d-day-centre"
+date: "2025-06-10T07:42:01.961Z"
+poster: "SimonB"
+lat: "50.568458"
+lng: "-2.444018"
+location: "Admiralty Buildings, Castletown, Portland, Dorset, UK, DT5 1BD"
+title: "The Castletown D-day centre"
+external_url: https://ddaycentre.com/
+---
+An impressive collection of world war II artifacts, vehicles, weapons, etc that can be handled, and explored. Interaction is encouraged. Suitable for wet or dry weather and all ages.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Castletown D-day centre
**Location:** Admiralty Buildings, Castletown, Portland, Dorset, UK, DT5 1BD
**Submitted by:** SimonB
**Website:** https://ddaycentre.com/

### Description
An impressive collection of world war II artifacts, vehicles, weapons, etc that can be handled, and explored. Interaction is encouraged. Suitable for wet or dry weather and all ages.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 348
**File:** `content/daytrip/eu/gb/the-castletown-d-day-centre.md`

Please review this venue submission and edit the content as needed before merging.