### PR TITLE
New: Derby Computer Museum from Adagis

### DIFF
--- a/content/daytrip/eu/gb/derby-computer-museum.md
+++ b/content/daytrip/eu/gb/derby-computer-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/derby-computer-museum"
+date: "2025-06-12T07:36:29.462Z"
+poster: "Adagis"
+lat: "52.923578"
+lng: "-1.47728"
+location: "Derby Computer Museum, 3-4, Iron Gate, Cathedral Quarter, Little Chester, Derby, East Midlands, England, DE1 3FJ, United Kingdom"
+title: "Derby Computer Museum"
+external_url: https://www.derbycomputermuseum.co.uk
+---
+Full of retro computers and games consoles, with the opportunity to play retro games, or try to do work on Windows 3!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Derby Computer Museum
**Location:** Derby Computer Museum, 3-4, Iron Gate, Cathedral Quarter, Little Chester, Derby, East Midlands, England, DE1 3FJ, United Kingdom
**Submitted by:** Adagis
**Website:** https://www.derbycomputermuseum.co.uk

### Description
Full of retro computers and games consoles, with the opportunity to play retro games, or try to do work on Windows 3!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 420
**File:** `content/daytrip/eu/gb/derby-computer-museum.md`

Please review this venue submission and edit the content as needed before merging.