### PR TITLE
New: Remise Transport Museum from EJ

### DIFF
--- a/content/daytrip/eu/at/remise-transport-museum.md
+++ b/content/daytrip/eu/at/remise-transport-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/at/remise-transport-museum"
+date: "2025-06-11T13:07:17.477Z"
+poster: "EJ"
+lat: "48.1966"
+lng: "16.408292"
+location: "Remise Transport Museum, Ludwig-Koeßler-Platz, Erdberger Mais, KG Landstraße, Landstraße, Wien, Vienna, 1030, Austria"
+title: "Remise Transport Museum"
+external_url: https://www.wienerlinien.at/verkehrsmuseum-remise
+---
+150 years of public transport in Vienna!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Remise Transport Museum
**Location:** Remise Transport Museum, Ludwig-Koeßler-Platz, Erdberger Mais, KG Landstraße, Landstraße, Wien, Vienna, 1030, Austria
**Submitted by:** EJ
**Website:** https://www.wienerlinien.at/verkehrsmuseum-remise

### Description
150 years of public transport in Vienna!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 377
**File:** `content/daytrip/eu/at/remise-transport-museum.md`

Please review this venue submission and edit the content as needed before merging.