### PR TITLE
New: Royal Observatory Greenwich from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/royal-observatory-greenwich.md
+++ b/content/daytrip/eu/gb/royal-observatory-greenwich.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/royal-observatory-greenwich"
+date: "2025-06-11T18:04:40.563Z"
+poster: "AndiBing"
+lat: "51.477362"
+lng: "-0.000846"
+location: "Royal Observatory Greenwich, London, England, SE10 8XJ, United Kingdom"
+title: "Royal Observatory Greenwich"
+external_url: https://www.rmg.co.uk/royal-observatory
+---
+Stand on the prime meridian.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Royal Observatory Greenwich
**Location:** Royal Observatory Greenwich, London, England, SE10 8XJ, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.rmg.co.uk/royal-observatory

### Description
Stand on the prime meridian.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 401
**File:** `content/daytrip/eu/gb/royal-observatory-greenwich.md`

Please review this venue submission and edit the content as needed before merging.