### PR TITLE
New: Zeppelin Museum Friedrichshafen from NAB

### DIFF
--- a/content/daytrip/eu/de/zeppelin-museum-friedrichshafen.md
+++ b/content/daytrip/eu/de/zeppelin-museum-friedrichshafen.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/zeppelin-museum-friedrichshafen"
+date: "2025-06-10T12:56:43.238Z"
+poster: "NAB"
+lat: "47.650801"
+lng: "9.483181"
+location: "Seestraße 22, 88045 Friedrichshafen"
+title: "Zeppelin Museum Friedrichshafen"
+external_url: https://www.zeppelin-museum.de
+---
+The Zeppelin Museum, which owes its name to the airships developed by Count Zeppelin on Lake Constance, is particularly dedicated to innovative processes in technology, art and society. With permanent and temporary exhibitions and accompanying events, they build a bridge between the humanities and natural sciences and relate them to current social discourses. As an interdisciplinary museum for technology and art, the Hafenbahnhof not only houses the world's largest and most important collection on the history of airship travel, but also an art collection with extensive holdings by Otto Dix, Marta Hoepffner and Andreas Feininger. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Zeppelin Museum Friedrichshafen
**Location:** Seestraße 22, 88045 Friedrichshafen
**Submitted by:** NAB
**Website:** https://www.zeppelin-museum.de

### Description
The Zeppelin Museum, which owes its name to the airships developed by Count Zeppelin on Lake Constance, is particularly dedicated to innovative processes in technology, art and society. With permanent and temporary exhibitions and accompanying events, they build a bridge between the humanities and natural sciences and relate them to current social discourses. As an interdisciplinary museum for technology and art, the Hafenbahnhof not only houses the world's largest and most important collection on the history of airship travel, but also an art collection with extensive holdings by Otto Dix, Marta Hoepffner and Andreas Feininger. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 360
**File:** `content/daytrip/eu/de/zeppelin-museum-friedrichshafen.md`

Please review this venue submission and edit the content as needed before merging.