### PR TITLE
New: The Devil's Porridge Museum from Hugo

### DIFF
--- a/content/daytrip/eu/gb/the-devils-porridge-museum.md
+++ b/content/daytrip/eu/gb/the-devils-porridge-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/the-devils-porridge-museum"
+date: "2025-06-11T20:35:36.388Z"
+poster: "Hugo"
+lat: "54.985277"
+lng: "-3.169867"
+location: "Stanfield, Annan Road, Eastriggs, Dumfries and Galloway DG12 6TF, Alba/Scotland, UK"
+title: "The Devil's Porridge Museum"
+external_url: https://www.devilsporridge.org.uk
+---
+The Devil's Porridge: Cordite, an explosive and propellant used heavily in the First World War.
+
+This location near Gretna, on the south coast of Scotland, was a major factory for cordite in the 20th century, and the museum tells the story of the factory, and of the history of the area in both world wars and the cold war.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Devil's Porridge Museum
**Location:** Stanfield, Annan Road, Eastriggs, Dumfries and Galloway DG12 6TF, Alba/Scotland, UK
**Submitted by:** Hugo
**Website:** https://www.devilsporridge.org.uk

### Description
The Devil's Porridge: Cordite, an explosive and propellant used heavily in the First World War.

This location near Gretna, on the south coast of Scotland, was a major factory for cordite in the 20th century, and the museum tells the story of the factory, and of the history of the area in both world wars and the cold war.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 407
**File:** `content/daytrip/eu/gb/the-devils-porridge-museum.md`

Please review this venue submission and edit the content as needed before merging.