### PR TITLE
New: Dungeness Old Lighthouse from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/dungeness-old-lighthouse.md
+++ b/content/daytrip/eu/gb/dungeness-old-lighthouse.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/eu/gb/dungeness-old-lighthouse"
+date: "2025-06-15T13:30:17.660Z"
+poster: "alwAudio"
+lat: "50.913744"
+lng: "0.969707"
+location: "Dungeness Old Lighthouse, Dungeness Road, Lydd, Dungeness, Kent, England, TN29 9ND"
+title: "Dungeness Old Lighthouse"
+external_url: https://dungenesslighthouse.com/
+---
+Opened with great ceremony by His Royal Majesty the Prince of Wales in 1904 after a 3 year build, it survived two world wars before being decommissioned in 1960. For 56 years it provided a welcome light to vessels negotiating the perils of the English Channel. The Lighthouse features in Nickolaus Pevsner's "Buildings of Kent".
+
+This imposing building is almost 46 metres high to the top of the weather vane, 11 metres in diameter and constructed of engineering bricks with sandstone inner walls. Over three million bricks were used to build the structure.
+
+Internally, there are a series of mezzanine floors made of slate and supported by steel beams and massive rivets. Each floor is linked by circular concrete stairs which hug the walls and have decorative wrought iron bannisters. There are cambered casement viewing windows on all floors.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dungeness Old Lighthouse
**Location:** Dungeness Old Lighthouse, Dungeness Road, Lydd, Dungeness, Kent, England, TN29 9ND
**Submitted by:** alwAudio
**Website:** https://dungenesslighthouse.com/

### Description
Opened with great ceremony by His Royal Majesty the Prince of Wales in 1904 after a 3 year build, it survived two world wars before being decommissioned in 1960. For 56 years it provided a welcome light to vessels negotiating the perils of the English Channel. The Lighthouse features in Nickolaus Pevsner's "Buildings of Kent".

This imposing building is almost 46 metres high to the top of the weather vane, 11 metres in diameter and constructed of engineering bricks with sandstone inner walls. Over three million bricks were used to build the structure.

Internally, there are a series of mezzanine floors made of slate and supported by steel beams and massive rivets. Each floor is linked by circular concrete stairs which hug the walls and have decorative wrought iron bannisters. There are cambered casement viewing windows on all floors.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 466
**File:** `content/daytrip/eu/gb/dungeness-old-lighthouse.md`

Please review this venue submission and edit the content as needed before merging.