### PR TITLE
Trim England, Alba / Scotland, Cymru / Wales - from UK venues 

### DIFF
--- a/content/daytrip/eu/be/royal-belgian-institute-of-natural-sciences.md
+++ b/content/daytrip/eu/be/royal-belgian-institute-of-natural-sciences.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/be/royal-belgian-institute-of-natural-sciences"
 date: '2001-01-30T04:37:00'
 lat: '50.83647428150043'
 lng: '4.376491087036129'
-location: "Muséum des sciences naturelles de Belgique - Museum voor Natuurwetenschappen van België, Rue Vautier - Vautierstraat, Quartier européen - Europese Wijk, Bruxelles - Brussel, Brussel-Hoofdstad - Bruxelles-Capitale, Région de Bruxelles-Capitale - Brussels Hoofdstedelijk Gewest, 1000, België / Belgique / Belgien"
+location: "Museum for Natural Sciences of Belgium, Rue Vautier - Vautierstraat, European Quarter, Brussels, Brussels-Capital, 1000, Belgium"
 title: Royal Belgian Institute of Natural Sciences
 external_url: https://www.naturalsciences.be/fr
 ---

--- a/content/daytrip/eu/de/rendsburger-hochbrcke-mit-schwebefhre.md
+++ b/content/daytrip/eu/de/rendsburger-hochbrcke-mit-schwebefhre.md
@@ -4,7 +4,7 @@ date: "2025-06-02T17:11:51.046Z"
 poster: "MarcN"
 lat: "54.293567"
 lng: "9.682674"
-location: "Rendsburger Hochbrücke mit Schwebefähre, Am Kreishafen, Kreishafen, Rendsburg-Süd, Rendsburg, Kreis Rendsburg-Eckernförde, Schleswig-Holstein, 24768, Deutschland"
+location: "Rendsburger Hochbrücke mit Schwebefähre, Kreishafen, Rendsburg, Schleswig-Holstein, 24768, Deutschland"
 title: "Rendsburger Hochbrücke mit Schwebefähre"
 external_url: https://www.wsa-nord-ostsee-kanal.wsv.de/Webs/WSA/WSA-Nord-Ostsee-Kanal/DE/1_Wasserstrasse/2_Tunnel-Bruecken-Faehren/2_Bruecken_Schwebefaehre/1_EHB-RD_Schwebefaehre/6_Schwebefaehre/Schwebefaehre_node.html
 ---

--- a/content/daytrip/eu/fi/suomenlinna.md
+++ b/content/daytrip/eu/fi/suomenlinna.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/fi/suomenlinna"
 date: '2001-01-30T04:37:00'
 lat: '60.14493247488122'
 lng: '24.98318142111816'
-location: "Suomenlinnan linnoitus, Suomenlinnan huoltotunneli, Suomenlinna, Eteläinen suurpiiri, Helsinki, Helsingin seutukunta, Uusimaa, Manner-Suomi, 00140, Suomi / Finland"
+location: "Suomenlinnan linnoitus, Suomenlinnan huoltotunneli, Suomenlinna, Helsinki, Uusimaa, Manner-Suomi, 00140, Finland"
 title: Suomenlinna
 external_url: https://suomenlinna.fi/en/
 ---

--- a/content/daytrip/eu/gb/78-derngate.md
+++ b/content/daytrip/eu/gb/78-derngate.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/78-derngate"
 date: '2001-01-30T04:37:00'
 lat: '52.202016'
 lng: '-0.894286'
-location: Tarragon Way, Blacky More, East Hunsbury, Wootton, West Northamptonshire, England, NN4 0SF, United Kingdom
+location: Tarragon Way, Blacky More, East Hunsbury, Wootton, West Northamptonshire, NN4 0SF, United Kingdom
 title: 78 Derngate
 external_url: https://www.78derngate.org.uk
 ---

--- a/content/daytrip/eu/gb/adventure-valley.md
+++ b/content/daytrip/eu/gb/adventure-valley.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/adventure-valley"
 date: '2001-01-30T04:37:00'
 lat: '54.80711'
 lng: '-1.53963'
-location: Brasside, Framwellgate Moor, County Durham, North East, England, DH1 5SG, United Kingdom
+location: Brasside, Framwellgate Moor, County Durham, North East, DH1 5SG, United Kingdom
 title: Adventure Valley
 external_url: https://www.adventurevalley.co.uk
 ---

--- a/content/daytrip/eu/gb/alice-holt-forest-caf.md
+++ b/content/daytrip/eu/gb/alice-holt-forest-caf.md
@@ -4,7 +4,7 @@ date: '2025-05-31T15:36:48.378Z'
 poster: 'popey'
 lat: '51.168908'
 lng: '-0.839623'
-location: 'Alice Holt Forest Café, Hardings Road, Bucks Horn Oak, Binsted, East Hampshire, Hampshire, England, GU10 4LF, United Kingdom'
+location: 'Alice Holt Forest Café, Hardings Road, Bucks Horn Oak, Binsted, East Hampshire, Hampshire, GU10 4LF, United Kingdom'
 title: 'Alice Holt Forest Café'
 external_url: https://www.forestryengland.uk/alice-holt-forest
 ---

--- a/content/daytrip/eu/gb/amazing-hedge-puzzle.md
+++ b/content/daytrip/eu/gb/amazing-hedge-puzzle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/amazing-hedge-puzzle"
 date: '2001-01-30T04:37:00'
 lat: '51.85365'
 lng: '-2.64856'
-location: Court Cottage, B4164, Whitchurch, Herefordshire, England, HR9 6DA, United Kingdom
+location: Court Cottage, B4164, Whitchurch, Herefordshire, HR9 6DA, United Kingdom
 title: Amazing Hedge Puzzle
 external_url: https://www.mazes.co.uk
 ---

--- a/content/daytrip/eu/gb/amberley-museum-and-heritage-centre.md
+++ b/content/daytrip/eu/gb/amberley-museum-and-heritage-centre.md
@@ -4,7 +4,7 @@ date: '2025-06-02T04:04:50.826Z'
 poster: 'plett'
 lat: '50.899254'
 lng: '-0.537708'
-location: 'Amberley Museum and Heritage Centre, New Barn Road, Amberley, Horsham, West Sussex, England, BN18 9LT, United Kingdom'
+location: 'Amberley Museum and Heritage Centre, New Barn Road, Amberley, Horsham, West Sussex, BN18 9LT, United Kingdom'
 title: 'Amberley Museum and Heritage Centre'
 external_url: https://www.amberleymuseum.co.uk/
 ---

--- a/content/daytrip/eu/gb/amelia-earhart-memorial.md
+++ b/content/daytrip/eu/gb/amelia-earhart-memorial.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/amelia-earhart-memorial"
 date: '2001-01-30T04:37:00'
 lat: '51.685388'
 lng: '-4.249048'
-location: Sandhills Bar, 1, Gors Road, Pembrey and Burry Port Town, Burry Port, Sir Gaerfyrddin / Carmarthenshire, Cymru / Wales, SA16 0EL, United Kingdom
+location: Sandhills Bar, 1, Gors Road, Pembrey and Burry Port Town, Burry Port, Sir Gaerfyrddin / Carmarthenshire, SA16 0EL, United Kingdom
 title: Amelia Earhart Memorial
 external_url: https://pembreyburryport-tc.co.uk/whats-on/listing/amelia-earhart-monument/
 ---

--- a/content/daytrip/eu/gb/american-museum.md
+++ b/content/daytrip/eu/gb/american-museum.md
@@ -3,8 +3,8 @@ slug: "daytrip/eu/gb/american-museum"
 date: '2001-01-30T04:37:00'
 lat: '51.37527493660226'
 lng: '-2.310856801910404'
-location: Claverton Hill, Claverton, Bath, Bath and North East Somerset, West of England,
-  England, BA2 7BE, United Kingdom
+location: Claverton Hill, Claverton, Bath, Bath and North East Somerset, West of
+  BA2 7BE, United Kingdom
 title: American Museum
 external_url: https://www.americanmuseum.org
 ---

--- a/content/daytrip/eu/gb/another-place.md
+++ b/content/daytrip/eu/gb/another-place.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/another-place"
 date: '2001-01-30T04:37:00'
 lat: '53.478940208465474'
 lng: '-3.045889360351566'
-location: Sefton Coastal Path, Brighton le Sands, Crosby, Sefton, Liverpool City Region, England, L22 6QQ, United Kingdom
+location: Sefton Coastal Path, Brighton le Sands, Crosby, Sefton, Liverpool City Region, L22 6QQ, United Kingdom
 title: Another Place
 external_url: https://www.sefton.gov.uk/around-sefton/another-place-by-antony-gormley/
 ---

--- a/content/daytrip/eu/gb/argylls-lodge.md
+++ b/content/daytrip/eu/gb/argylls-lodge.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/argylls-lodge"
 date: '2001-01-30T04:37:00'
 lat: '56.121945555821725'
 lng: '-3.9440488815307617'
-location: Upper Castlehill, Top of the Town, Old Town, Stirling, Alba / Scotland, FK8 1EH, United Kingdom
+location: Upper Castlehill, Top of the Town, Old Town, Stirling, FK8 1EH, United Kingdom
 title: Argyll's Lodging
 external_url: https://www.stirlingcityheritagetrust.org/explore-historic-stirling/argylls-lodging
 ---

--- a/content/daytrip/eu/gb/bagshaw-museum.md
+++ b/content/daytrip/eu/gb/bagshaw-museum.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/bagshaw-museum"
 date: '2001-01-30T04:37:00'
 lat: '53.72782030480945'
 lng: '-1.6453742980957031'
-location: Bagshaw Museum, Woodlands Road, Brookroyd, Batley, Kirklees, West Yorkshire, England, WF17 0RE, United Kingdom
+location: Bagshaw Museum, Woodlands Road, Brookroyd, Batley, Kirklees, West Yorkshire, WF17 0RE, United Kingdom
 title: Bagshaw Museum
 external_url: https://www.kirklees.gov.uk/beta/museums-and-galleries/bagshaw-museum.aspx
 ---

--- a/content/daytrip/eu/gb/bannockburn-heritage-centre.md
+++ b/content/daytrip/eu/gb/bannockburn-heritage-centre.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/bannockburn-heritage-centre"
 date: '2001-01-30T04:37:00'
 lat: '56.092498'
 lng: '-3.935144'
-location: 101, Glasgow Road, Borestone, St Ninians, Stirling, Alba / Scotland, FK7 0PQ, United Kingdom
+location: 101, Glasgow Road, Borestone, St Ninians, Stirling, FK7 0PQ, United Kingdom
 title: Bannockburn Heritage Centre
 external_url: https://www.nts.org.uk/visit/places/bannockburn/
 ---

--- a/content/daytrip/eu/gb/barnard-castle.md
+++ b/content/daytrip/eu/gb/barnard-castle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/barnard-castle"
 date: '2001-01-30T04:37:00'
 lat: '54.5439076'
 lng: '-1.9255707'
-location: Barnard Castle Grounds, Bridgegate, Barnard Castle, County Durham, North East, England, DL12 9BE, United Kingdom
+location: Barnard Castle Grounds, Bridgegate, Barnard Castle, County Durham, North East, DL12 9BE, United Kingdom
 title: Barnard Castle
 external_url: https://www.english-heritage.org.uk/visit/places/barnard-castle/
 ---

--- a/content/daytrip/eu/gb/barra-airport.md
+++ b/content/daytrip/eu/gb/barra-airport.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/barra-airport"
 date: '2001-01-30T04:37:00'
 lat: '57.02606342507703'
 lng: '-7.442792979098499'
-location: "Suidheachan, Eòlaigearraidh, Na h-Eileanan Siar, Alba / Scotland, HS9 5YD, United Kingdom"
+location: "Suidheachan, Eòlaigearraidh, Na h-Eileanan Siar, HS9 5YD, United Kingdom"
 title: Barra Airport
 external_url: https://www.hial.co.uk/barra-airport
 ---

