### PR TITLE
New: Asmbly Makerspace from Jim Kelley

### DIFF
--- a/content/daytrip/na/us/asmbly-makerspace.md
+++ b/content/daytrip/na/us/asmbly-makerspace.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/asmbly-makerspace"
+date: "2025-06-12T15:12:21.592Z"
+poster: "Jim Kelley"
+lat: "30.354765"
+lng: "-97.672592"
+location: "9701, Dessau Road, Cameron Industrial, Austin, Travis County, Texas, 78754, United States"
+title: "Asmbly Makerspace"
+external_url: https://asmbly.org/
+---
+Asmbly is Austin’s largest nonprofit community makerspace. They have shops for woodworking, metal work, laser cutting, electronics, 3D-printing, ceramics, and textiles.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Asmbly Makerspace
**Location:** 9701, Dessau Road, Cameron Industrial, Austin, Travis County, Texas, 78754, United States
**Submitted by:** Jim Kelley
**Website:** https://asmbly.org/

### Description
Asmbly is Austin’s largest nonprofit community makerspace. They have shops for woodworking, metal work, laser cutting, electronics, 3D-printing, ceramics, and textiles.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 433
**File:** `content/daytrip/na/us/asmbly-makerspace.md`

Please review this venue submission and edit the content as needed before merging.