### PR TITLE
New: Swarkestone Causeway from Roger Light

### DIFF
--- a/content/daytrip/eu/gb/swarkestone-causeway.md
+++ b/content/daytrip/eu/gb/swarkestone-causeway.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/swarkestone-causeway"
+date: "2025-06-11T20:35:50.103Z"
+poster: "Roger Light"
+lat: "52.849102"
+lng: "-1.453295"
+location: "Swarkestone Causeway, Stanton by Bridge, Derbyshire, DE73 7GU, United Kingdom"
+title: "Swarkestone Causeway"
+external_url: https://www.visitsouthderbyshire.co.uk/place/swarkestone/swarkestone-bridge/
+---
+An ancient stone bridge built in the 13th century, and the longest in England. Some may say that it's just a fancy road, but I enjoy it each time I drive over it.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Swarkestone Causeway
**Location:** Swarkestone Causeway, Stanton by Bridge, Derbyshire, DE73 7GU, United Kingdom
**Submitted by:** Roger Light
**Website:** https://www.visitsouthderbyshire.co.uk/place/swarkestone/swarkestone-bridge/

### Description
An ancient stone bridge built in the 13th century, and the longest in England. Some may say that it's just a fancy road, but I enjoy it each time I drive over it.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 408
**File:** `content/daytrip/eu/gb/swarkestone-causeway.md`

Please review this venue submission and edit the content as needed before merging.