--- a/content/daytrip/eu/gb/barra-head-lighthouse.md
+++ b/content/daytrip/eu/gb/barra-head-lighthouse.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/barra-head-lighthouse"
 date: '2001-01-30T04:37:00'
 lat: '56.785420'
 lng: '-7.653469'
-location: Alba / Scotland, United Kingdom
+location: United Kingdom
 title: Barra Head Lighthouse
 external_url: https://www.nlb.org.uk/lighthouses/barra-head/
 ---

--- a/content/daytrip/eu/gb/bentley-miniature-railway.md
+++ b/content/daytrip/eu/gb/bentley-miniature-railway.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/bentley-miniature-railway"
 date: '2001-01-30T04:37:00'
 lat: '50.923490546802256'
 lng: '0.11229910190581904'
-location: The Broyle, Turnpike Farm, Ringmer, Broyle Side, Wealden, East Sussex, England, BN8 5NP, United Kingdom
+location: The Broyle, Turnpike Farm, Ringmer, Broyle Side, Wealden, East Sussex, BN8 5NP, United Kingdom
 title: Bentley Miniature Railway
 external_url: https://www.bentleyrailway.co.uk
 ---

--- a/content/daytrip/eu/gb/birmingham-city-centre-gardens.md
+++ b/content/daytrip/eu/gb/birmingham-city-centre-gardens.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/birmingham-city-centre-gardens
 date: 2025-05-25T11:02:30
 lat: 52.4802501
 lng: -1.9091485
-location: Cambridge Street, Ladywood, Park Central, Birmingham, West Midlands, England, B1 2EP, United Kingdom
+location: Cambridge Street, Ladywood, Park Central, Birmingham, West Midlands, B1 2EP, United Kingdom
 title: Birmingham City Centre Gardens
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/birmingham-indoor-market.md
+++ b/content/daytrip/eu/gb/birmingham-indoor-market.md
@@ -3,7 +3,7 @@ slug: 'daytrip/eu/gb/birmingham-indoor-market'
 date: '2025-05-25T20:01:00+01:00'
 lat: '52.4759204'
 lng: '-1.89540515'
-location: 'Birmingham Indoor Market, Edgbaston Street, Bullring, Vauxhall, Park Central, Birmingham, West Midlands, England, B5 4RQ, United Kingdom'
+location: 'Birmingham Indoor Market, Edgbaston Street, Bullring, Vauxhall, Park Central, Birmingham, West Midlands, B5 4RQ, United Kingdom'
 title: 'Birmingham Indoor Market'
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/birmingham-museum-art-gallery.md
+++ b/content/daytrip/eu/gb/birmingham-museum-art-gallery.md
@@ -3,7 +3,7 @@ slug: 'daytrip/eu/gb/birmingham-museum-art-gallery'
 date: '2025-05-25T19:56:31+01:00'
 lat: '52.4804297'
 lng: '-1.90324985'
-location: 'Birmingham Museum & Art Gallery, Chamberlain Square, Chinese Quarter, Ladywood, Park Central, Birmingham, West Midlands, England, B3 3DH, United Kingdom'
+location: 'Birmingham Museum & Art Gallery, Chamberlain Square, Chinese Quarter, Ladywood, Park Central, Birmingham, West Midlands, B3 3DH, United Kingdom'
 title: 'Birmingham Museum & Art Gallery'
 external_url: https://www.birminghammuseums.org.uk/birmingham-museum-and-art-gallery
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/black-mountain-quarries.md
+++ b/content/daytrip/eu/gb/black-mountain-quarries.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/black-mountain-quarries"
 date: '2001-01-30T04:37:00'
 lat: '51.85450723871657'
 lng: '-3.8389649218750037'
-location: Black Mountain Quarries Walk, Llangadog, Sir Gaerfyrddin / Carmarthenshire, Cymru / Wales, SA19 9PA, United Kingdom
+location: Black Mountain Quarries Walk, Llangadog, Sir Gaerfyrddin / Carmarthenshire, SA19 9PA, United Kingdom
 title: Black Mountain Quarries
 external_url: https://beacons-npa.gov.uk/planning/heritage2/heritage-hotspots/black-mountain-quarries/
 ---

--- a/content/daytrip/eu/gb/black-sabbath-bridge.md
+++ b/content/daytrip/eu/gb/black-sabbath-bridge.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/black-sabbath-bridge
 date: 2025-05-25T10:43:58
 lat: 52.4778489
 lng: -1.9109452
-location: Black Sabbath, Broad Street, Ladywood, Park Central, Birmingham, West Midlands, England, B1 2HP, United Kingdom
+location: Black Sabbath, Broad Street, Ladywood, Park Central, Birmingham, West Midlands, B1 2HP, United Kingdom
 title: Black Sabbath Bridge
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/bloom-street-power-station.md
+++ b/content/daytrip/eu/gb/bloom-street-power-station.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/bloom-street-power-station"
 date: '2001-01-30T04:37:00'
 lat: '53.476260051233496'
 lng: '-2.239418847007755'
-location: Bloom Street, Petersfield, City Centre, Manchester, Greater Manchester, England, M1 6JX, United Kingdom
+location: Bloom Street, Petersfield, City Centre, Manchester, Greater Manchester, M1 6JX, United Kingdom
 title: Bloom Street Power Station
 external_url: https://manchesterhistory.net/manchester/tours/tour6/area6page59.html
 ---

--- a/content/daytrip/eu/gb/bodelwyddan-castle.md
+++ b/content/daytrip/eu/gb/bodelwyddan-castle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/bodelwyddan-castle"
 date: '2001-01-30T04:37:00'
 lat: '53.260527'
 lng: '-3.502809'
-location: Bodelwyddan Castle, Engine Hill, Glascoed, Bodelwyddan, Denbighshire, Cymru / Wales, LL18 5YD, United Kingdom
+location: Bodelwyddan Castle, Engine Hill, Glascoed, Bodelwyddan, Denbighshire, LL18 5YD, United Kingdom
 title: Bodelwyddan Castle
 external_url: https://www.bodelwyddan.org.uk/history-of-bodelwyddan/
 ---

--- a/content/daytrip/eu/gb/boulton-watt-murdoch-statue.md
+++ b/content/daytrip/eu/gb/boulton-watt-murdoch-statue.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/boulton-watt-murdoch-statue"
 date: '2001-01-30T04:37:00'
 lat: '52.47864211591314'
 lng: '-1.909093309803109'
-location: Centenary Square, Ladywood, Park Central, Birmingham, West Midlands, England, B1 2NR, United Kingdom
+location: Centenary Square, Ladywood, Park Central, Birmingham, West Midlands, B1 2NR, United Kingdom
 title: Boulton, Watt, and Murdoch statue
 external_url: https://www.birmingham.gov.uk/info/50050/culture_arts_and_heritage/190/statues_and_public_art/2
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/bowes-railway.md
+++ b/content/daytrip/eu/gb/bowes-railway.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/bowes-railway
 date: '2001-01-30T04:37:00'
 lat: 54.923511
 lng: -1.557248
-location: Springwell Road, Tyne and Wear, England, NE9 7QG, United Kingdom
+location: Springwell Road, Tyne and Wear, NE9 7QG, United Kingdom
 external_url: https://bowesrailway.uk
 title: Bowes Railway
 ---

--- a/content/daytrip/eu/gb/brambleton-model-railway.md
+++ b/content/daytrip/eu/gb/brambleton-model-railway.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/brambleton-model-railway"
 date: '2001-01-30T04:37:00'
 lat: '51.82507472308233'
 lng: '-0.35642765228271855'
-location: Brambleton Model Railway Club, The Nickey Line, Roundwood, Harpenden, St Albans, Hertfordshire, England, AL5 4AY, United Kingdom
+location: Brambleton Model Railway Club, The Nickey Line, Roundwood, Harpenden, St Albans, Hertfordshire, AL5 4AY, United Kingdom
 title: Brambleton Model Railway
 external_url: https://www.brambleton.org.uk
 ---

--- a/content/daytrip/eu/gb/branston-waterpark.md
+++ b/content/daytrip/eu/gb/branston-waterpark.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/branston-waterpark"
 date: '2001-01-30T04:37:00'
 lat: '52.7808460'
 lng: '-1.6821446'
-location: Ferroli, Lichfield Road, Branston, East Staffordshire, Staffordshire, England, DE14 3HD, United Kingdom
+location: Ferroli, Lichfield Road, Branston, East Staffordshire, Staffordshire, DE14 3HD, United Kingdom
 title: Branston Waterpark
 external_url: https://www.eaststaffsbc.gov.uk/parks-and-open-spaces/branston-water-park
 ---

--- a/content/daytrip/eu/gb/brecon-forest-tramroad.md
+++ b/content/daytrip/eu/gb/brecon-forest-tramroad.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/brecon-forest-tramroad"
 date: '2001-01-30T04:37:00'
 lat: '51.79266345814947'
 lng: '-3.663870317382816'
-location: Dol Henrhyd, Coelbren, Powys, Cymru / Wales, SA10 9PG, United Kingdom
+location: Dol Henrhyd, Coelbren, Powys, SA10 9PG, United Kingdom
 title: Brecon Forest Tramroad
 external_url: https://www.fforestfawrgeopark.org.uk/understanding/archaeology-and-industrial-heritage/transport-by-road-rail-and-water/the-brecon-forest-tramroad/
 ---

--- a/content/daytrip/eu/gb/brynich-aqueduct.md
+++ b/content/daytrip/eu/gb/brynich-aqueduct.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/brynich-aqueduct"
 date: '2001-01-30T04:37:00'
 lat: '51.93657782213868'
 lng: '-3.3408465213012732'
-location: Cefn Brynich Canal Bridge Aqueduct, A40, Llanhamlach, Llanfrynach, Groesffordd, Powys, Cymru / Wales, LD3 7SU, United Kingdom
+location: Cefn Brynich Canal Bridge Aqueduct, A40, Llanhamlach, Llanfrynach, Groesffordd, Powys, LD3 7SU, United Kingdom
 title: Brynich Aqueduct
 external_url: https://ancientmonuments.uk/128305-brynich-aqueduct-brecknock-abergavenny-canal-llanfrynach
 ---

--- a/content/daytrip/eu/gb/buttertubs-pass.md
+++ b/content/daytrip/eu/gb/buttertubs-pass.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/buttertubs-pass"
 date: '2001-01-30T04:37:00'
 lat: '54.35514'
 lng: '-2.20486'
-location: A684, Gayle, Hawes, North Yorkshire, York and North Yorkshire, England, DL8 3LQ, United Kingdom
+location: A684, Gayle, Hawes, North Yorkshire, York and North Yorkshire, DL8 3LQ, United Kingdom
 title: Buttertubs pass
 external_url: https://www.yorkshiredales.org.uk/places/buttertubs_pass/
 ---

--- a/content/daytrip/eu/gb/cadbury-world.md
+++ b/content/daytrip/eu/gb/cadbury-world.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/cadbury-world"
 date: '2001-01-30T04:37:00'
 lat: '52.429796518543824'
 lng: '-1.932456118507389'
-location: Cadbury World, The Birdcage Walk, Bournville, Stirchley, Birmingham, West Midlands, England, B30 1JR, United Kingdom
+location: Cadbury World, The Birdcage Walk, Bournville, Stirchley, Birmingham, West Midlands, B30 1JR, United Kingdom
 title: Cadbury World
 external_url: https://www.cadburyworld.co.uk
 ---

--- a/content/daytrip/eu/gb/cafe-wall-illusion.md
+++ b/content/daytrip/eu/gb/cafe-wall-illusion.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/cafe-wall-illusion"
 date: '2001-01-30T04:37:00'
 lat: '51.4569336404392'
 lng: '-2.597649318618778'
