### PR TITLE
New: Herschel Museum of Astronomy from Hugo

### DIFF
--- a/content/daytrip/eu/gb/herschel-museum-of-astronomy.md
+++ b/content/daytrip/eu/gb/herschel-museum-of-astronomy.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/herschel-museum-of-astronomy"
+date: "2025-06-11T20:35:22.940Z"
+poster: "Hugo"
+lat: "51.382509"
+lng: "-2.36694219"
+location: "19 New King Street, Bath, BA1 2BL, England, UK"
+title: "Herschel Museum of Astronomy"
+external_url: https://herschelmuseum.org.uk
+---
+This museum is the house that William Herschel lived in, and from where Uranus was discovered. It commemorates the astronomical and musical accomplishments of William, and his sister Caroline -- a well-known astronomer in her own right.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Herschel Museum of Astronomy
**Location:** 19 New King Street, Bath, BA1 2BL, England, UK
**Submitted by:** Hugo
**Website:** https://herschelmuseum.org.uk

### Description
This museum is the house that William Herschel lived in, and from where Uranus was discovered. It commemorates the astronomical and musical accomplishments of William, and his sister Caroline -- a well-known astronomer in her own right.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 406
**File:** `content/daytrip/eu/gb/herschel-museum-of-astronomy.md`

Please review this venue submission and edit the content as needed before merging.