### PR TITLE
New: Pacific Southwest Railway Museum Campo Depot from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/pacific-southwest-railway-museum-campo-depot.md
+++ b/content/daytrip/na/us/pacific-southwest-railway-museum-campo-depot.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/na/us/pacific-southwest-railway-museum-campo-depot"
+date: "2025-06-12T07:03:10.175Z"
+poster: "Bill Sanders"
+lat: "32.616908"
+lng: "-116.470179"
+location: "750 Depot Street, Campo, California, United States"
+title: "Pacific Southwest Railway Museum Campo Depot"
+external_url: https://www.psrm.org/
+---
+Aside from the outdoor and indoor walk through museum, this railway still offers rides on vintage locomotives.  Up until semi-recent damage to a tunnel, there were even rides across the border to Tecate brewery.
+
+The Pacific Southwest Railway Museum Association is a non-profit educational organization dedicated to the preservation and interpretation of railroads as they existed in the Pacific Southwest. With over 120 pieces of equipment and artifacts on display between our two facilities in Campo, CA and La Mesa, CA, the Pacific Southwest Railway Museum Association provides a unique learning experience for all ages. At our Campo facility, we offer vintage train rides with locomotives and cars from the early 20th century operated by our all-volunteer train crews and support staff.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Pacific Southwest Railway Museum Campo Depot
**Location:** 750 Depot Street, Campo, California, United States
**Submitted by:** Bill Sanders
**Website:** https://www.psrm.org/

### Description
Aside from the outdoor and indoor walk through museum, this railway still offers rides on vintage locomotives.  Up until semi-recent damage to a tunnel, there were even rides across the border to Tecate brewery.

The Pacific Southwest Railway Museum Association is a non-profit educational organization dedicated to the preservation and interpretation of railroads as they existed in the Pacific Southwest. With over 120 pieces of equipment and artifacts on display between our two facilities in Campo, CA and La Mesa, CA, the Pacific Southwest Railway Museum Association provides a unique learning experience for all ages. At our Campo facility, we offer vintage train rides with locomotives and cars from the early 20th century operated by our all-volunteer train crews and support staff.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 418
**File:** `content/daytrip/na/us/pacific-southwest-railway-museum-campo-depot.md`

Please review this venue submission and edit the content as needed before merging.