### PR TITLE
New: Retro Replay from Steve Engledow

### DIFF
--- a/content/daytrip/eu/gb/retro-replay.md
+++ b/content/daytrip/eu/gb/retro-replay.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/retro-replay"
+date: "2025-06-10T09:33:45.421Z"
+poster: "Steve Engledow"
+lat: "52.62698"
+lng: "1.296458"
+location: "Retro Replay, 24-26, Castle Quarter, Norwich, Norfolk, England, NR1 3DD, United Kingdom"
+title: "Retro Replay"
+external_url: https://www.retro-replay.games/
+---
+It's an arcade full of videogames from the 80s and 90s and some more modern consoles too. It's a single price for all day entry and there's a bar serving drinks and snacks. Open til 10pm every day.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Retro Replay
**Location:** Retro Replay, 24-26, Castle Quarter, Norwich, Norfolk, England, NR1 3DD, United Kingdom
**Submitted by:** Steve Engledow
**Website:** https://www.retro-replay.games/

### Description
It's an arcade full of videogames from the 80s and 90s and some more modern consoles too. It's a single price for all day entry and there's a bar serving drinks and snacks. Open til 10pm every day.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 351
**File:** `content/daytrip/eu/gb/retro-replay.md`

Please review this venue submission and edit the content as needed before merging.