### PR TITLE
New: Arcade Club Bury from Irrelevant

### DIFF
--- a/content/daytrip/eu/gb/arcade-club-bury.md
+++ b/content/daytrip/eu/gb/arcade-club-bury.md
@@ -2,8 +2,8 @@
 slug: "daytrip/eu/gb/arcade-club-bury"
 date: "2025-06-10T12:38:56.918Z"
 poster: "Irrelevant"
-lat: "51.453647"
-lng: "-0.041199"
+lat: "53.5951729"
+lng: "-2.2838063"
 location: "Cork Street, Ela Mill, Bury, GB BL9 7BW"
 title: "Arcade Club Bury"
 external_url: https://www.arcadeclub.co.uk/bury/


### PR DESCRIPTION
## New Venue Submission

**Venue:** Arcade Club Bury
**Location:** Cork Street, Ela Mill, Bury, GB BL9 7BW
**Submitted by:** Irrelevant
**Website:** https://www.arcadeclub.co.uk/bury/

### Description
Fantastic site with four floors of an old mill filled with arcade machines and gaming systems, from 1980s to present day, all on free play. Cafes and bars on site too. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 358
**File:** `content/daytrip/eu/gb/arcade-club-bury.md`

Please review this venue submission and edit the content as needed before merging.