### PR TITLE
New: Aeroteca Flight Sim Store from Sam D

### DIFF
--- a/content/daytrip/eu/es/aeroteca-flight-sim-store.md
+++ b/content/daytrip/eu/es/aeroteca-flight-sim-store.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/es/aeroteca-flight-sim-store"
+date: "2025-06-11T09:34:55.389Z"
+poster: "Sam D"
+lat: "41.4031193"
+lng: "2.1605754"
+location: "Travessera de Gràcia, 209, Gràcia, 08012 Barcelona"
+title: "Aeroteca Flight Sim Store"
+external_url: https://www.aeroteca.com/en/
+---
+Flight sim store that has been open for over 40 years. They have a basic simulator, motion simulator and a Boeing 737 Simulator all available to use in store if you book a slot in advance. They also sell various sim gear, model planes, books and other airplane paraphernalia.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Aeroteca Flight Sim Store
**Location:** Travessera de Gràcia, 209, Gràcia, 08012 Barcelona
**Submitted by:** Sam D
**Website:** https://www.aeroteca.com/en/

### Description
Flight sim store that has been open for over 40 years. They have a basic simulator, motion simulator and a Boeing 737 Simulator all available to use in store if you book a slot in advance. They also sell various sim gear, model planes, books and other airplane paraphernalia.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 373
**File:** `content/daytrip/eu/es/aeroteca-flight-sim-store.md`

Please review this venue submission and edit the content as needed before merging.