### PR TITLE
New: Pacific Pinball Museum from sharp-meal

### DIFF
--- a/content/daytrip/na/us/pacific-pinball-museum.md
+++ b/content/daytrip/na/us/pacific-pinball-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/pacific-pinball-museum"
+date: "2025-06-13T09:16:55.491Z"
+poster: "sharp-meal"
+lat: "37.773754"
+lng: "-122.276585"
+location: "1510, Webster Street, Alameda, CA, 94501, United States"
+title: "Pacific Pinball Museum"
+external_url: https://www.pacificpinball.org/
+---
+Pinball museum with cabinets from the 1940s to present -- all can be played free by visitors with admission. An interesting march through pinball history.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Pacific Pinball Museum
**Location:** 1510, Webster Street, Alameda, CA, 94501, United States
**Submitted by:** sharp-meal
**Website:** https://www.pacificpinball.org/

### Description
Pinball museum with cabinets from the 1940s to present -- all can be played free by visitors with admission. An interesting march through pinball history.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 439
**File:** `content/daytrip/na/us/pacific-pinball-museum.md`

Please review this venue submission and edit the content as needed before merging.