### PR TITLE
New: Cramond Island from jfml

### DIFF
--- a/content/daytrip/eu/gb/cramond-island.md
+++ b/content/daytrip/eu/gb/cramond-island.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/cramond-island"
+date: "2025-06-13T20:38:58.113Z"
+poster: "jfml"
+lat: "55.993096"
+lng: "-3.289966"
+location: "Cramond Island, City of Edinburgh, Scotland, EH4 6HZ, United Kingdom"
+title: "Cramond Island"
+external_url: https://en.wikipedia.org/wiki/Cramond_Island
+---
+Cramond island is only accessible at low tide (so check the tides!) but has a very nice walk way to the island as well as bunkers and ruins.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cramond Island
**Location:** Cramond Island, City of Edinburgh, Scotland, EH4 6HZ, United Kingdom
**Submitted by:** jfml
**Website:** https://en.wikipedia.org/wiki/Cramond_Island

### Description
Cramond island is only accessible at low tide (so check the tides!) but has a very nice walk way to the island as well as bunkers and ruins.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 456
**File:** `content/daytrip/eu/gb/cramond-island.md`

Please review this venue submission and edit the content as needed before merging.