### PR TITLE
New: Royal Observatory from ChrisC

### DIFF
--- a/content/daytrip/af/za/royal-observatory.md
+++ b/content/daytrip/af/za/royal-observatory.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/af/za/royal-observatory"
+date: "2025-06-11T13:09:04.693Z"
+poster: "ChrisC"
+lat: "-33.93459"
+lng: "18.477526"
+location: "Royal Observatory, Cape of Good Hope, Observatory Road, Observatory, Cape Town Ward 57, Cape Town, City of Cape Town, Western Cape, 7925, South Africa"
+title: "Royal Observatory"
+external_url: http://www.royalobservatorygreenwich.org/articles.php?article=915
+---
+The SAAO’s headquarters are in the Cape Town suburb of Observatory on the site of the former Royal Observatory. You are welcome to visit the SAAO in Cape Town on SAAO Open Nights, on the second and fourth Saturday of every month at 20:00


### PR DESCRIPTION
## New Venue Submission

**Venue:** Royal Observatory
**Location:** Royal Observatory, Cape of Good Hope, Observatory Road, Observatory, Cape Town Ward 57, Cape Town, City of Cape Town, Western Cape, 7925, South Africa
**Submitted by:** ChrisC
**Website:** https://www.openstreetmap.org/way/239789864#map=19/-33.934590/18.477526

### Description
The SAAO’s headquarters are in the Cape Town suburb of Observatory on the site of the former Royal Observatory. You are welcome to visit the SAAO in Cape Town on SAAO Open Nights, on the second and fourth Saturday of every month at 20:00

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 380
**File:** `content/daytrip/af/za/royal-observatory.md`

Please review this venue submission and edit the content as needed before merging.