### PR TITLE
New: Swiss Museum of Transport from Renaldo

### DIFF
--- a/content/daytrip/eu/ch/swiss-museum-of-transport.md
+++ b/content/daytrip/eu/ch/swiss-museum-of-transport.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/ch/swiss-museum-of-transport"
+date: "2025-06-15T16:32:06.738Z"
+poster: "Renaldo"
+lat: "47.052753"
+lng: "8.336636"
+location: "Swiss Museum of Transport, 5, Lidostrasse, Schlössli, Lucerne, 6006, Switzerland"
+title: "Swiss Museum of Transport"
+external_url: https://www.verkehrshaus.ch/en/home.html
+---
+Anyone interested in the technical details of transportaion (rail, automotive, marine, aviation, space) will have a good time


### PR DESCRIPTION
## New Venue Submission

**Venue:** Swiss Museum of Transport
**Location:** Swiss Museum of Transport, 5, Lidostrasse, Schlössli, Lucerne, 6006, Switzerland
**Submitted by:** Renaldo
**Website:** https://www.verkehrshaus.ch/en/home.html

### Description
Anyone interested in the technical details of transportaion (rail, automotive, marine, aviation, space) will have a good time

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 474
**File:** `content/daytrip/eu/ch/swiss-museum-of-transport.md`

Please review this venue submission and edit the content as needed before merging.