### PR TITLE
New: Tuna Harbor Dockside Market from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/tuna-harbor-dockside-market.md
+++ b/content/daytrip/na/us/tuna-harbor-dockside-market.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/tuna-harbor-dockside-market"
+date: "2025-06-12T07:36:14.327Z"
+poster: "Bill Sanders"
+lat: "32.7095"
+lng: "-117.17227"
+location: "598 Harbor Lane  San Diego, California, United States"
+title: "Tuna Harbor Dockside Market"
+external_url: https://www.thdocksidemarket.com/
+---
+An open-air locally-caught seafood market run by independent fishers, open Saturdays only.  In addition to finding local species unlikely to be encountered at the grocery store, this market also has a a cutting booth where you can have whole fish processed as well as a seafood stand with unique San Diego-inspired dishes.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tuna Harbor Dockside Market
**Location:** 598 Harbor Lane  San Diego, California, United States
**Submitted by:** Bill Sanders
**Website:** https://www.thdocksidemarket.com/

### Description
An open-air locally-caught seafood market run by independent fishers, open Saturdays only.  In addition to finding local species unlikely to be encountered at the grocery store, this market also has a a cutting booth where you can have whole fish processed as well as a seafood stand with unique San Diego-inspired dishes.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 419
**File:** `content/daytrip/na/us/tuna-harbor-dockside-market.md`

Please review this venue submission and edit the content as needed before merging.