### PR TITLE
New: Kelvingrove Art Gallery and Museum from Keota

### DIFF
--- a/content/daytrip/eu/gb/kelvingrove-art-gallery-and-museum.md
+++ b/content/daytrip/eu/gb/kelvingrove-art-gallery-and-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/kelvingrove-art-gallery-and-museum"
+date: "2025-06-11T14:41:42.401Z"
+poster: "Keota"
+lat: "55.868583"
+lng: "-4.290628"
+location: "Kelvingrove Art Gallery and Museum, Argyle Street, Stobcross, Kelvinhaugh, Glasgow, Glasgow City, Scotland, G3 8AG, United Kingdom"
+title: "Kelvingrove Art Gallery and Museum"
+external_url: https://www.glasgowlife.org.uk/museums/venues/kelvingrove-art-gallery-and-museum
+---
+A vast museum that includes many famous pieces of art and artifacts of various cultures and regions.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Kelvingrove Art Gallery and Museum
**Location:** Kelvingrove Art Gallery and Museum, Argyle Street, Stobcross, Kelvinhaugh, Glasgow, Glasgow City, Scotland, G3 8AG, United Kingdom
**Submitted by:** Keota
**Website:** https://www.glasgowlife.org.uk/museums/venues/kelvingrove-art-gallery-and-museum

### Description
A vast museum that includes many famous pieces of art and artifacts of various cultures and regions.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 394
**File:** `content/daytrip/eu/gb/kelvingrove-art-gallery-and-museum.md`

Please review this venue submission and edit the content as needed before merging.