### PR TITLE
New: Seebühne Bregenz from AndiBing

### DIFF
--- a/content/daytrip/eu/at/seebhne-bregenz.md
+++ b/content/daytrip/eu/at/seebhne-bregenz.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/at/seebhne-bregenz"
+date: "2025-06-16T13:50:48.007Z"
+poster: "AndiBing"
+lat: "47.505731"
+lng: "9.738096"
+location: "Seebühne Bregenz, Bregenz,Vorarlberg, 6900, Austria"
+title: "Seebühne Bregenz"
+external_url: https://bregenzerfestspiele.com/en
+---
+Floating theatre. Made famous(er) by the film Quantum of Solace (2008).
+


### PR DESCRIPTION
## New Venue Submission

**Venue:** Seebühne Bregenz
**Location:** Seebühne Bregenz, Bregenz,Vorarlberg, 6900, Austria
**Submitted by:** AndiBing
**Website:** https://bregenzerfestspiele.com/en

### Description
Floating theatre. Made famous(er) by the film Quantum of Solace (2008).



### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 481
**File:** `content/daytrip/eu/at/seebhne-bregenz.md`

Please review this venue submission and edit the content as needed before merging.