### PR TITLE
New: The Rock House from Resin

### DIFF
--- a/content/daytrip/na/us/the-rock-house.md
+++ b/content/daytrip/na/us/the-rock-house.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/na/us/the-rock-house"
+date: "2025-06-13T09:17:12.209Z"
+poster: "Resin"
+lat: "35.920275"
+lng: "-85.403859"
+location: "Rockhouse State Memorial, 3663 Country Club Rd, Sparta, TN 38583"
+title: "The Rock House"
+external_url: https://www.tn.gov/historicalcommission/state-programs/state-historic-sites/sparta-rock-house.html
+---
+The small, stone Rock House, originally built to collect tolls on a private road, was built between 1835 and 1839 by Barlow Fiske, who operated a stage coach inn and stables nearby.
+
+It played an important role in the early development of Tennessee's transportation system. Andrew Jackson often stopped here on trips from Nashville to Washington. Other notable visitors included James K. Polk, Sam Houston, and Frank Clement, all once governors of the Volunteer State.
+
+-Credit to the Tennessee State Government website-


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Rock House
**Location:** Rockhouse State Memorial, 3663 Country Club Rd, Sparta, TN 38583
**Submitted by:** Resin
**Website:** https://www.tn.gov/historicalcommission/state-programs/state-historic-sites/sparta-rock-house.html

### Description
The small, stone Rock House, originally built to collect tolls on a private road, was built between 1835 and 1839 by Barlow Fiske, who operated a stage coach inn and stables nearby.

It played an important role in the early development of Tennessee's transportation system. Andrew Jackson often stopped here on trips from Nashville to Washington. Other notable visitors included James K. Polk, Sam Houston, and Frank Clement, all once governors of the Volunteer State.

-Credit to the Tennessee State Government website-

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 441
**File:** `content/daytrip/na/us/the-rock-house.md`

Please review this venue submission and edit the content as needed before merging.