### PR TITLE
New: Abyss Coffee Roasters from Sam D

### DIFF
--- a/content/daytrip/eu/es/abyss-coffee-roasters.md
+++ b/content/daytrip/eu/es/abyss-coffee-roasters.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/es/abyss-coffee-roasters"
+date: "2025-06-11T09:33:58.300Z"
+poster: "Sam D"
+lat: "41.4076213"
+lng: "2.2051969"
+location: "Av. Diagonal, 93, Sant Martí, 08019 Barcelona"
+title: "Abyss Coffee Roasters"
+external_url: https://abysscoffee.es/
+---
+Independent coffee roasters in Barcelona. Within the store you can see all of the roasting equipment, often in use. There are interesting infographics on the walls about the farming, cultivation and processing of coffee. It's also one of the few good coffee places in BCN that is open week round. Worth a short trip!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Abyss Coffee Roasters
**Location:** Av. Diagonal, 93, Sant Martí, 08019 Barcelona
**Submitted by:** Sam D
**Website:** https://abysscoffee.es/

### Description
Independent coffee roasters in Barcelona. Within the store you can see all of the roasting equipment, often in use. There are interesting infographics on the walls about the farming, cultivation and processing of coffee. It's also one of the few good coffee places in BCN that is open week round. Worth a short trip!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 372
**File:** `content/daytrip/eu/es/abyss-coffee-roasters.md`

Please review this venue submission and edit the content as needed before merging.