### PR TITLE
New: Museum of Timekeeping from The Doctor

### DIFF
--- a/content/daytrip/eu/gb/museum-of-timekeeping.md
+++ b/content/daytrip/eu/gb/museum-of-timekeeping.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/museum-of-timekeeping"
+date: "2025-06-12T07:36:48.814Z"
+poster: "The Doctor"
+lat: "53.081864"
+lng: "-0.904197"
+location: "Museum of Timekeeping, Main Street, Upton , Nottinghamshire, NG23 5TE, United Kingdom"
+title: "Museum of Timekeeping"
+external_url: https://www.museumoftimekeeping.org.uk/
+---
+A museum all about clocks and timekeeping.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum of Timekeeping
**Location:** Museum of Timekeeping, Main Street, Upton , Nottinghamshire, NG23 5TE, United Kingdom
**Submitted by:** The Doctor
**Website:** https://www.museumoftimekeeping.org.uk/

### Description
A museum all about clocks and timekeeping.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 421
**File:** `content/daytrip/eu/gb/museum-of-timekeeping.md`

Please review this venue submission and edit the content as needed before merging.