-location: 808, 19-20, Perry Road, Old City, City Centre, Bristol, City of Bristol, West of England, England, BS1 5BG, United Kingdom
+location: 808, 19-20, Perry Road, Old City, City Centre, Bristol, City of Bristol, West of BS1 5BG, United Kingdom
 title: Cafe Wall Illusion
 external_url: https://www.bristol247.com/news-and-features/features/current-custodians-cafe-wall-illusion/
 ---

--- a/content/daytrip/eu/gb/canada-tips.md
+++ b/content/daytrip/eu/gb/canada-tips.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/canada-tips"
 date: '2001-01-30T04:37:00'
 lat: '51.79692349307595'
 lng: '-3.10322426025391'
-location: The Dyne-Steel Incline, Blaenavon, Torfaen, Cymru / Wales, NP4 9SS, United Kingdom
+location: The Dyne-Steel Incline, Blaenavon, Torfaen, NP4 9SS, United Kingdom
 title: Canada Tips
 external_url: https://heneb.org.uk/hcla/blaenavon/canada-tips-and-blaen-pig/
 ---

--- a/content/daytrip/eu/gb/castell-dinas-brân.md
+++ b/content/daytrip/eu/gb/castell-dinas-brân.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/castell-dinas-brân"
 date: '2001-01-30T04:37:00'
 lat: '51.96324030742324'
 lng: '-3.195578081054691'
-location: Castell Dinas Brân, A479, Pen-y-wern, Talgarth, Powys, Cymru / Wales, LD3 0ER, United Kingdom
+location: Castell Dinas Brân, A479, Pen-y-wern, Talgarth, Powys, LD3 0ER, United Kingdom
 title: Castell Dinas Brân
 external_url: https://www.clwydianrangeanddeevalleyaonb.org.uk/projects/dinas-bran/
 ---

--- a/content/daytrip/eu/gb/castle-campbell.md
+++ b/content/daytrip/eu/gb/castle-campbell.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/castle-campbell"
 date: '2001-01-30T04:37:00'
 lat: '56.17483'
 lng: '-3.67471'
-location: Hillfoots Road, Dollar, Clackmannanshire, Alba / Scotland, FK14 7PL, United Kingdom
+location: Hillfoots Road, Dollar, Clackmannanshire, FK14 7PL, United Kingdom
 title: Castle Campbell
 external_url: https://www.historicenvironment.scot/visit-a-place/places/castle-campbell/overview/
 ---

--- a/content/daytrip/eu/gb/castle-carr.md
+++ b/content/daytrip/eu/gb/castle-carr.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/castle-carr"
 date: '2001-01-30T04:37:00'
 lat: '53.76558'
 lng: '-1.96321'
-location: Castle Carr Road, Lower Saltonstall, Wainstalls, Calderdale, West Yorkshire, England, HX2 7TR, United Kingdom
+location: Castle Carr Road, Lower Saltonstall, Wainstalls, Calderdale, West Yorkshire, HX2 7TR, United Kingdom
 title: Castle Carr
 external_url: https://www.calderdale.gov.uk/wtw/search/controlservlet?PageId=Detail&DocId=101925
 ---

--- a/content/daytrip/eu/gb/castleshaw-roman-fort.md
+++ b/content/daytrip/eu/gb/castleshaw-roman-fort.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/castleshaw-roman-fort"
 date: '2001-01-30T04:37:00'
 lat: '53.583278612622905'
 lng: '-2.0033093518447913'
-location: Rigodunum Roman Fort, Dirty Lane, Castleshaw, Saddleworth, Oldham, Greater Manchester, England, OL3 5HS, United Kingdom
+location: Rigodunum Roman Fort, Dirty Lane, Castleshaw, Saddleworth, Oldham, Greater Manchester, OL3 5HS, United Kingdom
 title: Castleshaw Roman fort
 external_url: https://www.castleshawarchaeology.co.uk
 ---

--- a/content/daytrip/eu/gb/cathedral-church-of-saint-philip.md
+++ b/content/daytrip/eu/gb/cathedral-church-of-saint-philip.md
@@ -3,7 +3,7 @@ slug: 'daytrip/eu/gb/cathedral-church-of-saint-philip'
 date: '2025-05-25T19:59:43+01:00'
 lat: '52.48117875'
 lng: '-1.8989031500000002'
-location: 'Cathedral Church of Saint Philip, Colmore Row, Digbeth, Park Central, Birmingham, West Midlands, England, B3 2QB, United Kingdom'
+location: 'Cathedral Church of Saint Philip, Colmore Row, Digbeth, Park Central, Birmingham, West Midlands, B3 2QB, United Kingdom'
 title: 'Cathedral Church of Saint Philip'
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/chained-library.md
+++ b/content/daytrip/eu/gb/chained-library.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/chained-library"
 date: '2001-01-30T04:37:00'
 lat: '50.79895601850151'
 lng: '-1.9881655997467078'
-location: Minster of St. Cuthburga, High Street, East Brook, Wimborne Minster, Dorset, England, BH21 1HT, United Kingdom
+location: Minster of St. Cuthburga, High Street, East Brook, Wimborne Minster, Dorset, BH21 1HT, United Kingdom
 title: Chained Library
 external_url: http://www.wimborneminster.org.uk/137/visitor-information.html
 ---

--- a/content/daytrip/eu/gb/chamberlain-clock.md
+++ b/content/daytrip/eu/gb/chamberlain-clock.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/chamberlain-clock
 date: 2025-05-25T10:20:56
 lat: 52.4870085
 lng: -1.9125779
-location: Chamberlain Clock, Vyse Street, Jewellery Quarter, Birmingham, West Midlands, England, B18 6LT, United Kingdom
+location: Chamberlain Clock, Vyse Street, Jewellery Quarter, Birmingham, West Midlands, B18 6LT, United Kingdom
 title: Chamberlain Clock
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/chance-counters.md
+++ b/content/daytrip/eu/gb/chance-counters.md
@@ -4,7 +4,7 @@ date: "2025-06-09T19:19:29.673Z"
 poster: "Stuart Langridge"
 lat: "52.475458"
 lng: "-1.884368"
-location: "Chance & Counters, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom"
+location: "Chance & Counters, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, B9 4BG, United Kingdom"
 title: "Chance & Counters"
 external_url: https://www.chanceandcounters.com/birmingham/
 ---

--- a/content/daytrip/eu/gb/charlestown-lime-kilns.md
+++ b/content/daytrip/eu/gb/charlestown-lime-kilns.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/charlestown-lime-kilns"
 date: '2001-01-30T04:37:00'
 lat: '56.03563805394618'
 lng: '-3.503270370407108'
-location: Lime Kilns, East Harbour Road, Charlestown, Fife, Alba / Scotland, KY11 3EA, United Kingdom
+location: Lime Kilns, East Harbour Road, Charlestown, Fife, KY11 3EA, United Kingdom
 title: Charlestown Lime Kilns
 external_url: https://www.welcometofife.com/destination/limekilns--charlestown
 ---

--- a/content/daytrip/eu/gb/chepstow-castle.md
+++ b/content/daytrip/eu/gb/chepstow-castle.md
@@ -1,7 +1,7 @@
 ---
 slug: "daytrip/eu/gb/chepstow-castle.md"
 title: Chepstow Castle
-location: Chepstow Castle, Bridge Street, Chepstow, Monmouthshire, Cymru / Wales, NP16 5EZ, United Kingdom
+location: Chepstow Castle, Bridge Street, Chepstow, Monmouthshire, NP16 5EZ, United Kingdom
 poster: popey
 date: '2025-05-23T15:22:00+01:00'
 lat: '51.6441606'

--- a/content/daytrip/eu/gb/chesil-beach.md
+++ b/content/daytrip/eu/gb/chesil-beach.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/chesil-beach"
 date: '2001-01-30T04:37:00'
 lat: '50.62189973167613'
 lng: '-2.554251176757816'
-location: Langton Herring, Dorset, England, DT3 4HT, United Kingdom
+location: Langton Herring, Dorset, DT3 4HT, United Kingdom
 title: Chesil Beach
 external_url: http://www.chesilbeach.org/Chesil/
 ---

--- a/content/daytrip/eu/gb/chew-reservoir.md
+++ b/content/daytrip/eu/gb/chew-reservoir.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/chew-reservoir"
 date: '2001-01-30T04:37:00'
 lat: '53.513455838252746'
 lng: '-1.9481148547363318'
-location: Chew Road, Saddleworth, Oldham, Greater Manchester, England, OL3 7NE, United Kingdom
+location: Chew Road, Saddleworth, Oldham, Greater Manchester, OL3 7NE, United Kingdom
 title: Chew Reservoir
 external_url: https://en.wikipedia.org/wiki/Chew_Reservoir
 ---

--- a/content/daytrip/eu/gb/church-of-saint-peter-on-the-wall.md
+++ b/content/daytrip/eu/gb/church-of-saint-peter-on-the-wall.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/church-of-saint-peter-on-the-wall"
 date: '2001-01-30T04:37:00'
 lat: '51.735341'
 lng: '0.939910'
-location: Othona Saxon Shore Fort, East End Road, Bradwell-on-Sea, Maldon, Essex, England, CM0 7PN, United Kingdom
+location: Othona Saxon Shore Fort, East End Road, Bradwell-on-Sea, Maldon, Essex, CM0 7PN, United Kingdom
 title: Church of Saint-Peter-on-the-Wall
 external_url: https://www.bradwellchapel.org
 ---

--- a/content/daytrip/eu/gb/city-of-norwich-aviation-museum.md
+++ b/content/daytrip/eu/gb/city-of-norwich-aviation-museum.md
@@ -4,7 +4,7 @@ date: "2025-06-10T09:32:59.671Z"
 poster: "Steve Engledow"
 lat: "52.680603"
 lng: "1.273262"
-location: "City of Norwich Aviation Museum, Old Norwich Road, Horsham St. Faith and Newton St. Faith, Horsham St Faith, Norwich, Norfolk, England, NR10 3JF, United Kingdom"
+location: "City of Norwich Aviation Museum, Old Norwich Road, Horsham St. Faith and Newton St. Faith, Horsham St Faith, Norwich, Norfolk, NR10 3JF, United Kingdom"
 title: "City of Norwich Aviation Museum"
 external_url: https://www.cnam.org.uk/
 ---

--- a/content/daytrip/eu/gb/clockworks.md
+++ b/content/daytrip/eu/gb/clockworks.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/clockworks"
 date: '2001-01-30T04:37:00'
 lat: '52.926011429983554'
 lng: '-1.4786317176055945'
-location: John Smith's Clockmakers (closed), 27-29, Queen Street, Cathedral Quarter, Little Chester, Derby, East Midlands, England, DE1 3DS, United Kingdom
+location: John Smith's Clockmakers (closed), 27-29, Queen Street, Cathedral Quarter, Little Chester, Derby, East Midlands, DE1 3DS, United Kingdom
 title: Clockworks
 external_url: https://www.derbyshirehistoricbuildingstrust.org.uk/post/clock-works-is-running-out-of-time
 ---

--- a/content/daytrip/eu/gb/clun-castle.md
+++ b/content/daytrip/eu/gb/clun-castle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/clun-castle"
 date: '2001-01-30T04:37:00'
 lat: '52.422168206043295'
 lng: '-3.0331274098587073'
-location: Clun Castle, B4368, Clun, Shropshire, England, SY7 8JQ, United Kingdom
+location: Clun Castle, B4368, Clun, Shropshire, SY7 8JQ, United Kingdom
 title: Clun Castle
 external_url: https://www.english-heritage.org.uk/visit/places/clun-castle/
 ---

--- a/content/daytrip/eu/gb/cole-museum-of-zoology.md
+++ b/content/daytrip/eu/gb/cole-museum-of-zoology.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.443533'
 lng: '-0.944628'
 location: University of Reading - Whiteknights Campus, Pepper Lane, Earley, Reading,
