### PR TITLE
New: Schifffahrtsmuseum Rostock from debb1046

### DIFF
--- a/content/daytrip/eu/de/schifffahrtsmuseum-rostock.md
+++ b/content/daytrip/eu/de/schifffahrtsmuseum-rostock.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/schifffahrtsmuseum-rostock"
+date: "2025-06-12T15:13:36.235Z"
+poster: "debb1046"
+lat: "54.141861"
+lng: "12.086602"
+location: "Schmarl Dorf 40, Rostock, Mecklenburg-Vorpommern, 18106, Germany"
+title: "Schifffahrtsmuseum Rostock"
+external_url: https://schifffahrtsmuseum-rostock.de/
+---
+Diesel powered cargo ship from the GDR era that has been converted to a museum of maritime history. The engine room is open to visitors.  


### PR DESCRIPTION
## New Venue Submission

**Venue:** Schifffahrtsmuseum Rostock
**Location:** Schmarl Dorf 40, Rostock, Mecklenburg-Vorpommern, 18106, Germany
**Submitted by:** debb1046
**Website:** https://schifffahrtsmuseum-rostock.de/

### Description
Diesel powered cargo ship from the GDR era that has been converted to a museum of maritime history. The engine room is open to visitors.  

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 436
**File:** `content/daytrip/eu/de/schifffahrtsmuseum-rostock.md`

Please review this venue submission and edit the content as needed before merging.