### PR TITLE
New: Baddesley Clinton from NAB

### DIFF
--- a/content/daytrip/eu/gb/baddesley-clinton.md
+++ b/content/daytrip/eu/gb/baddesley-clinton.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/baddesley-clinton"
+date: "2025-06-10T11:09:49.082Z"
+poster: "NAB"
+lat: "52.340885"
+lng: "-1.708503"
+location: "Rising Lane, Baddesley Clinton, Warwickshire, B93 0DQ"
+title: "Baddesley Clinton"
+external_url: https://www.nationaltrust.org.uk/visit/warwickshire/baddesley-clinton
+---
+The house, a secluded and intimate estate set in the heart of the Forest of Arden, was a sanctuary for persecuted Catholics who were hidden from priest hunters in its secret hiding places during the 1590s. The house, gardens and vegetable patch are well worth visiting also.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Baddesley Clinton
**Location:** Rising Lane, Baddesley Clinton, Warwickshire, B93 0DQ
**Submitted by:** NAB
**Website:** https://www.nationaltrust.org.uk/visit/warwickshire/baddesley-clinton

### Description
The house, a secluded and intimate estate set in the heart of the Forest of Arden, was a sanctuary for persecuted Catholics who were hidden from priest hunters in its secret hiding places during the 1590s. The house, gardens and vegetable patch are well worth visiting also.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 356
**File:** `content/daytrip/eu/gb/baddesley-clinton.md`

Please review this venue submission and edit the content as needed before merging.