### PR TITLE
New: Chislehurst Caves from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/chislehurst-caves.md
+++ b/content/daytrip/eu/gb/chislehurst-caves.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/eu/gb/chislehurst-caves"
+date: "2025-06-15T13:30:35.999Z"
+poster: "alwAudio"
+lat: "51.407317"
+lng: "0.057849"
+location: "Chislehurst Caves, Rutland Court, Chislehurst, Bromley, London, Greater London, BR7 5QX"
+title: "Chislehurst Caves"
+external_url: https://chislehurst-caves.co.uk/
+---
+The caves have been carved out over hundreds of years. The caves were dug for chalk used in lime burning and brick making for the Building of London, as well as for flints to fire the tinderboxes and flintlock guns of years ago.
+
+First open to the public in 1900 as a showplace, the guides told the Victorians history of Romans, Druids and Saxons, Smuggling and Murder. The last 100 years has added munitions storage for the Woolwich Arsenal in the 1914-18 war, Mushroom growing in the 1920 and 1930’s and becoming an underground town as the largest deep air-raid shelter outside London, protecting over 15000 people every night during the Blitz.
+
+In the 1950’s, 1960’s and 1970’s the caves were used as a venue for dances and concerts, presenting the foundations of Jazz, Skiffle and Folk music to the most famous names in pop and rock.
+
+Now the caves are open as a tourist attraction and education centre with a gift shop and Café catering for visitors, group outings, private functions and children’s parties.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Chislehurst Caves
**Location:** Chislehurst Caves, Rutland Court, Chislehurst, Bromley, London, Greater London, BR7 5QX
**Submitted by:** alwAudio
**Website:** https://chislehurst-caves.co.uk/

### Description
The caves have been carved out over hundreds of years. The caves were dug for chalk used in lime burning and brick making for the Building of London, as well as for flints to fire the tinderboxes and flintlock guns of years ago.

First open to the public in 1900 as a showplace, the guides told the Victorians history of Romans, Druids and Saxons, Smuggling and Murder. The last 100 years has added munitions storage for the Woolwich Arsenal in the 1914-18 war, Mushroom growing in the 1920 and 1930’s and becoming an underground town as the largest deep air-raid shelter outside London, protecting over 15000 people every night during the Blitz.

In the 1950’s, 1960’s and 1970’s the caves were used as a venue for dances and concerts, presenting the foundations of Jazz, Skiffle and Folk music to the most famous names in pop and rock.

Now the caves are open as a tourist attraction and education centre with a gift shop and Café catering for visitors, group outings, private functions and children’s parties.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 467
**File:** `content/daytrip/eu/gb/chislehurst-caves.md`

Please review this venue submission and edit the content as needed before merging.