### PR TITLE
daytrip: world chess hall of fame

### DIFF
--- a/content/daytrip/na/us/world-chess-hall-of-fame.md
+++ b/content/daytrip/na/us/world-chess-hall-of-fame.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/world-chess-hall-of-fame"
+title: "World Chess Hall of Fame & Galleries"
+location: "St. Louis, MO, USA, 63108"
+poster: "ifTaylor"
+date: '2025-06-16T13:00:00'
+lat: '38.644510780180326'
+lng: '-90.26122117301887'
+external_url: https://worldchesshof.org/
+---
+Educate visitors, fans, players, and scholars by collecting, preserving, exhibiting, and interpreting the game of chess and its continuing cultural and artistic significance.


### PR DESCRIPTION
## New Venue Submission
**Venue:** World Chess Hall of Fame & Galleries
**Location:** St. Louis, MO
**Submitted by:** ifTaylor
**Website:** https://worldchesshof.org/

### Description
Honoring the masters of chess, the World Chess Hall of Fame & Galleries (WCHOF) is a premier destination for chess enthusiasts, dedicated to preserving and celebrating the rich history of the game. Located in Saint Louis, Missouri, United States, the WCHOF is a hub for education, exhibitions, and events that showcase the cultural significance and impact of chess.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

Submission: 768
File: content/daytrip/na/us/world-chess-hall-of-fame.md

Please review this venue submission and edit the content as needed before merging.