### PR TITLE
New: City of Norwich Aviation Museum from Steve Engledow

### DIFF
--- a/content/daytrip/eu/gb/city-of-norwich-aviation-museum.md
+++ b/content/daytrip/eu/gb/city-of-norwich-aviation-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/city-of-norwich-aviation-museum"
+date: "2025-06-10T09:32:59.671Z"
+poster: "Steve Engledow"
+lat: "52.680603"
+lng: "1.273262"
+location: "City of Norwich Aviation Museum, Old Norwich Road, Horsham St. Faith and Newton St. Faith, Horsham St Faith, Norwich, Norfolk, England, NR10 3JF, United Kingdom"
+title: "City of Norwich Aviation Museum"
+external_url: https://www.cnam.org.uk/
+---
+Old aircraft, some of which you can clamber inside. It's directly opposite Norwich's small, yet _international_, airport.


### PR DESCRIPTION
## New Venue Submission

**Venue:** City of Norwich Aviation Museum
**Location:** City of Norwich Aviation Museum, Old Norwich Road, Horsham St. Faith and Newton St. Faith, Horsham St Faith, Norwich, Norfolk, England, NR10 3JF, United Kingdom
**Submitted by:** Steve Engledow
**Website:** https://www.cnam.org.uk/

### Description
Old aircraft, some of which you can clamber inside. It's directly opposite Norwich's small, yet _international_, airport.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 350
**File:** `content/daytrip/eu/gb/city-of-norwich-aviation-museum.md`

Please review this venue submission and edit the content as needed before merging.