### PR TITLE
New: Högbo Bruk from NerdyCec

### DIFF
--- a/content/daytrip/eu/se/hgbo-bruk.md
+++ b/content/daytrip/eu/se/hgbo-bruk.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/eu/se/hgbo-bruk"
+date: "2025-06-16T20:22:41.178Z"
+poster: "NerdyCec"
+lat: "60.670767"
+lng: "16.817633"
+location: "Hans Hiertas väg, Sandviken, Sweden"
+title: "Högbo Bruk"
+external_url: https://www.hogbobruk.se
+---
+The story of Högbo Bruk began with Bergslagen's good iron ore, skilled miners and a rare suitable watercourse. With the rich forests, there were all the conditions for a flourishing ironworks. In the 17th century, Högbo Bruk became a center for iron production, a place where development took place and wealth was created.
+
+Högbo Bruk is best known as the place where Consul Göransson forged the first Bessemer steel in 1858 and revolutionized steel production. Göransson's steel became a worldwide success and he started a completely new industrial company from the ironworks in Högbo. Thus, a 200-year-long era ended and another began. New owners took over and the mill was given new purposes such as agriculture and summer entertainment. Högbo Bruk is today an open outdoor paradise, a living cultural heritage and an important cog in society.
+
+Consul Göransson then? Well, things went well for him and his new steel mill, which has developed into the world-renowned industrial group Sandvik. Not bad!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Högbo Bruk
**Location:** Hans Hiertas väg, Sandviken, Sweden
**Submitted by:** NerdyCec
**Website:** https://www.hogbobruk.se

### Description
The story of Högbo Bruk began with Bergslagen's good iron ore, skilled miners and a rare suitable watercourse. With the rich forests, there were all the conditions for a flourishing ironworks. In the 17th century, Högbo Bruk became a center for iron production, a place where development took place and wealth was created.

Högbo Bruk is best known as the place where Consul Göransson forged the first Bessemer steel in 1858 and revolutionized steel production. Göransson's steel became a worldwide success and he started a completely new industrial company from the ironworks in Högbo. Thus, a 200-year-long era ended and another began. New owners took over and the mill was given new purposes such as agriculture and summer entertainment. Högbo Bruk is today an open outdoor paradise, a living cultural heritage and an important cog in society.

Consul Göransson then? Well, things went well for him and his new steel mill, which has developed into the world-renowned industrial group Sandvik. Not bad!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 484
**File:** `content/daytrip/eu/se/hgbo-bruk.md`

Please review this venue submission and edit the content as needed before merging.