### PR TITLE
New: Ness Point from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/ness-point.md
+++ b/content/daytrip/eu/gb/ness-point.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/ness-point"
+date: "2025-06-13T10:40:41.962Z"
+poster: "AndiBing"
+lat: "52.481207"
+lng: "1.762799"
+location: "Ness Point, Lowestoft, Suffolk, England, NR32 1UZ, United Kingdom"
+title: "Ness Point"
+external_url: https://www.ness-point.co.uk/
+---
+The most easterly point in the United Kingdom


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ness Point
**Location:** Ness Point, Lowestoft, Suffolk, England, NR32 1UZ, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.ness-point.co.uk/

### Description
The most easterly point in the United Kingdom

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 444
**File:** `content/daytrip/eu/gb/ness-point.md`

Please review this venue submission and edit the content as needed before merging.