### PR TITLE
New: Musée des Moulages from MarcN

### DIFF
--- a/content/daytrip/eu/fr/muse-des-moulages.md
+++ b/content/daytrip/eu/fr/muse-des-moulages.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/fr/muse-des-moulages"
+date: "2025-06-14T13:10:04.731Z"
+poster: "MarcN"
+lat: "48.872197"
+lng: "2.368134"
+location: "Rue Bichat, Quartier de l'Hôpital Saint-Louis, Paris 10e Arrondissement, Paris, 75010, France"
+title: "Musée des Moulages"
+external_url: https://hopital-saintlouis.aphp.fr/le-musee-des-moulages-de-lhopital-de-saint-louis/
+---
+A collection, unique in the world, that bears witness to the history of medicine and dermatology. It contains apprinately 5000 wax castings of parts of the body affected by dermatological lesions like skin diseases and syphilis. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Musée des Moulages
**Location:** Rue Bichat, Quartier de l'Hôpital Saint-Louis, Paris 10e Arrondissement, Paris, 75010, France
**Submitted by:** MarcN
**Website:** https://hopital-saintlouis.aphp.fr/le-musee-des-moulages-de-lhopital-de-saint-louis/

### Description
A collection, unique in the world, that bears witness to the history of medicine and dermatology. It contains apprinately 5000 wax castings of parts of the body affected by dermatological lesions like skin diseases and syphilis. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 457
**File:** `content/daytrip/eu/fr/muse-des-moulages.md`

Please review this venue submission and edit the content as needed before merging.