### PR TITLE
New: Cragside from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/cragside.md
+++ b/content/daytrip/eu/gb/cragside.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/cragside"
+date: "2025-06-15T13:29:53.322Z"
+poster: "alwAudio"
+lat: "55.313628"
+lng: "-1.885633"
+location: "Cragside, Carriage Drive, Rothbury, Northumberland, North East, England, NE65 7PU, United Kingdom"
+title: "Cragside"
+external_url: https://www.nationaltrust.org.uk/visit/north-east/cragside
+---
+Victorian Tudor Revival house, nestled in acres of wooded landscape. Arguably the first 'smart' home, with dams and lakes generating hydroelectric power, a water-driven sawmill, laundry, early dishwasher, dumb waiter, hydraulic lift and a hydroelectric rotisserie.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cragside
**Location:** Cragside, Carriage Drive, Rothbury, Northumberland, North East, England, NE65 7PU, United Kingdom
**Submitted by:** alwAudio
**Website:** https://www.nationaltrust.org.uk/visit/north-east/cragside

### Description
Victorian Tudor Revival house, nestled in acres of wooded landscape. Arguably the first 'smart' home, with dams and lakes generating hydroelectric power, a water-driven sawmill, laundry, early dishwasher, dumb waiter, hydraulic lift and a hydroelectric rotisserie.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 464
**File:** `content/daytrip/eu/gb/cragside.md`

Please review this venue submission and edit the content as needed before merging.