### PR TITLE
New: Veenpark Barger-Compascuum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/veenpark-barger-compascuum.md
+++ b/content/daytrip/eu/nl/veenpark-barger-compascuum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/veenpark-barger-compascuum"
+date: "2025-06-10T18:52:51.013Z"
+poster: "Frederik Dekker"
+lat: "52.755772"
+lng: "7.025961"
+location: "Berkenrode 4, 7884 TR, Barger-Compascuum, The Netherlands"
+title: "Veenpark Barger-Compascuum"
+external_url: https://www.veenpark.nl/
+---
+Open air museum village in a former peat colony. In the village you can explore how peat was extracted from the peatlands. It was then dried and transported to Holland to be used as fuel for domestic heating. Also all professions and trades that you would find in a village of that time are shown in approriate workshops. Last but not least: the park has two narrow gauge trains.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Veenpark Barger-Compascuum
**Location:** Berkenrode 4, 7884 TR, Barger-Compascuum, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.veenpark.nl/

### Description
Open air museum village in a former peat colony. In the village you can explore how peat was extracted from the peatlands. It was then dried and transported to Holland to be used as fuel for domestic heating. Also all professions and trades that you would find in a village of that time are shown in approriate workshops. Last but not least: the park has two narrow gauge trains.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 361
**File:** `content/daytrip/eu/nl/veenpark-barger-compascuum.md`

Please review this venue submission and edit the content as needed before merging.