### PR TITLE
New: Batavialand from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/batavialand.md
+++ b/content/daytrip/eu/nl/batavialand.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/nl/batavialand"
+date: "2025-06-14T15:13:27.318Z"
+poster: "Frederik Dekker"
+lat: "52.522324"
+lng: "5.437406"
+location: "Oostvaardersdijk 01-13, 8242 PA, Lelystad, The Netherlands"
+title: "Batavialand"
+external_url: https://www.batavialand.nl/en/
+---
+Museum that started out as social project to reconstruct a Dutch East Indiaman trading ship. The Batavia that was built here can be visited as well as the shipyard where a new reconstruction is being built. In the shipyard all trades necessary to built such a ship are shown. 
+
+The museum also has a part on the history of Flevoland, from the land reclamation part to underwater archeology in the whole Northsea and former Zuiderzee.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Batavialand
**Location:** Oostvaardersdijk 01-13, 8242 PA, Lelystad, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.batavialand.nl/en/

### Description
Museum that started out as social project to reconstruct a Dutch East Indiaman trading ship. The Batavia that was built here can be visited as well as the shipyard where a new reconstruction is being built. In the shipyard all trades necessary to built such a ship are shown. 

The museum also has a part on the history of Flevoland, from the land reclamation part to underwater archeology in the whole Northsea and former Zuiderzee.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 462
**File:** `content/daytrip/eu/nl/batavialand.md`

Please review this venue submission and edit the content as needed before merging.