### PR TITLE
New: Nintendo Museum from popey

### DIFF
--- a/content/daytrip/as/jp/nintendo-museum.md
+++ b/content/daytrip/as/jp/nintendo-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/as/jp/nintendo-museum"
+date: "2025-06-10T10:31:30.791Z"
+poster: "popey"
+lat: "34.89257"
+lng: "135.784205"
+location: "Nintendo Museum, ujiogura station line, Oguracho, Uji, Kyoto Prefecture, 611-0042, Japan"
+title: "Nintendo Museum"
+external_url: https://museum.nintendo.com/en/index.html
+---
+Step into a real-life Mario universe at the Nintendo Museum in Japan. This interactive playground lets you spend digital coins to play classic games on giant controllers and retro consoles like the Nintendo 64. 
+
+Explore Nintendo's history through behind-the-scenes exhibits, get creative in a Japanese playing card workshop, and snap photos with iconic in-game items like the green Warp Pipe and Super Mushroom. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Nintendo Museum
**Location:** Nintendo Museum, ujiogura station line, Oguracho, Uji, Kyoto Prefecture, 611-0042, Japan
**Submitted by:** popey
**Website:** https://museum.nintendo.com/en/index.html

### Description
Step into a real-life Mario universe at the Nintendo Museum in Japan. This interactive playground lets you spend digital coins to play classic games on giant controllers and retro consoles like the Nintendo 64. 

Explore Nintendo's history through behind-the-scenes exhibits, get creative in a Japanese playing card workshop, and snap photos with iconic in-game items like the green Warp Pipe and Super Mushroom. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 352
**File:** `content/daytrip/as/jp/nintendo-museum.md`

Please review this venue submission and edit the content as needed before merging.