### PR TITLE
New: Blue Fin building from popey

### DIFF
--- a/content/daytrip/eu/gb/blue-fin-building.md
+++ b/content/daytrip/eu/gb/blue-fin-building.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/gb/blue-fin-building"
+date: "2025-06-13T12:20:33.180Z"
+poster: "popey"
+lat: "51.505911"
+lng: "-0.100191"
+location: "Southwark Street"
+title: "Blue Fin building"
+external_url: https://canonical.com/
+---
+The old Canonical office.
+This is just for testing a new API key.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Blue Fin building
**Location:** Southwark Street
**Submitted by:** popey
**Website:** https://canonical.com/

### Description
The old Canonical office.
This is just for testing a new API key.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 449
**File:** `content/daytrip/eu/gb/blue-fin-building.md`

Please review this venue submission and edit the content as needed before merging.