### PR TITLE
New: Catacombe dei Cappuccini from Robercrantz

### DIFF
--- a/content/daytrip/eu/it/catacombe-dei-cappuccini.md
+++ b/content/daytrip/eu/it/catacombe-dei-cappuccini.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/it/catacombe-dei-cappuccini"
+date: "2025-06-10T12:39:14.359Z"
+poster: "Robercrantz"
+lat: "38.111834"
+lng: "13.33922"
+location: "Piazza Cappuccini 1, 90129 Palermo (PA)"
+title: "Catacombe dei Cappuccini"
+external_url: https://www.catacombefraticappuccini.com/en/
+---
+The catacombs of the Capuchins friars of Palermo. Due to the presence of a lot of mummified bodies it is definitely a macabre experience that may not be suitable for everyone.
+
+More info here: https://en.wikipedia.org/wiki/Catacombe_dei_Cappuccini


### PR DESCRIPTION
## New Venue Submission

**Venue:** Catacombe dei Cappuccini
**Location:** Piazza Cappuccini 1, 90129 Palermo (PA)
**Submitted by:** Robercrantz
**Website:** https://www.catacombefraticappuccini.com/en/

### Description
The catacombs of the Capuchins friars of Palermo. Due to the presence of a lot of mummified bodies it is definitely a macabre experience that may not be suitable for everyone.

More info here: https://en.wikipedia.org/wiki/Catacombe_dei_Cappuccini

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 359
**File:** `content/daytrip/eu/it/catacombe-dei-cappuccini.md`

Please review this venue submission and edit the content as needed before merging.