### PR TITLE
New: Great Barr Hall from Andy Mabbett

### DIFF
--- a/content/daytrip/eu/gb/great-barr-hall.md
+++ b/content/daytrip/eu/gb/great-barr-hall.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/great-barr-hall"
+date: "2025-06-14T13:11:36.273Z"
+poster: "Andy Mabbett"
+lat: "52.556318"
+lng: "-1.920951"
+location: "Great Barr Hall, Walsall, England B43 7BL"
+title: "Great Barr Hall"
+external_url: https://en.wikipedia.org/wiki/Great_Barr_Hall
+---
+18th-century mansion in Strawberry Hill style. Has associations with the Lunar Society and is Grade II listed. In a very poor state of repair and on the Buildings at Risk Register.
+
+Featured in an episode of Dalziel and Pascoe, in which James Bolam guest starred.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Great Barr Hall
**Location:** Great Barr Hall, Walsall, England B43 7BL
**Submitted by:** Andy Mabbett
**Website:** https://en.wikipedia.org/wiki/Great_Barr_Hall

### Description
18th-century mansion in Strawberry Hill style. Has associations with the Lunar Society and is Grade II listed. In a very poor state of repair and on the Buildings at Risk Register.

Featured in an episode of Dalziel and Pascoe, in which James Bolam guest starred.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 461
**File:** `content/daytrip/eu/gb/great-barr-hall.md`

Please review this venue submission and edit the content as needed before merging.