### PR TITLE
New: Museumspark Rüdersdorf from debb1046

### DIFF
--- a/content/daytrip/eu/de/museumspark-rdersdorf.md
+++ b/content/daytrip/eu/de/museumspark-rdersdorf.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/museumspark-rdersdorf"
+date: "2025-06-12T15:12:45.279Z"
+poster: "debb1046"
+lat: "52.480298"
+lng: "13.782732"
+location: "Museumspark Rüdersdorf, 41, Bergbrück, Rüdersdorf, Rüdersdorf bei Berlin, Märkisch-Oderland, Brandenburg, 15562, Germany"
+title: "Museumspark Rüdersdorf"
+external_url: https://www.museumspark.de/
+---
+Industrial heritage site where lime used to be made in several big coal fired lime kilns. Some of the buildings and kilns and other infrastructure have been preserved and can be visited with a guided tour. There is a also a tour and exhibition about geology and fossils found in the lime stone. An open pit limestone mine which is still used is next to the museum area.  


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museumspark Rüdersdorf
**Location:** Museumspark Rüdersdorf, 41, Bergbrück, Rüdersdorf, Rüdersdorf bei Berlin, Märkisch-Oderland, Brandenburg, 15562, Germany
**Submitted by:** debb1046
**Website:** https://www.museumspark.de/

### Description
Industrial heritage site where lime used to be made in several big coal fired lime kilns. Some of the buildings and kilns and other infrastructure have been preserved and can be visited with a guided tour. There is a also a tour and exhibition about geology and fossils found in the lime stone. An open pit limestone mine which is still used is next to the museum area.  

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 434
**File:** `content/daytrip/eu/de/museumspark-rdersdorf.md`

Please review this venue submission and edit the content as needed before merging.