### PR TITLE
New: Hatchlands Park from LewJ

### DIFF
--- a/content/daytrip/eu/gb/hatchlands-park.md
+++ b/content/daytrip/eu/gb/hatchlands-park.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/hatchlands-park"
+date: "2025-06-12T07:02:15.696Z"
+poster: "LewJ"
+lat: "51.257723"
+lng: "-0.471762"
+location: "Hatchlands Park, A246, West Horsley, Guildford, Surrey, England, KT24 6EA, United Kingdom"
+title: "Hatchlands Park"
+external_url: https://www.nationaltrust.org.uk/visit/surrey/hatchlands-park
+---
+Historical House, great views.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hatchlands Park
**Location:** Hatchlands Park, A246, West Horsley, Guildford, Surrey, England, KT24 6EA, United Kingdom
**Submitted by:** LewJ
**Website:** https://www.nationaltrust.org.uk/visit/surrey/hatchlands-park

### Description
Historical House, great views.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 415
**File:** `content/daytrip/eu/gb/hatchlands-park.md`

Please review this venue submission and edit the content as needed before merging.