### PR TITLE
New: Bell Pettigrew Museum from Pound Shop David Attenborough

### DIFF
--- a/content/daytrip/eu/gb/bell-pettigrew-museum.md
+++ b/content/daytrip/eu/gb/bell-pettigrew-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/bell-pettigrew-museum"
+date: "2025-06-12T11:58:06.028Z"
+poster: "Pound Shop David Attenborough"
+lat: "56.337724"
+lng: "-2.793631"
+location: "Bell Pettigrew Museum, North Street, St Andrews, Fife, Scotland, KY16 9AJ, United Kingdom"
+title: "Bell Pettigrew Museum"
+external_url: https://www.visitscotland.com/info/see-do/bell-pettigrew-museum-of-natural-history-p2216261
+---
+A small and unusual natural history museum hidden in the back streets of St Andrews.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bell Pettigrew Museum
**Location:** Bell Pettigrew Museum, North Street, St Andrews, Fife, Scotland, KY16 9AJ, United Kingdom
**Submitted by:** Pound Shop David Attenborough
**Website:** https://www.visitscotland.com/info/see-do/bell-pettigrew-museum-of-natural-history-p2216261

### Description
A small and unusual natural history museum hidden in the back streets of St Andrews.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 429
**File:** `content/daytrip/eu/gb/bell-pettigrew-museum.md`

Please review this venue submission and edit the content as needed before merging.