### PR TITLE
New: USS Midway Museum from Bill Sanders

### DIFF
--- a/content/daytrip/na/us/uss-midway-museum.md
+++ b/content/daytrip/na/us/uss-midway-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/uss-midway-museum"
+date: "2025-06-12T07:37:02.987Z"
+poster: "Bill Sanders"
+lat: "32.71385"
+lng: "-117.175173"
+location: "910 N. Harbor Drive, San Diego, California, United States"
+title: "USS Midway Museum"
+external_url: https://www.midway.org
+---
+One of the largest and longest-serving naval vessels in the 20th century, now permanently moored in San Diego Harbor to serve as a multi-level museum with various tours and a flight deck with dozens of aircraft.


### PR DESCRIPTION
## New Venue Submission

**Venue:** USS Midway Museum
**Location:** 910 N. Harbor Drive, San Diego, California, United States
**Submitted by:** Bill Sanders
**Website:** https://www.midway.org

### Description
One of the largest and longest-serving naval vessels in the 20th century, now permanently moored in San Diego Harbor to serve as a multi-level museum with various tours and a flight deck with dozens of aircraft.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 422
**File:** `content/daytrip/na/us/uss-midway-museum.md`

Please review this venue submission and edit the content as needed before merging.