### PR TITLE
New: Hawker Hunter WT723 from Andy Mabbett

### DIFF
--- a/content/daytrip/eu/gb/hawker-hunter-wt723.md
+++ b/content/daytrip/eu/gb/hawker-hunter-wt723.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/hawker-hunter-wt723"
+date: "2025-06-15T13:31:06.652Z"
+poster: "Andy Mabbett"
+lat: "52.452745"
+lng: "-1.854092"
+location: "Hawker Hunter WT723, Warwick Road, Greet, Birmingham, England B11 3RF"
+title: "Hawker Hunter WT723"
+external_url: https://www.thunder-and-lightnings.co.uk/hunter/survivor.php?id=338
+---
+Preserved Hawker Hunter aircraft.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Hawker Hunter WT723
**Location:** Hawker Hunter WT723, Warwick Road, Greet, Birmingham, England B11 3RF
**Submitted by:** Andy Mabbett
**Website:** https://www.thunder-and-lightnings.co.uk/hunter/survivor.php?id=338

### Description
Preserved Hawker Hunter aircraft.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 470
**File:** `content/daytrip/eu/gb/hawker-hunter-wt723.md`

Please review this venue submission and edit the content as needed before merging.