-  Wokingham, England, RG2 7DN, United Kingdom
+  Wokingham, RG2 7DN, United Kingdom
 title: Cole Museum of Zoology
 external_url: https://collections.reading.ac.uk/cole-museum/
 ---

--- a/content/daytrip/eu/gb/conisbrough-castle.md
+++ b/content/daytrip/eu/gb/conisbrough-castle.md
@@ -4,7 +4,7 @@ date: "2025-06-08T11:29:32.808Z"
 poster: "Robin"
 lat: "53.483825"
 lng: "-1.227168"
-location: "Conisbrough Castle, Castle Hill, Conanby, Conisbrough, Doncaster, South Yorkshire, England, DN12 3BU, United Kingdom"
+location: "Conisbrough Castle, Castle Hill, Conanby, Conisbrough, Doncaster, South Yorkshire, DN12 3BU, United Kingdom"
 title: "Conisbrough Castle"
 external_url: https://www.english-heritage.org.uk/visit/places/conisbrough-castle/
 ---

--- a/content/daytrip/eu/gb/cookworthy-forest.md
+++ b/content/daytrip/eu/gb/cookworthy-forest.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/cookworthy-forest"
 date: '2001-01-30T04:37:00'
 lat: '50.79599258809827'
 lng: '-4.241081697387699'
-location: Black Torrington, Torridge, Devon, Devon and Torbay, England, United Kingdom
+location: Black Torrington, Torridge, Devon, Devon and Torbay, United Kingdom
 title: Cookworthy Forest
 external_url: https://www.woodlandtrust.org.uk/visiting-woods/woods/cookworthy-forest/
 ---

--- a/content/daytrip/eu/gb/corfe-castle.md
+++ b/content/daytrip/eu/gb/corfe-castle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/corfe-castle"
 date: '2001-01-30T04:37:00'
 lat: '50.64149908677783'
 lng: '-2.059866411132816'
-location: Corfe Castle, Dorset, England, BH20 5DR, United Kingdom
+location: Corfe Castle, Dorset, BH20 5DR, United Kingdom
 title: Corfe Castle
 external_url: https://www.nationaltrust.org.uk/visit/dorset/corfe-castle
 ---

--- a/content/daytrip/eu/gb/cribarth.md
+++ b/content/daytrip/eu/gb/cribarth.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/cribarth"
 date: '2001-01-30T04:37:00'
 lat: '51.814251'
 lng: '-3.698203'
-location: Ynyswen, Pen y Cae, Powys, Cymru / Wales, SA9 1YT, United Kingdom
+location: Ynyswen, Pen y Cae, Powys, SA9 1YT, United Kingdom
 title: Cribarth
 external_url: https://www.fforestfawrgeopark.org.uk/enjoying/places-to-go/caves-and-kilns-delving-into-the-wild/cribarth/
 ---

--- a/content/daytrip/eu/gb/crinan-canal.md
+++ b/content/daytrip/eu/gb/crinan-canal.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/crinan-canal"
 date: '2001-01-30T04:37:00'
 lat: '56.01232'
 lng: '-5.44724'
-location: Seaside Park, Ardrishaig, Argyll and Bute, Alba / Scotland, PA30 8EB, United Kingdom
+location: Seaside Park, Ardrishaig, Argyll and Bute, PA30 8EB, United Kingdom
 title: Crinan Canal
 external_url: https://www.scottishcanals.co.uk/visit/canals/visit-the-crinan-canal
 ---

--- a/content/daytrip/eu/gb/crook-hall-gardens.md
+++ b/content/daytrip/eu/gb/crook-hall-gardens.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/crook-hall-gardens"
 date: '2001-01-30T04:37:00'
 lat: '54.7826012'
 lng: '-1.5752040'
-location: Frankland Lane, Claypath, City of Durham, Durham, County Durham, North East, England, DH1 5SZ, United Kingdom
+location: Frankland Lane, Claypath, City of Durham, Durham, County Durham, North East, DH1 5SZ, United Kingdom
 title: Crook Hall Gardens
 external_url: https://www.nationaltrust.org.uk/visit/north-east/crook-hall-gardens
 ---

--- a/content/daytrip/eu/gb/dale-abbey.md
+++ b/content/daytrip/eu/gb/dale-abbey.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/dale-abbey"
 date: '2001-01-30T04:37:00'
 lat: '52.944280'
 lng: '-1.350412'
-location: "Dale Abbey, Erewash, Derbyshire, East Midlands, England, DE7 4PN, United Kingdom"
+location: "Dale Abbey, Erewash, Derbyshire, East Midlands, DE7 4PN, United Kingdom"
 external_url: https://www.daleabbey.org.uk/index.html
 title: Dale Abbey
 ---

--- a/content/daytrip/eu/gb/derry-ormond-tower.md
+++ b/content/daytrip/eu/gb/derry-ormond-tower.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/derry-ormond-tower"
 date: '2001-01-30T04:37:00'
 lat: '52.145272'
 lng: '-4.062310'
-location: Llangybi, Betws Bledrws, Ceredigion, Cymru / Wales, SA48 8PA, United Kingdom
+location: Llangybi, Betws Bledrws, Ceredigion, SA48 8PA, United Kingdom
 title: Derry Ormond Tower
 external_url: https://en.wikipedia.org/wiki/Derry_Ormond_Tower
 ---

--- a/content/daytrip/eu/gb/devynock-and-sennybridge-station.md
+++ b/content/daytrip/eu/gb/devynock-and-sennybridge-station.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/devynock-and-sennybridge-station
 date: '2001-01-30T04:37:00'
 lat: '51.95377270821673'
 lng: '-3.5640063113403357'
-location: Sennybridge, Powys, Cymru / Wales, LD3 8TP, United Kingdom
+location: Sennybridge, Powys, LD3 8TP, United Kingdom
 external_url: https://coflein.gov.uk/en/site/34648/
 title: Former Devynock and Sennybridge Railway Station
 ---

--- a/content/daytrip/eu/gb/dinosaur-footprints.md
+++ b/content/daytrip/eu/gb/dinosaur-footprints.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/dinosaur-footprints"
 date: '2001-01-30T04:37:00'
 lat: '57.712011'
 lng: '-3.410214'
-location: Beach Terrace, Hopeman, Moray, Alba / Scotland, IV30 5RX, United Kingdom
+location: Beach Terrace, Hopeman, Moray, IV30 5RX, United Kingdom
 title: Dinosaur Footprints
 external_url: https://www.geograph.org.uk/photo/5156136
 ---

--- a/content/daytrip/eu/gb/durham-botanic-garden.md
+++ b/content/daytrip/eu/gb/durham-botanic-garden.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '54.7633589'
 lng: '-1.5746284'
 location: Grey College, South Road, Elvet, City of Durham, Durham, County Durham,
-  North East, England, DH1 3LG, United Kingdom
+  North East, DH1 3LG, United Kingdom
 external_url: https://www.durham.ac.uk/things-to-do/venues/botanic-garden/
 title: Durham Botanic Garden
 ---

--- a/content/daytrip/eu/gb/east-dundry-lane-viewpoint.md
+++ b/content/daytrip/eu/gb/east-dundry-lane-viewpoint.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/east-dundry-lane-viewpoint"
 date: '2001-01-30T04:37:00'
 lat: '51.39671450975749'
 lng: '-2.6242930418682135'
-location: East Dundry Lane, Dundry, North Somerset, England, BS41 8NA, United Kingdom
+location: East Dundry Lane, Dundry, North Somerset, BS41 8NA, United Kingdom
 title: East Dundry Lane Viewpoint
 ---
 

--- a/content/daytrip/eu/gb/electric-palace-cinema.md
+++ b/content/daytrip/eu/gb/electric-palace-cinema.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 51.946525
 lng: 1.288860
 location: The Old Vicarage, Kings Quay Street, Harwich, Dovercourt, Tendring, Essex,
-  England, CO12 3ES, United Kingdom
+  CO12 3ES, United Kingdom
 external_url: https://www.electricpalacecinema.com
 title: Electric Palace Cinema
 ---

--- a/content/daytrip/eu/gb/fan-bay-deep-shelter.md
+++ b/content/daytrip/eu/gb/fan-bay-deep-shelter.md
@@ -4,7 +4,7 @@ date: '2025-06-01T21:48:48.264Z'
 poster: 'plett'
 lat: '51.136367'
 lng: '1.360484'
-location: "Fan Bay Deep Shelter, Upper Road, West Cliffe, St. Margaret's at Cliffe, Dover, Kent, England, CT15 6HY, United Kingdom"
+location: "Fan Bay Deep Shelter, Upper Road, West Cliffe, St. Margaret's at Cliffe, Dover, Kent, CT15 6HY, United Kingdom"
 title: 'Fan Bay Deep Shelter'
 external_url: https://www.nationaltrust.org.uk/visit/kent/the-white-cliffs-of-dover/the-fan-bay-deep-shelter-project-at-the-white-cliffs-of-dover
 ---

--- a/content/daytrip/eu/gb/farnborough-air-science-trust-museum.md
+++ b/content/daytrip/eu/gb/farnborough-air-science-trust-museum.md
@@ -4,7 +4,7 @@ date: "2025-06-02T18:26:04.239Z"
 poster: "popey"
 lat: "51.282228"
 lng: "-0.753651"
-location: "Farnborough Air Science Trust Museum, Farnborough Road, Farnborough, Rushmoor, Hampshire, England, GU14 6TL, United Kingdom"
+location: "Farnborough Air Science Trust Museum, Farnborough Road, Farnborough, Rushmoor, Hampshire, GU14 6TL, United Kingdom"
 title: "Farnborough Air Science Trust Museum"
 external_url: https://airsciences.org.uk/about-fast/
 ---

--- a/content/daytrip/eu/gb/gainsborough-old-hall.md
+++ b/content/daytrip/eu/gb/gainsborough-old-hall.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '53.400691135899905'
 lng: '-0.7784678763580359'
 location: Gainsborough Old Hall, Parnell Street, Gainsborough CP, West Lindsey, Lincolnshire,
-  Greater Lincolnshire, England, DN21 2NB, United Kingdom
+  Greater Lincolnshire, DN21 2NB, United Kingdom
 external_url: https://www.english-heritage.org.uk/visit/places/gainsborough-old-hall/
 title: Gainsborough Old Hall
 ---

--- a/content/daytrip/eu/gb/goodrich-castle.md
+++ b/content/daytrip/eu/gb/goodrich-castle.md
@@ -1,7 +1,7 @@
 ---
 slug: "daytrip/eu/gb/goodrich-castle.md"
 title: Goodrich Castle
-location: Goodrich Castle, Castle Lane, Goodrich, Herefordshire, England, HR9 6HL, United Kingdom
+location: Goodrich Castle, Castle Lane, Goodrich, Herefordshire, HR9 6HL, United Kingdom
 poster: popey
 date: '2025-05-23T15:27:43+01:00'
 lat: '51.876734'

--- a/content/daytrip/eu/gb/grave-of-sir-arthur-conan-doyle.md
+++ b/content/daytrip/eu/gb/grave-of-sir-arthur-conan-doyle.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 50.896699
 lng: -1.601695
 location: All Saints, Rownhams Road, Brown Hill, North Baddesley, Southampton, Hampshire,
-  England, SO52 9PE, United Kingdom
+  SO52 9PE, United Kingdom
 external_url: https://www.findagrave.com/memorial/1524/arthur_conan-doyle
 title: Grave of Sir Arthur Conan Doyle
 ---

--- a/content/daytrip/eu/gb/greens-windmill.md
+++ b/content/daytrip/eu/gb/greens-windmill.md
@@ -4,7 +4,7 @@ date: "2025-06-02T08:55:58.047Z"
 poster: "Colin Beveridge"
 lat: "52.952098"
 lng: "-1.129386"
