### PR TITLE
New: Papplewick Pumping Station from Pure Steamin' Man

### DIFF
--- a/content/daytrip/eu/gb/papplewick-pumping-station.md
+++ b/content/daytrip/eu/gb/papplewick-pumping-station.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/papplewick-pumping-station"
+date: "2025-06-16T10:13:14.346Z"
+poster: "Pure Steamin' Man"
+lat: "53.063205"
+lng: "-1.13136"
+location: "Papplewick Pumping Station, Rigg Lane, Nottinghamshire, NG15 9AJ, United Kingdom"
+title: "Papplewick Pumping Station"
+external_url: https://papplewickpumpingstation.org.uk/
+---
+This small museum is home to a steam engine that was used to pump millions of gallons of water into nearby Nottingham. They do fire up the boilers on semi-regular steaming days.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Papplewick Pumping Station
**Location:** Papplewick Pumping Station, Rigg Lane, Nottinghamshire, NG15 9AJ, United Kingdom
**Submitted by:** Pure Steamin' Man
**Website:** https://papplewickpumpingstation.org.uk/

### Description
This small museum is home to a steam engine that was used to pump millions of gallons of water into nearby Nottingham. They do fire up the boilers on semi-regular steaming days.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 478
**File:** `content/daytrip/eu/gb/papplewick-pumping-station.md`

Please review this venue submission and edit the content as needed before merging.