### PR TITLE
New: Schiphol Airport Panorama Terrace & Fokker 100 from robvdw2

### DIFF
--- a/content/daytrip/eu/nl/schiphol-airport-panorama-terrace-fokker-100.md
+++ b/content/daytrip/eu/nl/schiphol-airport-panorama-terrace-fokker-100.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/nl/schiphol-airport-panorama-terrace-fokker-100"
+date: "2025-06-15T13:30:55.493Z"
+poster: "robvdw2"
+lat: "52.308894"
+lng: "4.765673"
+location: "Panorama Terrace, Schiphol, 1118 CB, Netherlands"
+title: "Schiphol Airport Panorama Terrace & Fokker 100"
+external_url: https://www.schiphol.nl/en/at-schiphol/see-planes-up-close-from-panorama-terrace/
+---
+Large panorama terrace with view on the C, D and E aprons and 2 runways. On the terrace, you can also visit a Fokker 100 aircraft that has been turned into a small free museum on the history of the Dutch aircraft maker.
+Free access (at the main Plaza go to the right towards Arrivals 1-2 and then follow the signs all the way to the right and 2 floors up to the panaroma terrace), some outdoor benches and tables where you bring your own food and drinks, never busy


### PR DESCRIPTION
## New Venue Submission

**Venue:** Schiphol Airport Panorama Terrace & Fokker 100
**Location:** Panorama Terrace, Schiphol, 1118 CB, Netherlands
**Submitted by:** robvdw2
**Website:** https://www.schiphol.nl/en/at-schiphol/see-planes-up-close-from-panorama-terrace/

### Description
Large panorama terrace with view on the C, D and E aprons and 2 runways. On the terrace, you can also visit a Fokker 100 aircraft that has been turned into a small free museum on the history of the Dutch aircraft maker.
Free access (at the main Plaza go to the right towards Arrivals 1-2 and then follow the signs all the way to the right and 2 floors up to the panaroma terrace), some outdoor benches and tables where you bring your own food and drinks, never busy

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 469
**File:** `content/daytrip/eu/nl/schiphol-airport-panorama-terrace-fokker-100.md`

Please review this venue submission and edit the content as needed before merging.