### PR TITLE
New: Operation Chariot Memorial from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/operation-chariot-memorial.md
+++ b/content/daytrip/eu/gb/operation-chariot-memorial.md
@@ -1,0 +1,24 @@
+---
+slug: "daytrip/eu/gb/operation-chariot-memorial"
+date: "2025-06-16T13:50:10.478Z"
+poster: "AndiBing"
+lat: "50.15659"
+lng: "-5.070381"
+location: "Prince of Wales Pier, Falmouth, Cornwall, England, TR11 3DF, United Kingdom"
+title: "Operation Chariot Memorial"
+external_url: https://www.operation-chariot.org/
+---
+Memorial to Operation Chariot. The St. Nazaire Raid. Known as "The Greatest Raid of All".
+
+    OPERATION CHARIOT
+
+ FROM THIS HARBOUR 622 SAILORS
+  AND COMMANDOS SET SAIL FOR
+THE SUCCESSFUL RAID ON ST.NAZAIRE
+ 28TH MARCH 1942 168 WERE KILLED
+5 VICTORIA CROSSES WERE AWARDED
+         ----- o -----
+  DEDICATED TO THE MEMORY OF
+       THEIR COMRADES BY
+THE ST.NAZAIRE SOCIETY
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Operation Chariot Memorial
**Location:** Prince of Wales Pier, Falmouth, Cornwall, England, TR11 3DF, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.operation-chariot.org/

### Description
Memorial to Operation Chariot. The St. Nazaire Raid. Known as "The Greatest Raid of All".

    OPERATION CHARIOT

 FROM THIS HARBOUR 622 SAILORS
  AND COMMANDOS SET SAIL FOR
THE SUCCESSFUL RAID ON ST.NAZAIRE
 28TH MARCH 1942 168 WERE KILLED
5 VICTORIA CROSSES WERE AWARDED
         ----- o -----
  DEDICATED TO THE MEMORY OF
       THEIR COMRADES BY
THE ST.NAZAIRE SOCIETY



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 479
**File:** `content/daytrip/eu/gb/operation-chariot-memorial.md`

Please review this venue submission and edit the content as needed before merging.