-location: "Green's Windmill, Belvoir Hill, Sneinton, Nottingham, East Midlands, England, NG2 4QB, United Kingdom"
+location: "Green's Windmill, Belvoir Hill, Sneinton, Nottingham, East Midlands, NG2 4QB, United Kingdom"
 title: "Green's Windmill"
 external_url: https://www.greensmill.org.uk/
 ---

--- a/content/daytrip/eu/gb/ham-hill.md
+++ b/content/daytrip/eu/gb/ham-hill.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/ham-hill"
 date: '2001-01-30T04:37:00'
 lat: '50.948327806089075'
 lng: '-2.743250352783207'
-location: Ham Hill Road, Stoke sub Hamdon, Somerset, England, TA14 6RL, United Kingdom
+location: Ham Hill Road, Stoke sub Hamdon, Somerset, TA14 6RL, United Kingdom
 external_url: https://www.historic-uk.com/HistoryMagazine/DestinationsUK/Ham-Hill-Somerset/
 title: Ham Hill
 ---

--- a/content/daytrip/eu/gb/hamsterley-forest.md
+++ b/content/daytrip/eu/gb/hamsterley-forest.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '54.6713666'
 lng: '-1.8900165'
 location: Forest Drive, Middle Redford, South Bedburn, County Durham, North East,
-  England, DL13 3NL, United Kingdom
+  DL13 3NL, United Kingdom
 external_url: https://www.forestryengland.uk/hamsterley-forest
 title: Hamsterly Forest
 ---

--- a/content/daytrip/eu/gb/hawley-common.md
+++ b/content/daytrip/eu/gb/hawley-common.md
@@ -4,7 +4,7 @@ date: "2025-06-02T06:54:53.758Z"
 poster: "popey"
 lat: "51.31635"
 lng: "-0.793772"
-location: "Hawley Common, Hawley, Hart, Hampshire, England, GU17 9HU, United Kingdom"
+location: "Hawley Common, Hawley, Hart, Hampshire, GU17 9HU, United Kingdom"
 title: "Hawley Common"
 external_url: https://www.hawleylake.org.uk/
 ---

--- a/content/daytrip/eu/gb/heckington-windmill.md
+++ b/content/daytrip/eu/gb/heckington-windmill.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 52.977040
 lng: -0.295279
 location: Hale Road, Heckington, Great Hale, North Kesteven, Lincolnshire, Greater
-  Lincolnshire, England, NG34 9JN, United Kingdom
+  Lincolnshire, NG34 9JN, United Kingdom
 external_url: https://www.heckingtonwindmill.org.uk
 title: Heckington windmill
 ---

--- a/content/daytrip/eu/gb/highclere-castle.md
+++ b/content/daytrip/eu/gb/highclere-castle.md
@@ -4,7 +4,7 @@ date: "2025-06-02T18:25:51.993Z"
 poster: "popey"
 lat: "51.326603"
 lng: "-1.360513"
-location: "Highclere Castle, Limetree Avenue, Highclere, Basingstoke and Deane, Hampshire, England, RG20 9RL, United Kingdom"
+location: "Highclere Castle, Limetree Avenue, Highclere, Basingstoke and Deane, Hampshire, RG20 9RL, United Kingdom"
 title: "Highclere Castle"
 external_url: https://www.highclerecastle.co.uk/
 ---

--- a/content/daytrip/eu/gb/hms-belfast.md
+++ b/content/daytrip/eu/gb/hms-belfast.md
@@ -4,7 +4,7 @@ date: '2025-06-01T14:37:57.491Z'
 poster: 'popey'
 lat: '51.506543'
 lng: '-0.081152'
-location: "HMS Belfast, The Queen's Walk, Bermondsey Village, The Borough, London Borough of Southwark, London, Greater London, England, SE1 2JH, United Kingdom"
+location: "HMS Belfast, The Queen's Walk, Bermondsey Village, The Borough, London Borough of Southwark, London, Greater London, SE1 2JH, United Kingdom"
 title: 'HMS Belfast'
 external_url: https://www.iwm.org.uk/visits/hms-belfast
 ---

--- a/content/daytrip/eu/gb/inverary-jail.md
+++ b/content/daytrip/eu/gb/inverary-jail.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/inverary-jail
 date: '2001-01-30T04:37:00'
 lat: '56.229754'
 lng: '-5.072197'
-location: A819, Inveraray, Argyll and Bute, Alba / Scotland, PA32 8XE, United Kingdom
+location: A819, Inveraray, Argyll and Bute, PA32 8XE, United Kingdom
 external_url: https://www.inverarayjail.co.uk
 title: Jail in Inverary
 ---

--- a/content/daytrip/eu/gb/kingsley-hall.md
+++ b/content/daytrip/eu/gb/kingsley-hall.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.52648653510894'
 lng: '-0.014499647064212695'
 location: Kingsley Hall Community Centre, Powis Road, Bromley-by-Bow, Bow, London
-  Borough of Tower Hamlets, London, Greater London, England, E3 3HJ, United Kingdom
+  Borough of Tower Hamlets, London, Greater London, E3 3HJ, United Kingdom
 external_url: https://www.towerhamletsarts.org.uk/?cat=6&cid=64736&guide=Venues
 title: Kingsley Hall
 ---

--- a/content/daytrip/eu/gb/les-oakes-place.md
+++ b/content/daytrip/eu/gb/les-oakes-place.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '52.991112910472914'
 lng: '-1.9701357907486'
 location: Hales View Farm, Oakamoor Road, Lightwood, Cheadle, Staffordshire Moorlands,
-  Staffordshire, England, ST10 4QR, United Kingdom
+  Staffordshire, ST10 4QR, United Kingdom
 external_url: https://www.visitstaffordshire.com/listing/les-oakes-%26-sons-architectural-reclamation-yard/234419101/
 title: Les Oakes Place
 ---

--- a/content/daytrip/eu/gb/littledean-jail.md
+++ b/content/daytrip/eu/gb/littledean-jail.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.82202430837907'
 lng: '-2.4755229777526893'
 location: Littledean Jail, Church Street, Littledean, Forest of Dean, Gloucestershire,
-  England, GL14 3NL, United Kingdom
+  GL14 3NL, United Kingdom
 external_url: https://www.littledeanjail.com
 title: Littledean Jail
 ---

--- a/content/daytrip/eu/gb/lostwithiel.md
+++ b/content/daytrip/eu/gb/lostwithiel.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/lostwithiel"
 date: '2001-01-30T04:37:00'
 lat: '50.407073277577055'
 lng: '-4.6693875617218055'
-location: Lostwithiel, Cornwall, England, PL22 0BL, United Kingdom
+location: Lostwithiel, Cornwall, PL22 0BL, United Kingdom
 external_url: https://www.lostwithiel.org.uk
 title: Lostwithiel
 ---

--- a/content/daytrip/eu/gb/ludlow-castle.md
+++ b/content/daytrip/eu/gb/ludlow-castle.md
@@ -1,7 +1,7 @@
 ---
 slug: "daytrip/eu/gb/ludlow-castle.md"
 title: Ludlow Castle
-location: Middle Wood Road, Ludlow, Shropshire, England, SY8 2JF, United Kingdom
+location: Middle Wood Road, Ludlow, Shropshire, SY8 2JF, United Kingdom
 poster: popey
 date: '2025-05-23T15:52:13'
 lat: '52.3671215'

--- a/content/daytrip/eu/gb/lumley-castle.md
+++ b/content/daytrip/eu/gb/lumley-castle.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '54.8532930'
 lng: '-1.5537309'
 location: Lumley Castle, Ropery Lane, Little Lumley, Chester-le-Street, County Durham,
-  North East, England, DH3 4NX, United Kingdom
+  North East, DH3 4NX, United Kingdom
 external_url: https://www.historichouses.org/house/lumley-castle/visit/
 title: Lumley Castle
 ---

--- a/content/daytrip/eu/gb/maes-knoll.md
+++ b/content/daytrip/eu/gb/maes-knoll.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 51.39241
 lng: -2.57505
 location: Norton Lane, Norton Hawkfield, Norton Malreward, Bath and North East Somerset,
-  West of England, England, BS39 4EZ, United Kingdom
+  West of BS39 4EZ, United Kingdom
 external_url: https://www.megalithic.co.uk/article.php?sid=8405
 title: Maes Knoll
 ---

--- a/content/daytrip/eu/gb/mill-house-cider-museum.md
+++ b/content/daytrip/eu/gb/mill-house-cider-museum.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/mill-house-cider-museum"
 date: '2001-01-30T04:37:00'
 lat: 50.683027
 lng: -2.321827
-location: 33 Moreton Road, Owermoigne, Dorchester, Dorset, England, DT2 8HZ, United Kingdom
+location: 33 Moreton Road, Owermoigne, Dorchester, Dorset, DT2 8HZ, United Kingdom
 external_url: https://www.millhousecider.com/cider-museum
 title: Mill House Cider Museum
 ---

--- a/content/daytrip/eu/gb/muncaster-castle-hawk-and-owl-centre.md
+++ b/content/daytrip/eu/gb/muncaster-castle-hawk-and-owl-centre.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/muncaster-castle-hawk-and-owl-centre
 date: '2001-01-30T04:37:00'
 lat: 54.355762
 lng: -3.380919
-location: A595, Muncaster, Cumberland, England, CA18 1RD, United Kingdom
+location: A595, Muncaster, Cumberland, CA18 1RD, United Kingdom
 external_url: https://www.muncaster.co.uk/hawkowlcentre
 title: Muncaster Castle Hawk and Owl Centre
 ---

--- a/content/daytrip/eu/gb/museum-of-making.md
+++ b/content/daytrip/eu/gb/museum-of-making.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/museum-of-making"
 date: '2001-01-30T04:37:00'
 lat: '52.92544872475761'
 lng: '-1.4757778472137488'
-location: Silk Mill Lane, Derby, East Midlands, England, DE1 3AF, United Kingdom
+location: Silk Mill Lane, Derby, East Midlands, DE1 3AF, United Kingdom
 title: Museum of Making
 external_url: https://derbymuseums.org/museum-of-making/visit/
 ---

--- a/content/daytrip/eu/gb/national-glass-centre.md
+++ b/content/daytrip/eu/gb/national-glass-centre.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '54.9127833'
 lng: '-1.3708812'
 location: National Glass Centre, Liberty Way, Monkwearmouth, Sunderland, North East,
-  England, SR6 0GL, United Kingdom
+  SR6 0GL, United Kingdom
 external_url: https://www.sunderlandculture.org.uk/national-glass-centre/
 title: National Glass Centre
 ---

--- a/content/daytrip/eu/gb/new-quay-honey-farm.md
+++ b/content/daytrip/eu/gb/new-quay-honey-farm.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/new-quay-honey-farm"
 date: '2001-01-30T04:37:00'
 lat: '52.182127720104624'
 lng: '-4.343220216674808'
-location: New Quay Honey Farm, Penrhiwgaled Lane, Pentre'r Bryn, Llanllwchaiarn, Llanlwchaiarn, Ceredigion, Cymru / Wales, SA44 6NS, United Kingdom
+location: New Quay Honey Farm, Penrhiwgaled Lane, Pentre'r Bryn, Llanllwchaiarn, Llanlwchaiarn, Ceredigion, SA44 6NS, United Kingdom
 external_url: https://www.afonmel.com/honey-farm/
 title: New Quay Honey Farm
 ---

--- a/content/daytrip/eu/gb/niche-comics.md
+++ b/content/daytrip/eu/gb/niche-comics.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/niche-comics"
 date: '2001-01-30T04:37:00'
 lat: 52.328265
 lng: -0.179534
-location: 147 High Street, Huntingdon, Cambridgeshire, England, PE29 3TF, United Kingdom
+location: 147 High Street, Huntingdon, Cambridgeshire, PE29 3TF, United Kingdom
 external_url: https://nichecomicsbooks.co.uk
 title: Niche Comics
 ---

