### PR TITLE
New: West Berkshire Museum from Neil

### DIFF
--- a/content/daytrip/eu/gb/west-berkshire-museum.md
+++ b/content/daytrip/eu/gb/west-berkshire-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/west-berkshire-museum"
+date: "2025-06-16T20:22:21.938Z"
+poster: "Neil"
+lat: "51.40133"
+lng: "-1.321959"
+location: "West Berkshire Museum, Wharf Street, Newbury Wharf, Newbury, West Berkshire, England, RG14 5AS, United Kingdom"
+title: "West Berkshire Museum"
+external_url: https://www.westberkshireheritage.org/west-berkshire-museum
+---
+A small, free (but donations welcomed) museum. The downstairs section sets out the history of Newbury and wider west Berkshire, with trails for children available for free from the reception desk. The upstairs section houses temporarily exhibitions, and a small reference library.


### PR DESCRIPTION
## New Venue Submission

**Venue:** West Berkshire Museum
**Location:** West Berkshire Museum, Wharf Street, Newbury Wharf, Newbury, West Berkshire, England, RG14 5AS, United Kingdom
**Submitted by:** Neil
**Website:** https://www.westberkshireheritage.org/west-berkshire-museum

### Description
A small, free (but donations welcomed) museum. The downstairs section sets out the history of Newbury and wider west Berkshire, with trails for children available for free from the reception desk. The upstairs section houses temporarily exhibitions, and a small reference library.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 483
**File:** `content/daytrip/eu/gb/west-berkshire-museum.md`

Please review this venue submission and edit the content as needed before merging.