### PR TITLE
New: Packwood House from NAB

### DIFF
--- a/content/daytrip/eu/gb/packwood-house.md
+++ b/content/daytrip/eu/gb/packwood-house.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/packwood-house"
+date: "2025-06-10T11:07:38.703Z"
+poster: "NAB"
+lat: "52.34799"
+lng: "-1.746708"
+location: "Packwood Lane, Lapworth, Warwickshire, B94 6AT"
+title: "Packwood House"
+external_url: https://www.nationaltrust.org.uk/visit/warwickshire/packwood-house
+---
+Jacobean meets Edwardian style, the house was originally built in the 16th century, yet its interiors were extensively restored between the First and Second World Wars to create a 20th-century evocation of domestic Tudor architecture.
+
+Packwood House contains a fine collection of 16th-century textiles and furniture, and the gardens have renowned herbaceous borders and a famous collection of yews.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Packwood House
**Location:** Packwood Lane, Lapworth, Warwickshire, B94 6AT
**Submitted by:** NAB
**Website:** https://www.nationaltrust.org.uk/visit/warwickshire/packwood-house

### Description
Jacobean meets Edwardian style, the house was originally built in the 16th century, yet its interiors were extensively restored between the First and Second World Wars to create a 20th-century evocation of domestic Tudor architecture.

Packwood House contains a fine collection of 16th-century textiles and furniture, and the gardens have renowned herbaceous borders and a famous collection of yews.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 355
**File:** `content/daytrip/eu/gb/packwood-house.md`

Please review this venue submission and edit the content as needed before merging.