### PR TITLE
New: Marker Wadden from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/marker-wadden.md
+++ b/content/daytrip/eu/nl/marker-wadden.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/marker-wadden"
+date: "2025-06-11T05:56:15.468Z"
+poster: "Frederik Dekker"
+lat: "52.581776"
+lng: "5.367336"
+location: "De Aanloop 4, 8242NM, Lelystad, The Netherlands"
+title: "Marker Wadden"
+external_url: https://www.natuurmonumenten.nl/projecten/marker-wadden
+---
+Artificial islands in the Marker lake. These islands were created to enhance biodiversity both above and below water.  There are also vacation homes that are completely self supporting.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Marker Wadden
**Location:** De Aanloop 4, 8242NM, Lelystad, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.natuurmonumenten.nl/projecten/marker-wadden

### Description
Artificial islands in the Marker lake. These islands were created to enhance biodiversity both above and below water.  There are also vacation homes that are completely self supporting.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 368
**File:** `content/daytrip/eu/nl/marker-wadden.md`

Please review this venue submission and edit the content as needed before merging.