### PR TITLE
New: Industriemuseum Brandenburg from debb1046

### DIFF
--- a/content/daytrip/eu/de/industriemuseum-brandenburg.md
+++ b/content/daytrip/eu/de/industriemuseum-brandenburg.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/industriemuseum-brandenburg"
+date: "2025-06-11T14:24:52.055Z"
+poster: "debb1046"
+lat: "52.416532"
+lng: "12.505698"
+location: "Industriemuseum Brandenburg, 5, August-Sonntag-Straße, SWB-Industrie- und Gewerbepark, Quenzsiedlung, Brandenburg an der Havel, Brandenburg, 14770, Germany"
+title: "Industriemuseum Brandenburg"
+external_url: https://www.industriemuseum-brandenburg.de/home
+---
+Steel mill which was in operation from 1913 to 1993 and is now a museum.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Industriemuseum Brandenburg
**Location:** Industriemuseum Brandenburg, 5, August-Sonntag-Straße, SWB-Industrie- und Gewerbepark, Quenzsiedlung, Brandenburg an der Havel, Brandenburg, 14770, Germany
**Submitted by:** debb1046
**Website:** https://www.industriemuseum-brandenburg.de/home

### Description
Steel mill which was in operation from 1913 to 1993 and is now a museum.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 390
**File:** `content/daytrip/eu/de/industriemuseum-brandenburg.md`

Please review this venue submission and edit the content as needed before merging.