--- a/content/daytrip/eu/gb/novelty-automation.md
+++ b/content/daytrip/eu/gb/novelty-automation.md
@@ -4,7 +4,7 @@ date: "2025-06-02T23:05:39.409Z"
 poster: "andypiper"
 lat: "51.51976"
 lng: "-0.116525"
-location: "Novelty Automation, 1a, Princeton Street, Gray's Inn, Holborn, London Borough of Camden, London, Greater London, England, WC1R 4AX, United Kingdom"
+location: "Novelty Automation, 1a, Princeton Street, Gray's Inn, Holborn, London Borough of Camden, London, Greater London, WC1R 4AX, United Kingdom"
 title: "Novelty Automation"
 external_url: https://www.novelty-automation.com/
 ---

--- a/content/daytrip/eu/gb/nq64-arcade-bar.md
+++ b/content/daytrip/eu/gb/nq64-arcade-bar.md
@@ -4,7 +4,7 @@ date: "2025-06-09T19:19:41.313Z"
 poster: "Stuart Langridge"
 lat: "52.475398"
 lng: "-1.884421"
-location: "NQ64 Arcade Bar, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4BG, United Kingdom"
+location: "NQ64 Arcade Bar, Gibb Street, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, B9 4BG, United Kingdom"
 title: "NQ64 Arcade Bar"
 external_url: https://nq64.co.uk/birmingham/
 ---

--- a/content/daytrip/eu/gb/oriel-davies-art-gallery.md
+++ b/content/daytrip/eu/gb/oriel-davies-art-gallery.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '52.514742'
 lng: '-3.317405'
 location: Oriel Davies Gallery, Back Lane, Penygloddfa, Newtown and Llanllwchaiarn,
-  Newtown, Powys, Cymru / Wales, SY16 2QZ, United Kingdom
+  Newtown, Powys, SY16 2QZ, United Kingdom
 external_url: https://orieldavies.org
 title: Oriel Davies Art Gallery
 ---

--- a/content/daytrip/eu/gb/pinchbeck-engine-museum.md
+++ b/content/daytrip/eu/gb/pinchbeck-engine-museum.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 52.818073
 lng: -0.129154
 location: West Marsh Road, Pinchbeck CP, South Holland, Lincolnshire, Greater Lincolnshire,
-  England, PE11 3UW, United Kingdom
+  PE11 3UW, United Kingdom
 external_url: https://www.wellandidb.org.uk/about-us/our-museum
 title: Pinchbeck Engine Museum
 ---

--- a/content/daytrip/eu/gb/portable-airship-hangar.md
+++ b/content/daytrip/eu/gb/portable-airship-hangar.md
@@ -4,7 +4,7 @@ date: '2025-05-31T12:33:34.565Z'
 poster: 'popey'
 lat: '51.284843'
 lng: '-0.760999'
-location: 'Portable Airship Hangar, Fowler Avenue, Farnborough Business Park, Farnborough, Rushmoor, Hampshire, England, GU14 7JF, United Kingdom'
+location: 'Portable Airship Hangar, Fowler Avenue, Farnborough Business Park, Farnborough, Rushmoor, Hampshire, GU14 7JF, United Kingdom'
 title: 'Portable Airship Hangar'
 external_url: https://historicengland.org.uk/listing/the-list/list-entry/1393074
 ---

--- a/content/daytrip/eu/gb/porthcurno-telegraph-museum.md
+++ b/content/daytrip/eu/gb/porthcurno-telegraph-museum.md
@@ -4,7 +4,7 @@ date: '2025-06-01T21:22:02.763Z'
 poster: 'plett'
 lat: '50.046744'
 lng: '-5.654957'
-location: 'Porthcurno Telegraph Museum, Penzance, Porthcurno, Cornwall, England, TR19 6JX, United Kingdom'
+location: 'Porthcurno Telegraph Museum, Penzance, Porthcurno, Cornwall, TR19 6JX, United Kingdom'
 title: 'Porthcurno Telegraph Museum'
 external_url: https://pkporthcurno.com/
 ---

--- a/content/daytrip/eu/gb/potteries-museum-and-art-gallery.md
+++ b/content/daytrip/eu/gb/potteries-museum-and-art-gallery.md
@@ -4,7 +4,7 @@ date: "2025-06-02T10:10:54.948Z"
 poster: "Robin"
 lat: "53.022874"
 lng: "-2.178046"
-location: "Potteries Museum and Art Gallery, Bethesda Street, Joiner's Square, Hanley, Stoke-on-Trent, England, ST1 3DW, United Kingdom"
+location: "Potteries Museum and Art Gallery, Bethesda Street, Joiner's Square, Hanley, Stoke-on-Trent, ST1 3DW, United Kingdom"
 title: "Potteries Museum and Art Gallery"
 external_url: https://www.stokemuseums.org.uk/pmag/
 ---

--- a/content/daytrip/eu/gb/queen-victoria.md
+++ b/content/daytrip/eu/gb/queen-victoria.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/queen-victoria
 date: 2025-05-25T10:11:43
 lat: 52.4796426
 lng: -1.9030116
-location: Queen Victoria, Victoria Square, Chinese Quarter, Ladywood, Park Central, Birmingham, West Midlands, England, B1 1BB, United Kingdom
+location: Queen Victoria, Victoria Square, Chinese Quarter, Ladywood, Park Central, Birmingham, West Midlands, B1 1BB, United Kingdom
 title: Queen Victoria
 external_url: http://www.birmingham.gov.uk/cs/Satellite?c=Page&childpagename=WT-General%2FPageLayout&cid=1223092626187&pagename=BCC%2FCommon%2FWrapper%2FWrapper
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/raf-denge-sound-mirrors.md
+++ b/content/daytrip/eu/gb/raf-denge-sound-mirrors.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 50.956838
 lng: 0.954705
 location: Romney Sands Holiday Park, Leonard Road, Lade, Lydd, Folkestone and Hythe,
-  Kent, England, TN28 8RN, United Kingdom
+  Kent, TN28 8RN, United Kingdom
 external_url: https://en.wikipedia.org/wiki/RAF_Denge
 title: RAF Denge Sound Mirrors
 ---

--- a/content/daytrip/eu/gb/raf-saxa-vord.md
+++ b/content/daytrip/eu/gb/raf-saxa-vord.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 60.82793
 lng: -0.84037
 location: Remote Radar Head Saxa Vord, Holsens Road, Braehead, Unst, Saxa Vord, Shetland
-  Islands, Alba / Scotland, ZE2 9EF, United Kingdom
+  Islands, ZE2 9EF, United Kingdom
 external_url: https://en.wikipedia.org/wiki/RRH_Saxa_Vord
 title: RAF Saxa Vord
 ---

--- a/content/daytrip/eu/gb/raf-stenigot-dishes.md
+++ b/content/daytrip/eu/gb/raf-stenigot-dishes.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '53.32894054610747'
 lng: '-0.11849879371641237'
 location: Manor Hill, Donington on Bain, East Lindsey, Lincolnshire, Greater Lincolnshire,
-  England, LN11 9RH, United Kingdom
+  LN11 9RH, United Kingdom
 title: RAF Stenigot Dishes
 external_url: https://en.wikipedia.org/wiki/RAF_Stenigot
 ---

--- a/content/daytrip/eu/gb/ravenglass-railway-laal-ratty.md
+++ b/content/daytrip/eu/gb/ravenglass-railway-laal-ratty.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/ravenglass-railway-laal-ratty"
 date: '2001-01-30T04:37:00'
 lat: 54.355987
 lng: -3.409013
-location: Ravenglass, Cumberland, England, CA19 1YY, United Kingdom
+location: Ravenglass, Cumberland, CA19 1YY, United Kingdom
 external_url: https://ravenglass-railway.co.uk
 title: "Ravenglass railway: La'al Ratty."
 ---

--- a/content/daytrip/eu/gb/redbournbury-water-mill-and-bakery.md
+++ b/content/daytrip/eu/gb/redbournbury-water-mill-and-bakery.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.78429595695628'
 lng: '-0.3797271780624669'
 location: Redbournbury Mill, Redbournbury Lane, Redbourn, St Albans, Hertfordshire,
-  England, AL3 6RS, United Kingdom
+  AL3 6RS, United Kingdom
 external_url: https://www.redbournburymill.co.uk
 title: Redbournbury Water Mill and Bakery
 ---

--- a/content/daytrip/eu/gb/retro-replay.md
+++ b/content/daytrip/eu/gb/retro-replay.md
@@ -4,7 +4,7 @@ date: "2025-06-10T09:33:45.421Z"
 poster: "Steve Engledow"
 lat: "52.62698"
 lng: "1.296458"
-location: "Retro Replay, 24-26, Castle Quarter, Norwich, Norfolk, England, NR1 3DD, United Kingdom"
+location: "Retro Replay, 24-26, Castle Quarter, Norwich, Norfolk, NR1 3DD, United Kingdom"
 title: "Retro Replay"
 external_url: https://www.retro-replay.games/
 ---

--- a/content/daytrip/eu/gb/retrodome.md
+++ b/content/daytrip/eu/gb/retrodome.md
@@ -4,7 +4,7 @@ date: '2025-05-31T14:48:53.286Z'
 poster: 'Retrodome'
 lat: '53.54889'
 lng: '-1.480485'
-location: 'Retrodome, Thomas Street, Worsbrough Common, Kingstone, Barnsley, South Yorkshire, England, S70 1LH, United Kingdom'
+location: 'Retrodome, Thomas Street, Worsbrough Common, Kingstone, Barnsley, South Yorkshire, S70 1LH, United Kingdom'
 title: 'Retrodome'
 external_url: https://retrodome.co.uk
 ---

--- a/content/daytrip/eu/gb/riccarton-junction.md
+++ b/content/daytrip/eu/gb/riccarton-junction.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/riccarton-junction"
 date: '2001-01-30T04:37:00'
 lat: 55.271305
 lng: -2.726337
-location: Riccarton Junction, Scottish Borders, Alba / Scotland, TD9 0NA, United Kingdom
+location: Riccarton Junction, Scottish Borders, TD9 0NA, United Kingdom
 external_url: https://en.wikipedia.org/wiki/Riccarton_Junction_railway_station
 title: Riccarton Junction
 ---

--- a/content/daytrip/eu/gb/rmc-cave.md
+++ b/content/daytrip/eu/gb/rmc-cave.md
@@ -1,7 +1,7 @@
 ---
 slug: "daytrip/eu/gb/rmc-cave"
 title: RMC Cave
-location: Renegade Retro Repairs, Belvedere Mews, Chalford Hill, Chalford, Stroud, Gloucestershire, England, GL6 8PF, United Kingdom
+location: Renegade Retro Repairs, Belvedere Mews, Chalford Hill, Chalford, Stroud, Gloucestershire, GL6 8PF, United Kingdom
 poster: popey
 date: '2025-05-23T13:21:55+01:00'
 lat: '51.720677'

--- a/content/daytrip/eu/gb/rothamsted-research.md
+++ b/content/daytrip/eu/gb/rothamsted-research.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.80937395163692'
 lng: '-0.3563222221985143'
 location: Centenary Building, Sir Joseph's Walk, Southdown, Harpenden, Hatching Green,
-  St Albans, Hertfordshire, England, AL5 2FF, United Kingdom
+  St Albans, Hertfordshire, AL5 2FF, United Kingdom
 external_url: https://www.rothamsted.ac.uk/events
 title: Rothamsted Research
 ---

--- a/content/daytrip/eu/gb/saddleworth-museum.md
+++ b/content/daytrip/eu/gb/saddleworth-museum.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '53.54678638319253'
 lng: '-2.007689399166111'
 location: Saddleworth Museum, High Street, Saddleworth, Uppermill, Oldham, Greater
-  Manchester, England, OL3 6HR, United Kingdom
+  Manchester, OL3 6HR, United Kingdom
 external_url: https://www.saddleworthmuseum.co.uk
 title: Saddleworth Museum
 ---

