### PR TITLE
New: Gameorama from Renaldo

### DIFF
--- a/content/daytrip/eu/ch/gameorama.md
+++ b/content/daytrip/eu/ch/gameorama.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/ch/gameorama"
+date: "2025-06-15T16:32:51.891Z"
+poster: "Renaldo"
+lat: "47.050745"
+lng: "8.301024"
+location: "Gameorama, 49, Hirschengraben, Kleinstadt, Lucerne, 6000, Switzerland"
+title: "Gameorama"
+external_url: https://www.gameorama.ch/en
+---
+Games from different eras and with different technologies can be tried out. Reservations are recommended


### PR DESCRIPTION
## New Venue Submission

**Venue:** Gameorama
**Location:** Gameorama, 49, Hirschengraben, Kleinstadt, Lucerne, 6000, Switzerland
**Submitted by:** Renaldo
**Website:** https://www.gameorama.ch/en

### Description
Games from different eras and with different technologies can be tried out. Reservations are recommended

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 476
**File:** `content/daytrip/eu/ch/gameorama.md`

Please review this venue submission and edit the content as needed before merging.