### PR TITLE
Updated Poster information for Retrodome Barnsley

### DIFF
--- a/content/daytrip/eu/gb/retrodome.md
+++ b/content/daytrip/eu/gb/retrodome.md
@@ -1,7 +1,7 @@
 ---
 slug: 'daytrip/eu/gb/retrodome'
 date: '2025-05-31T14:48:53.286Z'
-poster: 'Retrodome'
+poster: 'David Cooper'
 lat: '53.54889'
 lng: '-1.480485'
 location: 'Retrodome, Thomas Street, Worsbrough Common, Kingstone, Barnsley, South Yorkshire, England, S70 1LH, United Kingdom'


### PR DESCRIPTION
---
name: Bug Fix
about: Create a report to help us improve
title: "[BUG]"
labels: bug
assignees: ''

---

**Describe the bug**
When I created the entry for Retrodome, I didn't include my name, but the name of the location, because I'm a numpty.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'Retrodome'
2. view detailed information
3. See the "Poster" as "Retrodome" rather that "David Cooper"

**Expected behavior**
The poster information should show David Cooper.

**Desktop (please complete the following information):**
 - OS: Zorin
 - Browser: Firefox
 - Version: 139

**Additional context**
Turns out I can do this in the browser, but had gone down this new PR rabbit hole

**Testing**


**Fixes Issue**