--- a/content/daytrip/eu/gb/schiehallion.md
+++ b/content/daytrip/eu/gb/schiehallion.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/schiehallion"
 date: '2001-01-30T04:37:00'
 lat: '56.66723962037906'
 lng: '-4.100947352575645'
-location: Perth and Kinross, Alba / Scotland, United Kingdom
+location: Perth and Kinross, United Kingdom
 external_url: https://en.wikipedia.org/wiki/Schiehallion#The_Schiehallion_experiment
 title: Schiehallion
 ---

--- a/content/daytrip/eu/gb/shaws-corner.md
+++ b/content/daytrip/eu/gb/shaws-corner.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.836081023793554'
 lng: '-0.26943824951172246'
 location: Bibbs Hall Lane, Ayot St Lawrence, Ayot St. Lawrence, Welwyn Hatfield, Hertfordshire,
-  England, AL6 9BX, United Kingdom
+  AL6 9BX, United Kingdom
 external_url: https://www.nationaltrust.org.uk/visit/essex-bedfordshire-hertfordshire/shaws-corner
 title: Shaw's Corner
 ---

--- a/content/daytrip/eu/gb/smith-art-gallery-and-museum.md
+++ b/content/daytrip/eu/gb/smith-art-gallery-and-museum.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/smith-art-gallery-and-museum
 date: '2001-01-30T04:37:00'
 lat: '56.11902693936727'
 lng: '-3.946366310119629'
-location: Smith Art Gallery & Museum, Dumbarton Road, Stirling, Alba / Scotland, FK8 2RQ, United Kingdom
+location: Smith Art Gallery & Museum, Dumbarton Road, Stirling, FK8 2RQ, United Kingdom
 external_url: https://www.smithartgalleryandmuseum.co.uk
 title: Smith Art Gallery and Museum
 ---

--- a/content/daytrip/eu/gb/south-foreland-lighthouse.md
+++ b/content/daytrip/eu/gb/south-foreland-lighthouse.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/south-foreland-lighthouse"
 date: '2001-01-30T04:37:00'
 lat: '51.14040992335679'
 lng: '1.3710007839965783'
-location: South Foreland Lighthouse, Seaview Road, St. Margaret's at Cliffe, Dover, Kent, England, CT15 6HP, United Kingdom
+location: South Foreland Lighthouse, Seaview Road, St. Margaret's at Cliffe, Dover, Kent, CT15 6HP, United Kingdom
 external_url: https://www.nationaltrust.org.uk/visit/kent/south-foreland-lighthouse
 title: South Foreland Lighthouse
 ---

--- a/content/daytrip/eu/gb/south-shields-museum.md
+++ b/content/daytrip/eu/gb/south-shields-museum.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '54.9986681'
 lng: '-1.4315039'
 location: South Shields Museum & Art Gallery, Ocean Road, The Lawe, South Shields,
-  South Tyneside, Tyne and Wear, North East, England, NE33 2JA, United Kingdom
+  South Tyneside, Tyne and Wear, North East, NE33 2JA, United Kingdom
 external_url: https://southshieldsmuseum.org.uk
 title: South Shields Museum
 ---

--- a/content/daytrip/eu/gb/spyway-dinosaur-footprints.md
+++ b/content/daytrip/eu/gb/spyway-dinosaur-footprints.md
@@ -4,7 +4,7 @@ date: '2025-06-01T21:34:04.601Z'
 poster: 'plett'
 lat: '50.602125'
 lng: '-2.020162'
-location: "Spyway Dinosaur Footprints, Priest's Way, Langton Matravers, Worth Matravers, Dorset, England, BH19 3LB, United Kingdom"
+location: "Spyway Dinosaur Footprints, Priest's Way, Langton Matravers, Worth Matravers, Dorset, BH19 3LB, United Kingdom"
 title: 'Spyway Dinosaur Footprints'
 external_url: https://dorset-nl.org.uk/location/spyway/
 ---

--- a/content/daytrip/eu/gb/st-albans-south-signal-box.md
+++ b/content/daytrip/eu/gb/st-albans-south-signal-box.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/st-albans-south-signal-box"
 date: '2001-01-30T04:37:00'
 lat: 51.748803
 lng: -0.327846
-location: Victoria Street, Cottonmill, St Albans, Hertfordshire, England, AL1 5HD, United Kingdom
+location: Victoria Street, Cottonmill, St Albans, Hertfordshire, AL1 5HD, United Kingdom
 external_url: https://www.tlr.ltd.uk/sigbox/home.eb
 title: St Albans South Signal Box
 ---

--- a/content/daytrip/eu/gb/st-martins.md
+++ b/content/daytrip/eu/gb/st-martins.md
@@ -3,7 +3,7 @@ slug: 'daytrip/eu/gb/st-martins'
 date: '2025-05-25T20:00:25+01:00'
 lat: '52.4769512'
 lng: '-1.8932318000000001'
-location: 'St Martins, Edgbaston Street, Bullring, Digbeth, Highgate, Birmingham, West Midlands, England, B5 5BB, United Kingdom'
+location: 'St Martins, Edgbaston Street, Bullring, Digbeth, Highgate, Birmingham, West Midlands, B5 5BB, United Kingdom'
 title: 'St Martins'
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/st-michaels-and-all-angels-church.md
+++ b/content/daytrip/eu/gb/st-michaels-and-all-angels-church.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/st-michaels-and-all-angels-church"
 date: '2001-01-30T04:37:00'
 lat: '50.872122361024594'
 lng: '-1.5777719020843506'
-location: High Street, Lyndhurst, Hampshire, England, SO43 7BD, United Kingdom
+location: High Street, Lyndhurst, Hampshire, SO43 7BD, United Kingdom
 external_url: https://www.nationalchurchestrust.org/church/st-michael-all-angels-lyndhurst
 title: St Michael's and All Angels Church
 ---

--- a/content/daytrip/eu/gb/st-peters-church.md
+++ b/content/daytrip/eu/gb/st-peters-church.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '50.72026311825353'
 lng: '-1.8760814494323768'
 location: Hinton Road, Lansdowne, West Cliff, Bournemouth, Bournemouth, Christchurch
-  and Poole, England, BH1 2AD, United Kingdom
+  and Poole, BH1 2AD, United Kingdom
 external_url: https://www.stpetersbournemouth.org.uk
 title: St. Peter's Church
 ---

--- a/content/daytrip/eu/gb/stanton-drew-stone-circles.md
+++ b/content/daytrip/eu/gb/stanton-drew-stone-circles.md
@@ -3,8 +3,8 @@ slug: daytrip/eu/gb/stanton-drew-stone-circles
 date: '2001-01-30T04:37:00'
 lat: 51.367078
 lng: -2.576101
-location: Sandy Lane, Stanton Drew, Bath and North East Somerset, West of England,
-  England, BS39 4HF, United Kingdom
+location: Sandy Lane, Stanton Drew, Bath and North East Somerset, West of
+  BS39 4HF, United Kingdom
 external_url: https://www.english-heritage.org.uk/visit/places/stanton-drew-circles-and-cove/
 title: Stanton Drew Stone Circles
 ---

--- a/content/daytrip/eu/gb/steeple-morden-airfield.md
+++ b/content/daytrip/eu/gb/steeple-morden-airfield.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '52.0645873577528'
 lng: '-0.10322712127685918'
 location: Litlington Road, Steeple Morden, South Cambridgeshire, Cambridgeshire, Cambridgeshire
-  and Peterborough, England, SG8 0RU, United Kingdom
+  and Peterborough, SG8 0RU, United Kingdom
 external_url: https://steeplemorden-pc.gov.uk/steeple-morden-airfield/
 title: Steeple Morden Airfield
 ---

--- a/content/daytrip/eu/gb/stockwood-discovery-centre.md
+++ b/content/daytrip/eu/gb/stockwood-discovery-centre.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/stockwood-discovery-centre"
 date: '2001-01-30T04:37:00'
 lat: '51.86520602056201'
 lng: '-0.4224547676697057'
-location: Stockwood Discovery Centre, London Road, Luton, England, LU1 4LX, United Kingdom
+location: Stockwood Discovery Centre, London Road, Luton, LU1 4LX, United Kingdom
 external_url: https://www.culturetrust.com/venues/stockwood-discovery-centre
 title: Stockwood Discovery Centre
 ---

--- a/content/daytrip/eu/gb/stokeleigh-camp-hill-fort.md
+++ b/content/daytrip/eu/gb/stokeleigh-camp-hill-fort.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/stokeleigh-camp-hill-fort"
 date: '2001-01-30T04:37:00'
 lat: 51.457116
 lng: -2.635614
-location: Valley Road, Leigh Woods, Bristol, England, United Kingdom
+location: Valley Road, Leigh Woods, Bristol, United Kingdom
 external_url: https://heritagerecords.nationaltrust.org.uk/HBSMR/MonRecord.aspx?uid=MNA139627
 title: Stokeleigh Camp hill fort
 ---

--- a/content/daytrip/eu/gb/stoney-littleton-long-barrow.md
+++ b/content/daytrip/eu/gb/stoney-littleton-long-barrow.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 51.313367
 lng: -2.381716
 location: Greenacres, Littleton Lane, Wellow, Bath and North East Somerset, West of
-  England, England, BA2 8NR, United Kingdom
+  BA2 8NR, United Kingdom
 external_url: https://www.english-heritage.org.uk/visit/places/stoney-littleton-long-barrow/
 title: Stoney Littleton Long Barrow
 ---

--- a/content/daytrip/eu/gb/the-birmingham-man.md
+++ b/content/daytrip/eu/gb/the-birmingham-man.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/the-birmingham-man
 date: '2025-05-25T10:15:15'
 lat: '52.4798132'
 lng: '-1.9042805'
-location: 'The Birmingham Man, Chamberlain Square, Ladywood, Birmingham, West Midlands, England, B3 3DQ, United Kingdom'
+location: 'The Birmingham Man, Chamberlain Square, Ladywood, Birmingham, West Midlands, B3 3DQ, United Kingdom'
 title: 'The Birmingham Man: Thomas Attwood (1783-1856)'
 external_url: https://www.siobancoppinger.co.uk/work/94b1a/
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/the-birmingham-man.md
+++ b/content/daytrip/eu/gb/the-birmingham-man.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/the-birmingham-man
 date: '2025-05-25T10:15:15'
 lat: '52.4798132'
 lng: '-1.9042805'
-location: 'The Birmingham Man: Thomas Attwood (1783-1856), Chamberlain Square, Chinese Quarter, Ladywood, Park Central, Birmingham, West Midlands, England, B3 3DQ, United Kingdom'
+location: 'The Birmingham Man, Chamberlain Square, Ladywood, Birmingham, West Midlands, England, B3 3DQ, United Kingdom'
 title: 'The Birmingham Man: Thomas Attwood (1783-1856)'
 external_url: https://www.siobancoppinger.co.uk/work/94b1a/
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/the-cat-and-fiddle.md
+++ b/content/daytrip/eu/gb/the-cat-and-fiddle.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 53.244121
 lng: -1.999748
 location: Macclesfield Main Road, Macclesfield Forest and Wildboarclough, High Peak,
-  Cheshire East, East Midlands, England, SK17 0TG, United Kingdom
+  Cheshire East, East Midlands, SK17 0TG, United Kingdom
 external_url: https://theforestdistillery.com/the-bar-at-cat-and-fiddle/
 title: The Cat and Fiddle
 ---

--- a/content/daytrip/eu/gb/the-look-out-discovery-centre-play-area.md
+++ b/content/daytrip/eu/gb/the-look-out-discovery-centre-play-area.md
@@ -4,7 +4,7 @@ date: '2025-05-31T15:36:58.507Z'
 poster: 'popey'
 lat: '51.386815'
 lng: '-0.740477'
