### PR TITLE
New: Poway Midland Railroad from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/poway-midland-railroad.md
+++ b/content/daytrip/na/us/poway-midland-railroad.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/poway-midland-railroad"
+date: "2025-06-12T07:02:50.290Z"
+poster: "Bill Sanders"
+lat: "32.970065"
+lng: "-117.03647"
+location: "14134 Midland Rd, Poway, California, United States"
+title: "Poway Midland Railroad"
+external_url: https://powaymidlandrr.org/
+---
+The Poway-Midland Railroad is a full-size, narrow-gauge railroad in Old Poway Park which carries passengers aboard vintage and antique railroad equipment. The railroad is owned by the City of Poway, and operated by the Poway Midland Railroad Volunteers, is a 501 (c) 3 Corporation that exists on passenger ticket fares and donations.
+
+Through the restoration, preservation, and operation of vintage railroad equipment, the Volunteers are able to offer the community and visitors alike with a vintage train ride around the park, and through interpretation, provide educational programs (such as Operation Lifesaver) as well.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Poway Midland Railroad
**Location:** 14134 Midland Rd, Poway, California, United States
**Submitted by:** Bill Sanders
**Website:** https://powaymidlandrr.org/

### Description
The Poway-Midland Railroad is a full-size, narrow-gauge railroad in Old Poway Park which carries passengers aboard vintage and antique railroad equipment. The railroad is owned by the City of Poway, and operated by the Poway Midland Railroad Volunteers, is a 501 (c) 3 Corporation that exists on passenger ticket fares and donations.

Through the restoration, preservation, and operation of vintage railroad equipment, the Volunteers are able to offer the community and visitors alike with a vintage train ride around the park, and through interpretation, provide educational programs (such as Operation Lifesaver) as well.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 417
**File:** `content/daytrip/na/us/poway-midland-railroad.md`

Please review this venue submission and edit the content as needed before merging.