### PR TITLE
New: John Taylor Bellfoundry Museum from Roger Light

### DIFF
--- a/content/daytrip/eu/gb/john-taylor-bellfoundry-museum.md
+++ b/content/daytrip/eu/gb/john-taylor-bellfoundry-museum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/john-taylor-bellfoundry-museum"
+date: "2025-06-11T20:36:01.800Z"
+poster: "Roger Light"
+lat: "52.7732"
+lng: "-1.198765"
+location: "John Taylor Bellfoundry Museum, Freehold Street, Loughborough  LE11 1AR, United Kingdom"
+title: "John Taylor Bellfoundry Museum"
+external_url: https://loughboroughbellfoundry.org/
+---
+The last working bell foundry in Britain. They do tours during the summer months, which need booking in advance. The tours cover all aspects of bell making and associated wood work. There are hundreds of bells of all sorts of sizes sitting around. They do rare casting tours as well, where you can see a casting of a bell or iron fitting.
+
+The start and end of the tour is up stairs.


### PR DESCRIPTION
## New Venue Submission

**Venue:** John Taylor Bellfoundry Museum
**Location:** John Taylor Bellfoundry Museum, Freehold Street, Loughborough  LE11 1AR, United Kingdom
**Submitted by:** Roger Light
**Website:** https://loughboroughbellfoundry.org/

### Description
The last working bell foundry in Britain. They do tours during the summer months, which need booking in advance. The tours cover all aspects of bell making and associated wood work. There are hundreds of bells of all sorts of sizes sitting around. They do rare casting tours as well, where you can see a casting of a bell or iron fitting.

The start and end of the tour is up stairs.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 409
**File:** `content/daytrip/eu/gb/john-taylor-bellfoundry-museum.md`

Please review this venue submission and edit the content as needed before merging.