### PR TITLE
New: Château de Vaux-le-Vicomte from NAB

### DIFF
--- a/content/daytrip/eu/fr/chteau-de-vaux-le-vicomte.md
+++ b/content/daytrip/eu/fr/chteau-de-vaux-le-vicomte.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/fr/chteau-de-vaux-le-vicomte"
+date: "2025-06-10T11:07:27.119Z"
+poster: "NAB"
+lat: "48.565788"
+lng: "2.714138"
+location: "77950 MAINCY"
+title: "Château de Vaux-le-Vicomte"
+external_url: https://vaux-le-vicomte.com/
+---
+A 17th century masterpiece, Vaux-le-Vicomte was the backdrop to many major historical events and witnessed the tragic eviction of its creator, Nicolas Fouquet, following an extraordinary trial.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Château de Vaux-le-Vicomte
**Location:** 77950 MAINCY
**Submitted by:** NAB
**Website:** https://vaux-le-vicomte.com/

### Description
A 17th century masterpiece, Vaux-le-Vicomte was the backdrop to many major historical events and witnessed the tragic eviction of its creator, Nicolas Fouquet, following an extraordinary trial.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 354
**File:** `content/daytrip/eu/fr/chteau-de-vaux-le-vicomte.md`

Please review this venue submission and edit the content as needed before merging.