### PR TITLE
New: Dampflokfreunde Berlin from debb1046

### DIFF
--- a/content/daytrip/eu/de/dampflokfreunde-berlin.md
+++ b/content/daytrip/eu/de/dampflokfreunde-berlin.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/dampflokfreunde-berlin"
+date: "2025-06-12T15:13:07.252Z"
+poster: "debb1046"
+lat: "52.446827"
+lng: "13.521565"
+location: "Dampflokfreunde Berlin, 9, Wagner-Régeny-Allee,  Berlin, 12487, Germany"
+title: "Dampflokfreunde Berlin"
+external_url: https://www.berlin-macht-dampf.com/
+---
+Railway yard with a roundhouse locomotive shed and turn table. The shed houses steam locomotives and old diesels. Only accessible during special events.  


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dampflokfreunde Berlin
**Location:** Dampflokfreunde Berlin, 9, Wagner-Régeny-Allee,  Berlin, 12487, Germany
**Submitted by:** debb1046
**Website:** https://www.berlin-macht-dampf.com/

### Description
Railway yard with a roundhouse locomotive shed and turn table. The shed houses steam locomotives and old diesels. Only accessible during special events.  

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 435
**File:** `content/daytrip/eu/de/dampflokfreunde-berlin.md`

Please review this venue submission and edit the content as needed before merging.