### PR TITLE
New: The Computer and Communications Museum of Ireland from PilloxMatters

### DIFF
--- a/content/daytrip/eu/ie/the-computer-and-communications-museum-of-ireland.md
+++ b/content/daytrip/eu/ie/the-computer-and-communications-museum-of-ireland.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/ie/the-computer-and-communications-museum-of-ireland"
+date: "2025-06-11T07:14:39.735Z"
+poster: "PilloxMatters"
+lat: "53.289887"
+lng: "-9.074092"
+location: "1st Floor, Insight Centre for Data Analytics, The DERI Building, IDA Business Park, Lower Dangan, Galway."
+title: "The Computer and Communications Museum of Ireland"
+external_url: https://ccmireland.com/about/
+---
+Founded in 2010, the Computer and Communications Museum of Ireland tells the fascinating story of key moments in the history of computing and communications. We explore technology by preserving the past, demonstrating the present and educating for the future.
+
+Visits by appointment except during public events, no admission fee, donations accepted.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Computer and Communications Museum of Ireland
**Location:** 1st Floor, Insight Centre for Data Analytics, The DERI Building, IDA Business Park, Lower Dangan, Galway.
**Submitted by:** PilloxMatters
**Website:** https://ccmireland.com/about/

### Description
Founded in 2010, the Computer and Communications Museum of Ireland tells the fascinating story of key moments in the history of computing and communications. We explore technology by preserving the past, demonstrating the present and educating for the future.

Visits by appointment except during public events, no admission fee, donations accepted.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 371
**File:** `content/daytrip/eu/ie/the-computer-and-communications-museum-of-ireland.md`

Please review this venue submission and edit the content as needed before merging.