### PR TITLE
New: Retro Gaming Museum from EJ

### DIFF
--- a/content/daytrip/eu/at/retro-gaming-museum.md
+++ b/content/daytrip/eu/at/retro-gaming-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/at/retro-gaming-museum"
+date: "2025-06-11T20:36:24.962Z"
+poster: "EJ"
+lat: "48.197861"
+lng: "16.352341"
+location: "Retro Gaming Museum, 1, Fritz-Grünbaum-Platz, Vienna, 1060, Austria"
+title: "Retro Gaming Museum"
+external_url: https://www.gamingmuseum.at/#wien
+---
+A retro gaming museum housed in a former flak tower.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Retro Gaming Museum
**Location:** Retro Gaming Museum, 1, Fritz-Grünbaum-Platz, Vienna, 1060, Austria
**Submitted by:** EJ
**Website:** https://www.gamingmuseum.at/#wien

### Description
A retro gaming museum housed in a former flak tower.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 411
**File:** `content/daytrip/eu/at/retro-gaming-museum.md`

Please review this venue submission and edit the content as needed before merging.