### PR TITLE
New: Heathrow Aircraft Viewing Area from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/heathrow-aircraft-viewing-area.md
+++ b/content/daytrip/eu/gb/heathrow-aircraft-viewing-area.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/heathrow-aircraft-viewing-area"
+date: "2025-06-13T10:40:58.922Z"
+poster: "AndiBing"
+lat: "51.480148"
+lng: "-0.442725"
+location: "Aircraft Viewing Area, Newall Road, London Borough of Hillingdon, London, Greater London, England, TW6 2FN, United Kingdom"
+title: "Heathrow Aircraft Viewing Area"
+external_url: https://www.heathrow.com/at-the-airport/airport-maps/spectator-areas
+---
+Hidden away on an industrial estate, a viewing platform to watch aeroplanes arriving and departing Heathrow Airport.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Heathrow Aircraft Viewing Area
**Location:** Aircraft Viewing Area, Newall Road, London Borough of Hillingdon, London, Greater London, England, TW6 2FN, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.heathrow.com/at-the-airport/airport-maps/spectator-areas

### Description
Hidden away on an industrial estate, a viewing platform to watch aeroplanes arriving and departing Heathrow Airport.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 446
**File:** `content/daytrip/eu/gb/heathrow-aircraft-viewing-area.md`

Please review this venue submission and edit the content as needed before merging.