### PR TITLE
New: East Midlands Aeropark from Roger Light

### DIFF
--- a/content/daytrip/eu/gb/east-midlands-aeropark.md
+++ b/content/daytrip/eu/gb/east-midlands-aeropark.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/east-midlands-aeropark"
+date: "2025-06-11T21:48:59.638Z"
+poster: "Roger Light"
+lat: "52.833187"
+lng: "-1.345763"
+location: "East Midlands Aeropark, Castle Donington, Leicestershire, DE74 2PR, United Kingdom"
+title: "East Midlands Aeropark"
+external_url: http://www.eastmidlandsaeropark.org/
+---
+A collection of aircraft, aircraft sections, and museum, run by volunteers. Notable aircraft include a Vulcan, a Nimrod with restored interior (including chunky laptops), a Lightning, and a front loading Argosy.


### PR DESCRIPTION
## New Venue Submission

**Venue:** East Midlands Aeropark
**Location:** East Midlands Aeropark, Castle Donington, Leicestershire, DE74 2PR, United Kingdom
**Submitted by:** Roger Light
**Website:** http://www.eastmidlandsaeropark.org/

### Description
A collection of aircraft, aircraft sections, and museum, run by volunteers. Notable aircraft include a Vulcan, a Nimrod with restored interior (including chunky laptops), a Lightning, and a front loading Argosy.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 412
**File:** `content/daytrip/eu/gb/east-midlands-aeropark.md`

Please review this venue submission and edit the content as needed before merging.