### PR TITLE
New: Saint Paul's Church from Andy Mabbett

### DIFF
--- a/content/daytrip/eu/gb/saint-pauls-church.md
+++ b/content/daytrip/eu/gb/saint-pauls-church.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/saint-pauls-church"
+date: "2025-06-14T13:13:59.723Z"
+poster: "Andy Mabbett"
+lat: "52.485253"
+lng: "-1.905763"
+location: "Saint Paul's Church, Saint Paul's Square, Jewellery Quarter, Birmingham, West Midlands, England, B3 1RB, United Kingdom"
+title: "Saint Paul's Church"
+external_url: http://www.saintpaulbrum.org/
+---
+Church used by James Watt and Matthew Boulton; East window by Francis Eginton.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Saint Paul's Church
**Location:** Saint Paul's Church, Saint Paul's Square, Jewellery Quarter, Birmingham, West Midlands, England, B3 1RB, United Kingdom
**Submitted by:** Andy Mabbett
**Website:** http://www.saintpaulbrum.org/

### Description
Church used by James Watt and Matthew Boulton; East window by Francis Eginton.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 458
**File:** `content/daytrip/eu/gb/saint-pauls-church.md`

Please review this venue submission and edit the content as needed before merging.