### PR TITLE
New: Train World from robvdw2

### DIFF
--- a/content/daytrip/eu/be/train-world.md
+++ b/content/daytrip/eu/be/train-world.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/be/train-world"
+date: "2025-06-15T13:30:44.858Z"
+poster: "robvdw2"
+lat: "50.878858"
+lng: "4.380883"
+location: "Train World, Prinses Elisabethplein, Monplaisir, Schaarbeek, Brussels-Capital, 1030, Belgium"
+title: "Train World"
+external_url: https://www.trainworld.be
+---
+Large indoor train museum at the Schaarbeek railway station focusing on the history of the Belgian railways. Spanning over 8000 square meters, the museum showcases more than 20 locomotives


### PR DESCRIPTION
## New Venue Submission

**Venue:** Train World
**Location:** Train World, Prinses Elisabethplein, Monplaisir, Schaarbeek, Brussels-Capital, 1030, Belgium
**Submitted by:** robvdw2
**Website:** https://www.trainworld.be

### Description
Large indoor train museum at the Schaarbeek railway station focusing on the history of the Belgian railways. Spanning over 8000 square meters, the museum showcases more than 20 locomotives

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 468
**File:** `content/daytrip/eu/be/train-world.md`

Please review this venue submission and edit the content as needed before merging.