### PR TITLE
New: Aichi Expo Memorial Museum from Shiawase

### DIFF
--- a/content/daytrip/as/jp/aichi-expo-memorial-museum.md
+++ b/content/daytrip/as/jp/aichi-expo-memorial-museum.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/as/jp/aichi-expo-memorial-museum"
+date: "2025-06-12T11:57:43.727Z"
+poster: "Shiawase"
+lat: "35.174791"
+lng: "137.086565"
+location: "〒480-1342 愛知県長久手市 茨ケ廻間乙1533-1"
+title: "Aichi Expo Memorial Museum"
+external_url: https://www.aichi-koen.com/moricoro/shisetsu/kinenkan/
+---
+Part of the legacy of the 2005 Expo. The small free museum houses a collection of artifacts donated by the exhibiting countries, and displays about the expo itself. There are also some robot/animatronics that were used. It is housed in what used to be the suites for visiting dignitaries. 
+Oddly for something from 2005 it has a very 60s futurist feel to the design. 
+
+You can get to the park on the Linimo maglev, another legacy of the Expo. 
+The Ghibli museum is also hosted in the park and there are many Ghibli items to discover in the public areas. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Aichi Expo Memorial Museum
**Location:** 〒480-1342 愛知県長久手市 茨ケ廻間乙1533-1
**Submitted by:** Shiawase
**Website:** https://www.aichi-koen.com/moricoro/shisetsu/kinenkan/

### Description
Part of the legacy of the 2005 Expo. The small free museum houses a collection of artifacts donated by the exhibiting countries, and displays about the expo itself. There are also some robot/animatronics that were used. It is housed in what used to be the suites for visiting dignitaries. 
Oddly for something from 2005 it has a very 60s futurist feel to the design. 

You can get to the park on the Linimo maglev, another legacy of the Expo. 
The Ghibli museum is also hosted in the park and there are many Ghibli items to discover in the public areas. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 428
**File:** `content/daytrip/as/jp/aichi-expo-memorial-museum.md`

Please review this venue submission and edit the content as needed before merging.