### PR TITLE
New: Perry Bridge from Andy Mabbett

### DIFF
--- a/content/daytrip/eu/gb/perry-bridge.md
+++ b/content/daytrip/eu/gb/perry-bridge.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/perry-bridge"
+date: "2025-06-14T13:13:20.962Z"
+poster: "Andy Mabbett"
+lat: "52.525519"
+lng: "-1.897109"
+location: "Perry Bridge, Perry Barr, Birmingham, West Midlands, England, B42 2HB, United Kingdom"
+title: "Perry Bridge"
+external_url: https://en.wikipedia.org/wiki/Perry_Bridge
+---
+Bridge built in 1711; Grade II listed building.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Perry Bridge
**Location:** Perry Bridge, Perry Barr, Birmingham, West Midlands, England, B42 2HB, United Kingdom
**Submitted by:** Andy Mabbett
**Website:** https://en.wikipedia.org/wiki/Perry_Bridge

### Description
Bridge built in 1711; Grade II listed building.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 460
**File:** `content/daytrip/eu/gb/perry-bridge.md`

Please review this venue submission and edit the content as needed before merging.