### PR TITLE
New: San Diego Model Railroad Museum from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/san-diego-model-railroad-museum.md
+++ b/content/daytrip/na/us/san-diego-model-railroad-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/san-diego-model-railroad-museum"
+date: "2025-06-11T18:04:30.385Z"
+poster: "Bill Sanders"
+lat: "32.731143"
+lng: "-117.148911"
+location: "1649, El Prado, Banker's Hill, San Diego, San Diego County, California, 92101, United States"
+title: "San Diego Model Railroad Museum"
+external_url: https://www.sdmrm.org/
+---
+Spanning over 27,000 square feet of trains, trestles, and tracks, we are in the heart of natural beauty framed by the majestic backdrop of Balboa Park. The San Diego Model Railroad Museum (SDMRM) is a space where imagination is beautifully engineered. SDMRM features both indoor and outdoor exhibits and programming for all ages.
+
+Our mission is to research, collect, preserve, and present the heritage of American railroading using educational programs, displays, toy trains, and scale models of California railroads. At every twist, turn, and tunnel we spark curiosity with developing educational programming that includes education milestones like critical thinking, creativity, and problem solving. Our exhibits transform little engineers to modelers who tinker with engines and nail down track to build and transform something from nothing.


### PR DESCRIPTION
## New Venue Submission

**Venue:** San Diego Model Railroad Museum
**Location:** 1649, El Prado, Banker's Hill, San Diego, San Diego County, California, 92101, United States
**Submitted by:** Bill Sanders
**Website:** https://www.sdmrm.org/

### Description
Spanning over 27,000 square feet of trains, trestles, and tracks, we are in the heart of natural beauty framed by the majestic backdrop of Balboa Park. The San Diego Model Railroad Museum (SDMRM) is a space where imagination is beautifully engineered. SDMRM features both indoor and outdoor exhibits and programming for all ages.

Our mission is to research, collect, preserve, and present the heritage of American railroading using educational programs, displays, toy trains, and scale models of California railroads. At every twist, turn, and tunnel we spark curiosity with developing educational programming that includes education milestones like critical thinking, creativity, and problem solving. Our exhibits transform little engineers to modelers who tinker with engines and nail down track to build and transform something from nothing.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 402
**File:** `content/daytrip/na/us/san-diego-model-railroad-museum.md`

Please review this venue submission and edit the content as needed before merging.