### PR TITLE
New: Wollaton Hall from Pound Shop David Attenborough

### DIFF
--- a/content/daytrip/eu/gb/wollaton-hall.md
+++ b/content/daytrip/eu/gb/wollaton-hall.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/wollaton-hall"
+date: "2025-06-12T11:57:06.462Z"
+poster: "Pound Shop David Attenborough"
+lat: "52.94796"
+lng: "-1.209771"
+location: "Wollaton Hall, Nottingham, NG8 2AE, United Kingdom"
+title: "Wollaton Hall"
+external_url: https://wollatonhall.org.uk/hall-and-museum/natural-history-museum/
+---
+A natural history museum full of interesting and unusual exhibits.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wollaton Hall
**Location:** Wollaton Hall, Nottingham, NG8 2AE, United Kingdom
**Submitted by:** Pound Shop David Attenborough
**Website:** https://wollatonhall.org.uk/hall-and-museum/natural-history-museum/

### Description
A natural history museum full of interesting and unusual exhibits.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 427
**File:** `content/daytrip/eu/gb/wollaton-hall.md`

Please review this venue submission and edit the content as needed before merging.