### PR TITLE
New: Museumspoorlijn STAR from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museumspoorlijn-star.md
+++ b/content/daytrip/eu/nl/museumspoorlijn-star.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/museumspoorlijn-star"
+date: "2025-06-11T05:55:13.852Z"
+poster: "Frederik Dekker"
+lat: "52.996371"
+lng: "6.935581"
+location: "Stationsstraat 3, 9503 AD, Stadskanaal, The Netherlands "
+title: "Museumspoorlijn STAR"
+external_url: https://www.stadskanaalrail.nl/
+---
+Historic railway between Stadskanaal and Ter Apel-Rijksgrens. Nowadays running between Veendam and Nieuw-Buinen. Has both steam and diesel locomotives. In Stadskanaal there is also a museum and workshops that can be visited. In Veendam you can change over to the regular Dutch railway system.
+
+Note: there are plans to extend the line to Emmen and make it part of the regular Dutch railway network again, the so called Nedersaksenlijn.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museumspoorlijn STAR
**Location:** Stationsstraat 3, 9503 AD, Stadskanaal, The Netherlands 
**Submitted by:** Frederik Dekker
**Website:** https://www.stadskanaalrail.nl/

### Description
Historic railway between Stadskanaal and Ter Apel-Rijksgrens. Nowadays running between Veendam and Nieuw-Buinen. Has both steam and diesel locomotives. In Stadskanaal there is also a museum and workshops that can be visited. In Veendam you can change over to the regular Dutch railway system.

Note: there are plans to extend the line to Emmen and make it part of the regular Dutch railway network again, the so called Nedersaksenlijn.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 366
**File:** `content/daytrip/eu/nl/museumspoorlijn-star.md`

Please review this venue submission and edit the content as needed before merging.