### PR TITLE
New: Hotel Del Coronado from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/hotel-del-coronado.md
+++ b/content/daytrip/na/us/hotel-del-coronado.md
@@ -1,0 +1,19 @@
+---
+slug: "daytrip/na/us/hotel-del-coronado"
+date: "2025-06-11T18:03:53.877Z"
+poster: "Bill Sanders"
+lat: "32.68091"
+lng: "-117.178436"
+location: "Hotel Del Coronado, 1500, Orange Avenue, Coronado, San Diego County, California, United States"
+title: "Hotel Del Coronado"
+external_url: https://en.wikipedia.org/wiki/Hotel_del_Coronado
+---
+The Del is an actively run hotel, but visitors can wander the grounds.  At Christmastime there's a gigantic tree decorated in the lobby.
+
+To the East is the Coronado Bridge, just to the North there's a fun dog beach, and South along the Silver Strand is a pedestrian trail with a unique Solstice Clock.
+
+From Wikipedia:
+
+The Hotel del Coronado, also known as The Del and Hotel Del, is a historic beachfront hotel in Coronado, California, just across San Diego Bay from San Diego. A rare surviving example of an American architectural genre—the wooden Victorian beach resort—it was designated a California Historical Landmark in 1970 and a National Historic Landmark in 1977. It is the second-largest wooden structure in the United States (after the Tillamook Air Museum in Tillamook, Oregon).
+
+When the hotel opened in 1888, it was the largest resort hotel in the world. It has hosted presidents, royalty, and celebrities, and been featured in numerous films and books.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hotel Del Coronado
**Location:** Hotel Del Coronado, 1500, Orange Avenue, Coronado, San Diego County, California, United States
**Submitted by:** Bill Sanders
**Website:** https://en.wikipedia.org/wiki/Hotel_del_Coronado

### Description
The Del is an actively run hotel, but visitors can wander the grounds.  At Christmastime there's a gigantic tree decorated in the lobby.

To the East is the Coronado Bridge, just to the North there's a fun dog beach, and South along the Silver Strand is a pedestrian trail with a unique Solstice Clock.

From Wikipedia:

The Hotel del Coronado, also known as The Del and Hotel Del, is a historic beachfront hotel in Coronado, California, just across San Diego Bay from San Diego. A rare surviving example of an American architectural genre—the wooden Victorian beach resort—it was designated a California Historical Landmark in 1970 and a National Historic Landmark in 1977. It is the second-largest wooden structure in the United States (after the Tillamook Air Museum in Tillamook, Oregon).

When the hotel opened in 1888, it was the largest resort hotel in the world. It has hosted presidents, royalty, and celebrities, and been featured in numerous films and books.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 405
**File:** `content/daytrip/na/us/hotel-del-coronado.md`

Please review this venue submission and edit the content as needed before merging.