### PR TITLE
Update ww2-plane-wreck-on-the-east-side-of-ben-havel.md

### DIFF
--- a/content/daytrip/eu/gb/ww2-plane-wreck-on-the-east-side-of-ben-havel.md
+++ b/content/daytrip/eu/gb/ww2-plane-wreck-on-the-east-side-of-ben-havel.md
@@ -5,8 +5,10 @@ lat: 56.963854
 lng: -7.465553
 location: "Our Lady of The Sea, A888, Gearraidh Gadhal, Bàgh a' Chaisteil, Na h-Eileanan\
   \ Siar, Alba / Scotland, HS9 5UH, United Kingdom"
-external_url: http://www.clydesideimages.co.uk/lockheed-hudson-wreck-on-ben-lui.html
+external_url: https://web.archive.org/web/20240527065704/http://www.clydesideimages.co.uk/lockheed-hudson-wreck-on-ben-lui.html
 title: WW2 Plane wreck on the east side of Ben Havel
 ---
+
+More images available at [http://www.edwardboyle.com/wreck8.html]
 
 


### PR DESCRIPTION
The Clydeside images site is returning 404. Using a recent Wayback Machine alternative.

Also, including another image site in the footnote.