### PR TITLE
New: Joseph Chamberlain Memorial Clock Tower from Andy Mabbett

### DIFF
--- a/content/daytrip/eu/gb/joseph-chamberlain-memorial-clock-tower.md
+++ b/content/daytrip/eu/gb/joseph-chamberlain-memorial-clock-tower.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/joseph-chamberlain-memorial-clock-tower"
+date: "2025-06-14T13:13:43.819Z"
+poster: "Andy Mabbett"
+lat: "52.449845"
+lng: "-1.930662"
+location: "University Square, Birmingham, England B15 2TT"
+title: "Joseph Chamberlain Memorial Clock Tower"
+external_url: https://en.wikipedia.org/wiki/Joseph_Chamberlain_Memorial_Clock_Tower
+---
+World's tallest free-standing clock tower.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Joseph Chamberlain Memorial Clock Tower
**Location:** University Square, Birmingham, England B15 2TT
**Submitted by:** Andy Mabbett
**Website:** https://en.wikipedia.org/wiki/Joseph_Chamberlain_Memorial_Clock_Tower

### Description
World's tallest free-standing clock tower.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 459
**File:** `content/daytrip/eu/gb/joseph-chamberlain-memorial-clock-tower.md`

Please review this venue submission and edit the content as needed before merging.