### PR TITLE
New: Tilt from Thor

### DIFF
--- a/content/daytrip/eu/no/tilt.md
+++ b/content/daytrip/eu/no/tilt.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/no/tilt"
+date: "2025-06-12T21:57:43.836Z"
+poster: "Thor"
+lat: "59.916203"
+lng: "10.750559"
+location: "Tilt, Badstugata, Hausmannskvartalene, St. Hanshaugen, Oslo, 0181, Norway"
+title: "Tilt"
+external_url: https://tiltoslo.no/om-tilt-oslo/
+---
+A pinball game bar


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tilt
**Location:** Tilt, Badstugata, Hausmannskvartalene, St. Hanshaugen, Oslo, 0181, Norway
**Submitted by:** Thor
**Website:** https://tiltoslo.no/om-tilt-oslo/

### Description
A pinball game bar

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 437
**File:** `content/daytrip/eu/no/tilt.md`

Please review this venue submission and edit the content as needed before merging.