### PR TITLE
New: Funkerberg Museum from debb1046

### DIFF
--- a/content/daytrip/eu/de/funkerberg-museum.md
+++ b/content/daytrip/eu/de/funkerberg-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/funkerberg-museum"
+date: "2025-06-11T13:11:37.462Z"
+poster: "debb1046"
+lat: "52.3043378"
+lng: "13.6206526"
+location: "funkerberg 20, 15711 Königs Wusterhausen, Germany"
+title: "Funkerberg Museum"
+external_url: https://museum.funkerberg.de/
+---
+The first German public radio broadcast was transmitted from this site. Exhibitions include radio transmitters and a collection of vacuum tubes (valves). The museum is currently (2025) closed for renovation but parts of it may be open for special events (see website).


### PR DESCRIPTION
## New Venue Submission

**Venue:** Funkerberg Museum
**Location:** funkerberg 20, 15711 Königs Wusterhausen, Germany
**Submitted by:** debb1046
**Website:** https://museum.funkerberg.de/

### Description
The first German public radio broadcast was transmitted from this site. Exhibitions include radio transmitters and a collection of vacuum tubes (valves). The museum is currently (2025) closed for renovation but parts of it may be open for special events (see website).

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 384
**File:** `content/daytrip/eu/de/funkerberg-museum.md`

Please review this venue submission and edit the content as needed before merging.