### PR TITLE
New: Ziegeleimuseum Glindow from debb1046

### DIFF
--- a/content/daytrip/eu/de/ziegeleimuseum-glindow.md
+++ b/content/daytrip/eu/de/ziegeleimuseum-glindow.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/ziegeleimuseum-glindow"
+date: "2025-06-11T13:12:15.247Z"
+poster: "debb1046"
+lat: "52.35503"
+lng: "12.9212"
+location: "Alpenstraße 44, 14542 Werder (Havel), Germany"
+title: "Ziegeleimuseum Glindow"
+external_url: https://www.ziegeleimuseum-glindow.de/
+---
+Industrial heritage of regional brick making. Coal fired ring kiln dating back to 1868 and a brickwork tower from 1890 that houses an exhibition on brick making and brick buildings.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ziegeleimuseum Glindow
**Location:** Alpenstraße 44, 14542 Werder (Havel), Germany
**Submitted by:** debb1046
**Website:** https://www.ziegeleimuseum-glindow.de/

### Description
Industrial heritage of regional brick making. Coal fired ring kiln dating back to 1868 and a brickwork tower from 1890 that houses an exhibition on brick making and brick buildings.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 388
**File:** `content/daytrip/eu/de/ziegeleimuseum-glindow.md`

Please review this venue submission and edit the content as needed before merging.