### PR TITLE
New: Museum 't Kromhout from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/museum-t-kromhout.md
+++ b/content/daytrip/eu/nl/museum-t-kromhout.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/museum-t-kromhout"
+date: "2025-06-11T18:03:33.218Z"
+poster: "Frederik Dekker"
+lat: "52.368158"
+lng: "4.92018"
+location: "Hoogte Kadijk 147, 1018 BJ, Amsterdam, The Netherlands"
+title: "Museum 't Kromhout"
+external_url: https://www.kromhoutmuseum.nl/en/
+---
+Former shipyard where also engines were built. Now a museum dedicated to those Kromhout engines.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum 't Kromhout
**Location:** Hoogte Kadijk 147, 1018 BJ, Amsterdam, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.kromhoutmuseum.nl/en/

### Description
Former shipyard where also engines were built. Now a museum dedicated to those Kromhout engines.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 400
**File:** `content/daytrip/eu/nl/museum-t-kromhout.md`

Please review this venue submission and edit the content as needed before merging.