### PR TITLE
New: Ofen- und Keramikmuseen Velten from debb1046

### DIFF
--- a/content/daytrip/eu/de/ofen-und-keramikmuseen-velten.md
+++ b/content/daytrip/eu/de/ofen-und-keramikmuseen-velten.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/ofen-und-keramikmuseen-velten"
+date: "2025-06-11T13:12:06.820Z"
+poster: "debb1046"
+lat: "52.6889743"
+lng: "13.1710996"
+location: "Wilhelmstraße 32, 16727 Velten, Germany"
+title: "Ofen- und Keramikmuseen Velten"
+external_url: https://okmhb.de/
+---
+Museum situated in a historic stove factory. Exhibition of stoves, tiles, ceramics. Another part of the museum is dedicated to the life and works of designer and artist Hedwig Bollhagen.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ofen- und Keramikmuseen Velten
**Location:** Wilhelmstraße 32, 16727 Velten, Germany
**Submitted by:** debb1046
**Website:** https://okmhb.de/

### Description
Museum situated in a historic stove factory. Exhibition of stoves, tiles, ceramics. Another part of the museum is dedicated to the life and works of designer and artist Hedwig Bollhagen.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 387
**File:** `content/daytrip/eu/de/ofen-und-keramikmuseen-velten.md`

Please review this venue submission and edit the content as needed before merging.