### PR TITLE
New: Nottingham Industrial Museum from Pure Steamin' Man

### DIFF
--- a/content/daytrip/eu/gb/nottingham-industrial-museum.md
+++ b/content/daytrip/eu/gb/nottingham-industrial-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/nottingham-industrial-museum"
+date: "2025-06-16T10:13:05.928Z"
+poster: "Pure Steamin' Man"
+lat: "52.9481"
+lng: "-1.211996"
+location: "Nottingham Industrial Museum, Lime Tree Avenue, Wollaton Vale, Wollaton, Nottingham, East Midlands, England, NG8 1BT, United Kingdom"
+title: "Nottingham Industrial Museum"
+external_url: https://nottinghamindustrialmuseum.org.uk/
+---
+See the mechanical and industrial heritage of Nottingham with exhibits covering motor vehicles, lace manufacturing, telecoms and steam engines. The museum has semi-regular steaming days where steam engines are run for real.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Nottingham Industrial Museum
**Location:** Nottingham Industrial Museum, Lime Tree Avenue, Wollaton Vale, Wollaton, Nottingham, East Midlands, England, NG8 1BT, United Kingdom
**Submitted by:** Pure Steamin' Man
**Website:** https://nottinghamindustrialmuseum.org.uk/

### Description
See the mechanical and industrial heritage of Nottingham with exhibits covering motor vehicles, lace manufacturing, telecoms and steam engines. The museum has semi-regular steaming days where steam engines are run for real.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 477
**File:** `content/daytrip/eu/gb/nottingham-industrial-museum.md`

Please review this venue submission and edit the content as needed before merging.