### PR TITLE
New: Shipwreck of the Swiks in Trollskogen from jfml

### DIFF
--- a/content/daytrip/eu/se/shipwreck-of-the-swiks-in-trollskogen.md
+++ b/content/daytrip/eu/se/shipwreck-of-the-swiks-in-trollskogen.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/se/shipwreck-of-the-swiks-in-trollskogen"
+date: "2025-06-13T20:38:49.943Z"
+poster: "jfml"
+lat: "57.35151"
+lng: "17.127806"
+location: "Vraket Swiks, Murgrönestigen, Borgholms kommun, Kalmar County, Sweden"
+title: "Shipwreck of the Swiks in Trollskogen"
+external_url: https://en.wikipedia.org/wiki/Trollskogen
+---
+Shipwreck of three-masted schooner „Swiks“ that was wrecked here in 1926. Near the parking space are small forest / themed huts and in the very fairy-tale like forest lots of cairns and stone circles.
+
+https://www.atlasobscura.com/places/trollskogen-troll-forest


### PR DESCRIPTION
## New Venue Submission

**Venue:** Shipwreck of the Swiks in Trollskogen
**Location:** Vraket Swiks, Murgrönestigen, Borgholms kommun, Kalmar County, Sweden
**Submitted by:** jfml
**Website:** https://en.wikipedia.org/wiki/Trollskogen

### Description
Shipwreck of three-masted schooner „Swiks“ that was wrecked here in 1926. Near the parking space are small forest / themed huts and in the very fairy-tale like forest lots of cairns and stone circles.

https://www.atlasobscura.com/places/trollskogen-troll-forest

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 455
**File:** `content/daytrip/eu/se/shipwreck-of-the-swiks-in-trollskogen.md`

Please review this venue submission and edit the content as needed before merging.