### PR TITLE
New: The Garden at 120 from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/the-garden-at-120.md
+++ b/content/daytrip/eu/gb/the-garden-at-120.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/the-garden-at-120"
+date: "2025-06-13T09:16:03.141Z"
+poster: "alwAudio"
+lat: "51.512142"
+lng: "-0.080781"
+location: "120, Fenchurch Street, Leadenhall Market, City of London, Greater London, England, EC3M 5BA"
+title: "The Garden at 120"
+external_url: https://www.thegardenat120.com/
+---
+Free skyline view of London


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Garden at 120
**Location:** 120, Fenchurch Street, Leadenhall Market, City of London, Greater London, England, EC3M 5BA
**Submitted by:** alwAudio
**Website:** https://www.thegardenat120.com/

### Description
Free skyline view of London

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 438
**File:** `content/daytrip/eu/gb/the-garden-at-120.md`

Please review this venue submission and edit the content as needed before merging.