### PR TITLE
New: Berliner U-Bahn-Museum from debb1046

### DIFF
--- a/content/daytrip/eu/de/berliner-u-bahn-museum.md
+++ b/content/daytrip/eu/de/berliner-u-bahn-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/berliner-u-bahn-museum"
+date: "2025-06-12T07:02:33.113Z"
+poster: "debb1046"
+lat: "52.517354"
+lng: "13.249973"
+location: "Berliner U-Bahn-Museum, Rossitter Platz, Westend, Charlottenburg-Wilmersdorf, Berlin, 14052, Germany"
+title: "Berliner U-Bahn-Museum"
+external_url: https://www.museumsportal-berlin.de/en/museums/berliner-u-bahn-museum/
+---
+A collection of artifacts connected to the Berlin subway (U-Bahn). The museum is located in the former Olympia stadium signal box dating back to 1931.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Berliner U-Bahn-Museum
**Location:** Berliner U-Bahn-Museum, Rossitter Platz, Westend, Charlottenburg-Wilmersdorf, Berlin, 14052, Germany
**Submitted by:** debb1046
**Website:** https://www.museumsportal-berlin.de/en/museums/berliner-u-bahn-museum/

### Description
A collection of artifacts connected to the Berlin subway (U-Bahn). The museum is located in the former Olympia stadium signal box dating back to 1931.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 416
**File:** `content/daytrip/eu/de/berliner-u-bahn-museum.md`

Please review this venue submission and edit the content as needed before merging.