### PR TITLE
New: Shakespearetheater Diever from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/shakespearetheater-diever.md
+++ b/content/daytrip/eu/nl/shakespearetheater-diever.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/shakespearetheater-diever"
+date: "2025-06-11T05:55:47.761Z"
+poster: "Frederik Dekker"
+lat: "52.864246"
+lng: "6.322203"
+location: "Hezenes 3, 7981 LD, Diever, The Netherlands"
+title: "Shakespearetheater Diever"
+external_url: https://shakespearetheaterdiever.nl/
+---
+Open air theatre where each summer a Shakespeare play is performed by volunteers, who are mostly from the local village of Diever and its surroundings. It seems like the whole village somehow supports the theater, from making costumes and decors to selling food during the break. Most of the times the stage and decors are a work of art all by themselves.
+
+In wintertime a different play is performed in the covered Globe theater.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Shakespearetheater Diever
**Location:** Hezenes 3, 7981 LD, Diever, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://shakespearetheaterdiever.nl/

### Description
Open air theatre where each summer a Shakespeare play is performed by volunteers, who are mostly from the local village of Diever and its surroundings. It seems like the whole village somehow supports the theater, from making costumes and decors to selling food during the break. Most of the times the stage and decors are a work of art all by themselves.

In wintertime a different play is performed in the covered Globe theater.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 367
**File:** `content/daytrip/eu/nl/shakespearetheater-diever.md`

Please review this venue submission and edit the content as needed before merging.