### PR TITLE
New: Lemmy sculpture from Robin

### DIFF
--- a/content/daytrip/eu/gb/lemmy-sculpture.md
+++ b/content/daytrip/eu/gb/lemmy-sculpture.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/lemmy-sculpture"
+date: "2025-06-12T11:58:26.020Z"
+poster: "Robin"
+lat: "53.046247"
+lng: "-2.197353"
+location: "Lemmy, Wedgwood Place, Longport, Burslem, Stoke-on-Trent, England, ST6 4ED, United Kingdom"
+title: "Lemmy sculpture"
+external_url: https://imotorhead.com/lemmy-forever-stoke-on-trent/
+---
+A sculpture of Lemmy in his home town. One for fans of heavy metal music, and Motörhead in particular. Apparently his ashes are in the sculpture.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lemmy sculpture
**Location:** Lemmy, Wedgwood Place, Longport, Burslem, Stoke-on-Trent, England, ST6 4ED, United Kingdom
**Submitted by:** Robin
**Website:** https://imotorhead.com/lemmy-forever-stoke-on-trent/

### Description
A sculpture of Lemmy in his home town. One for fans of heavy metal music, and Motörhead in particular. Apparently his ashes are in the sculpture.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 431
**File:** `content/daytrip/eu/gb/lemmy-sculpture.md`

Please review this venue submission and edit the content as needed before merging.