### PR TITLE
New: De Havilland Monument from Simon Reap

### DIFF
--- a/content/daytrip/eu/gb/de-havilland-monument.md
+++ b/content/daytrip/eu/gb/de-havilland-monument.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/de-havilland-monument"
+date: "2025-06-10T09:32:37.225Z"
+poster: "Simon Reap"
+lat: "51.2960155225099"
+lng: "-1.33897918962935"
+location: "A34, Whitchurch RG28 7QA"
+title: "De Havilland Monument"
+external_url: https://www.hants.gov.uk/thingstodo/countryside/finder/dehavilland
+---
+This is a small stone monument to the place that Geoffrey De Havilland (of Gipsy Moth and Mosquito fame) took his first flight in 1910. It's on the edge of a field, about 50 metres from the A34. To get there, drive North on the A34 (North of the A303 and of Whitchurch), stay on it past the turning for Litchfield and Dunley, then stop in the first parking layby about 1.5 miles further on. There's a small sign at the southern end of the layby to the monument. I drove past this hundreds of times before I decided to stop - well worth the few minutes it took!


### PR DESCRIPTION
## New Venue Submission

**Venue:** De Havilland Monument
**Location:** A34, Whitchurch RG28 7QA
**Submitted by:** Simon Reap
**Website:** https://www.hants.gov.uk/thingstodo/countryside/finder/dehavilland

### Description
This is a small stone monument to the place that Geoffrey De Havilland (of Gipsy Moth and Mosquito fame) took his first flight in 1910. It's on the edge of a field, about 50 metres from the A34. To get there, drive North on the A34 (North of the A303 and of Whitchurch), stay on it past the turning for Litchfield and Dunley, then stop in the first parking layby about 1.5 miles further on. There's a small sign at the southern end of the layby to the monument. I drove past this hundreds of times before I decided to stop - well worth the few minutes it took!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 349
**File:** `content/daytrip/eu/gb/de-havilland-monument.md`

Please review this venue submission and edit the content as needed before merging.