### PR TITLE
New: Mardale from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/mardale.md
+++ b/content/daytrip/eu/gb/mardale.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/mardale"
+date: "2025-06-13T10:41:07.451Z"
+poster: "AndiBing"
+lat: "54.492939"
+lng: "-2.815231"
+location: "Mardale, England, United Kingdom"
+title: "Mardale"
+external_url: https://en.wikipedia.org/wiki/Mardale
+---
+Mardale was flooded along with the rest of the valley, destroying several villages, creating Haweswater Reservoir. The dam was built in the 1930s. At times of drought, you can see the remains of the walls from the old buildings.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Mardale
**Location:** Mardale, England, United Kingdom
**Submitted by:** AndiBing
**Website:** https://en.wikipedia.org/wiki/Mardale

### Description
Mardale was flooded along with the rest of the valley, destroying several villages, creating Haweswater Reservoir. The dam was built in the 1930s. At times of drought, you can see the remains of the walls from the old buildings.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 447
**File:** `content/daytrip/eu/gb/mardale.md`

Please review this venue submission and edit the content as needed before merging.