-location: 'The Look Out Discovery Centre Play Area, Psyclo Path, Crowthorne, Bracknell Forest, England, RG12 7QW, United Kingdom'
+location: 'The Look Out Discovery Centre Play Area, Psyclo Path, Crowthorne, Bracknell Forest, RG12 7QW, United Kingdom'
 title: 'The Look Out Discovery Centre Play Area'
 external_url: https://www.bracknell-forest.gov.uk/leisure-and-events/look-out-discovery-centre
 ---

--- a/content/daytrip/eu/gb/the-nothe-fort.md
+++ b/content/daytrip/eu/gb/the-nothe-fort.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/the-nothe-fort"
 date: '2001-01-30T04:37:00'
 lat: 50.607366
 lng: -2.443804
-location: Nothe Fort, Barrack Road, Weymouth, Dorset, England, DT4 8UF, United Kingdom
+location: Nothe Fort, Barrack Road, Weymouth, Dorset, DT4 8UF, United Kingdom
 external_url: https://nothefort.org.uk
 title: The Nothe Fort
 ---

--- a/content/daytrip/eu/gb/the-pen-museum.md
+++ b/content/daytrip/eu/gb/the-pen-museum.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/the-pen-museum
 date: 2025-05-25T10:18:48
 lat: 52.4846038
 lng: -1.9116092
-location: The Pen Museum, 60, Frederick Street, Jewellery Quarter, Birmingham, West Midlands, England, B1 3HS, United Kingdom
+location: The Pen Museum, 60, Frederick Street, Jewellery Quarter, Birmingham, West Midlands, B1 3HS, United Kingdom
 title: The Pen Museum
 external_url: https://penmuseum.org.uk/
 poster: "Stuart Langridge"

--- a/content/daytrip/eu/gb/the-tank-museum.md
+++ b/content/daytrip/eu/gb/the-tank-museum.md
@@ -4,7 +4,7 @@ date: "2025-06-02T10:11:39.173Z"
 poster: "Robin"
 lat: "50.694398"
 lng: "-2.240881"
-location: "The Tank Museum, King George V Road, Wool, Wareham, Dorset, England, BH20 6JG, United Kingdom"
+location: "The Tank Museum, King George V Road, Wool, Wareham, Dorset, BH20 6JG, United Kingdom"
 title: "The Tank Museum"
 external_url: https://tankmuseum.org/
 ---

--- a/content/daytrip/eu/gb/the-uks-first-motorway.md
+++ b/content/daytrip/eu/gb/the-uks-first-motorway.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/the-uks-first-motorway"
 date: '2001-01-30T04:37:00'
 lat: 50.66912
 lng: -1.96123
-location: Ferry Road, Studland, Dorset, England, BH19 3AQ, United Kingdom
+location: Ferry Road, Studland, Dorset, BH19 3AQ, United Kingdom
 external_url: https://www.roads.org.uk/articles/studland-motor-road
 title: The UK's first motorway?
 ---

--- a/content/daytrip/eu/gb/the-watercress-line.md
+++ b/content/daytrip/eu/gb/the-watercress-line.md
@@ -1,7 +1,7 @@
 ---
 slug: "daytrip/eu/gb/the-watercress-line"
 title: The Watercress Line
-location: Station Approach, The Soke, New Alresford, Winchester, Hampshire, England, SO24 9JH, United Kingdom
+location: Station Approach, The Soke, New Alresford, Winchester, Hampshire, SO24 9JH, United Kingdom
 poster: popey
 date: '2025-05-24T17:47:36'
 lat: '51.088381'

--- a/content/daytrip/eu/gb/the-whangie.md
+++ b/content/daytrip/eu/gb/the-whangie.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/the-whangie"
 date: '2001-01-30T04:37:00'
 lat: '55.99543965454218'
 lng: '-4.387895090026859'
-location: A809, Carbeth, Stirling, Alba / Scotland, G63 9QP, United Kingdom
+location: A809, Carbeth, Stirling, G63 9QP, United Kingdom
 external_url: https://en.wikipedia.org/wiki/Kilpatrick_Hills#Geology
 title: The Whangie
 ---

--- a/content/daytrip/eu/gb/thomson-museum-of-anatomy.md
+++ b/content/daytrip/eu/gb/thomson-museum-of-anatomy.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/thomson-museum-of-anatomy"
 date: '2001-01-30T04:37:00'
 lat: '55.87173215636781'
 lng: '-4.287057572596041'
-location: University of Glasgow Gilmorehill Campus, Caledonian Crescent, North Kelvinside, North Woodside, Glasgow, Glasgow City, Alba / Scotland, G12 8HH, United Kingdom
+location: University of Glasgow Gilmorehill Campus, Caledonian Crescent, North Woodside, Glasgow, G12 8HH, United Kingdom
 external_url: https://www.gla.ac.uk/schools/medicine/anatomy/anatomymuseum/
 title: Thomson Museum of Anatomy
 ---

--- a/content/daytrip/eu/gb/tilestones-quarries.md
+++ b/content/daytrip/eu/gb/tilestones-quarries.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/tilestones-quarries"
 date: '2001-01-30T04:37:00'
 lat: '51.957184'
 lng: '-3.724982'
-location: Myddfai, Sir Gaerfyrddin / Carmarthenshire, Cymru / Wales, United Kingdom
+location: Myddfai, Sir Gaerfyrddin / Carmarthenshire, United Kingdom
 external_url: https://www.geograph.org.uk/photo/842379
 title: Tilestones Quarries
 ---

--- a/content/daytrip/eu/gb/tiptree-jam-factory-and-museum.md
+++ b/content/daytrip/eu/gb/tiptree-jam-factory-and-museum.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 51.806595
 lng: 0.754672
 location: Wilkin & Sons Jam Factory, Bainbridge Drive, Tiptree, Colchester, Essex,
-  England, CO5 0BP, United Kingdom
+  CO5 0BP, United Kingdom
 external_url: https://www.tiptree.com/blogs/news/tiptree-jam-museum
 title: Tiptree Jam Factory and Museum
 ---

--- a/content/daytrip/eu/gb/tuel-lane-lock.md
+++ b/content/daytrip/eu/gb/tuel-lane-lock.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/tuel-lane-lock"
 date: '2001-01-30T04:37:00'
 lat: '53.70961198263754'
 lng: '-1.9087028503417969'
-location: Tuel Lane, Sowerby Bridge, Halifax, West Yorkshire, England, HX6 2EH, United Kingdom
+location: Tuel Lane, Sowerby Bridge, Halifax, West Yorkshire, HX6 2EH, United Kingdom
 external_url: https://www.nationaltransporttrust.org.uk/heritage-sites/heritage-detail/tuel-lane-lock
 title: Tuel Lane Lock
 ---

--- a/content/daytrip/eu/gb/waylands-forge.md
+++ b/content/daytrip/eu/gb/waylands-forge.md
@@ -3,7 +3,7 @@ slug: daytrip/eu/gb/waylands-forge
 date: 2025-05-25T10:42:52
 lat: 52.4748956
 lng: -1.8845326
-location: Waylands Forge, High Street Deritend, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, England, B9 4AU, United Kingdom
+location: Waylands Forge, High Street Deritend, Rea Valley, Digbeth, Highgate, Birmingham, West Midlands, B9 4AU, United Kingdom
 title: Waylands Forge
 poster: "Stuart Langridge"
 ---

--- a/content/daytrip/eu/gb/waylands-smithy.md
+++ b/content/daytrip/eu/gb/waylands-smithy.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '51.56673218555707'
 lng: '-1.5960802859497107'
 location: Wayland's Smithy, The Ridgeway, Ashbury, Vale of White Horse, Oxfordshire,
-  England, SN6 8BZ, United Kingdom
+  SN6 8BZ, United Kingdom
 external_url: https://www.english-heritage.org.uk/visit/places/waylands-smithy/
 title: Wayland's Smithy
 ---

--- a/content/daytrip/eu/gb/witches-crag.md
+++ b/content/daytrip/eu/gb/witches-crag.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/witches-crag"
 date: '2001-01-30T04:37:00'
 lat: 56.15154
 lng: -3.90738
-location: Hillfoots Road, Blairlogie, Stirling, Alba / Scotland, FK9 5PJ, United Kingdom
+location: Hillfoots Road, Blairlogie, Stirling, FK9 5PJ, United Kingdom
 title: Witches Crag
 external_url: https://www.thenorthernantiquarian.org/2011/10/07/carlie-craig-blairlogie/
 ---

--- a/content/daytrip/eu/gb/worcester-cathedral.md
+++ b/content/daytrip/eu/gb/worcester-cathedral.md
@@ -4,7 +4,7 @@ date: "2025-06-02T07:07:11.532Z"
 poster: "popey"
 lat: "52.188731"
 lng: "-2.220807"
-location: "Cathedral Church of Christ and the Blessed Mary, the Virgin of Worcester, College Yard, Diglis, Worcester, Worcestershire, England, WR1 2LA, United Kingdom"
+location: "Cathedral Church of Christ and the Blessed Mary, the Virgin of Worcester, College Yard, Diglis, Worcester, Worcestershire, WR1 2LA, United Kingdom"
 title: "Worcester Cathedral"
 external_url: https://www.worcestercathedral.org.uk/
 ---

--- a/content/daytrip/eu/gb/wreck-of-ss-politician.md
+++ b/content/daytrip/eu/gb/wreck-of-ss-politician.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/wreck-of-ss-politician"
 date: '2001-01-30T04:37:00'
 lat: '57.052308532547805'
 lng: '-7.3230743408203125'
-location: Sloc na Creiche, Na h-Eileanan Siar, Alba / Scotland, HS8 5JN, United Kingdom
+location: Sloc na Creiche, Na h-Eileanan Siar, HS8 5JN, United Kingdom
 external_url: https://www.isle-of-south-uist.co.uk/isle-of-eriskay/whisky-galore-and-the-ss-politician/
 title: Wreck of SS Politician
 ---

--- a/content/daytrip/eu/gb/ww2-plane-wreck-on-the-east-side-of-ben-havel.md
+++ b/content/daytrip/eu/gb/ww2-plane-wreck-on-the-east-side-of-ben-havel.md
@@ -4,7 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 56.963854
 lng: -7.465553
 location: "Our Lady of The Sea, A888, Gearraidh Gadhal, Bàgh a' Chaisteil, Na h-Eileanan\
-  \ Siar, Alba / Scotland, HS9 5UH, United Kingdom"
+  \ Siar, HS9 5UH, United Kingdom"
 external_url: http://www.clydesideimages.co.uk/lockheed-hudson-wreck-on-ben-lui.html
 title: WW2 Plane wreck on the east side of Ben Havel
 ---

--- a/content/daytrip/na/us/cross-sound-ferry.md
+++ b/content/daytrip/na/us/cross-sound-ferry.md
@@ -4,7 +4,7 @@ date: "2025-06-04T18:41:42.206Z"
 poster: "Mark Dominus"
 lat: "41.356885"
 lng: "-72.093993"
-location: "Cross Sound Ferry, Ferry Street, Downtown New London Historic District, Downtown New London, New London, Southeastern Connecticut Planning Region, Connecticut, 06320, United States"
+location: "Cross Sound Ferry, Ferry Street, Downtown New London Historic District, Downtown New London, Connecticut, 06320, United States"
 title: "Cross Sound Ferry"
 external_url: https://www.dhs.gov/science-and-technology/plum-island-animal-disease-center
 ---


### PR DESCRIPTION
I have trimmed these locations because:

1) Despite being accurate, they're redundant (we don't tend to write to search for addresses like this).
2) It makes addresses longer and more complex than needed to find the venue.
3) I'm trying to fit addresses and descriptions in the pop-up, but some of them blow over the end of the box, and I'd rather not truncate the address.

I also trimmed a few (very long) locations that aren't in the UK.

I want to agree that this is okay before merging it.