### PR TITLE
New: Musée Mécanique from sharp-meal

### DIFF
--- a/content/daytrip/na/us/muse-mcanique.md
+++ b/content/daytrip/na/us/muse-mcanique.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/muse-mcanique"
+date: "2025-06-13T09:17:04.226Z"
+poster: "sharp-meal"
+lat: "37.809246"
+lng: "-122.415794"
+location: "Pier 45, Fishermans Wharf, San Francisco, CA, 94133, United States"
+title: "Musée Mécanique"
+external_url: https://museemecanique.com/
+---
+Lots of coin-operated machines ranging from gaming consoles to motorized dioramas to a vintage zeotrope. Lots of eclectic antique machines maintained to function. Free to enter but bring your quarters (or cash to be changed)!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Musée Mécanique
**Location:** Pier 45, Fishermans Wharf, San Francisco, CA, 94133, United States
**Submitted by:** sharp-meal
**Website:** https://museemecanique.com/

### Description
Lots of coin-operated machines ranging from gaming consoles to motorized dioramas to a vintage zeotrope. Lots of eclectic antique machines maintained to function. Free to enter but bring your quarters (or cash to be changed)!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 440
**File:** `content/daytrip/na/us/muse-mcanique.md`

Please review this venue submission and edit the content as needed before merging.