### PR TITLE
New: Andrew Carnegie Birthplace Museum from George Lauder

### DIFF
--- a/content/daytrip/eu/gb/andrew-carnegie-birthplace-museum.md
+++ b/content/daytrip/eu/gb/andrew-carnegie-birthplace-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/andrew-carnegie-birthplace-museum"
+date: "2025-06-12T11:58:16.370Z"
+poster: "George Lauder"
+lat: "56.067936"
+lng: "-3.461231"
+location: "Andrew Carnegie Birthplace Museum, Moodie Street, Dunfermline, Fife, KY12 7PL, United Kingdom"
+title: "Andrew Carnegie Birthplace Museum"
+external_url: https://www.carnegiebirthplace.com/
+---
+Understand the not quite rags to riches story of Andrew Carnegie, one of the world's biggest steel tycoons.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Andrew Carnegie Birthplace Museum
**Location:** Andrew Carnegie Birthplace Museum, Moodie Street, Dunfermline, Fife, KY12 7PL, United Kingdom
**Submitted by:** George Lauder
**Website:** https://www.carnegiebirthplace.com/

### Description
Understand the not quite rags to riches story of Andrew Carnegie, one of the world's biggest steel tycoons.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 430
**File:** `content/daytrip/eu/gb/andrew-carnegie-birthplace-museum.md`

Please review this venue submission and edit the content as needed before merging.