### PR TITLE
New: Bunhill Fields Burial Ground from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/bunhill-fields-burial-ground.md
+++ b/content/daytrip/eu/gb/bunhill-fields-burial-ground.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/bunhill-fields-burial-ground"
+date: "2025-06-16T21:40:45.359Z"
+poster: "alwAudio"
+lat: "51.52373"
+lng: "-0.088729"
+location: " Saint Luke's, Finsbury, London Borough of Islington, London, Greater London, England, EC1Y 2BG"
+title: "Bunhill Fields Burial Ground"
+external_url: https://www.cityoflondon.gov.uk/things-to-do/city-gardens/find-a-garden/bunhill-fields-burial-ground
+---
+Discovered after listening to the TheThe song 'Some Days I Drink My Coffee by the Grave of William Blake' and a detour on a cycle ride. It contains the graves of many non-conformists, including the aforementioned William Blake, but also of Thomas Bayes, statistician and Bayesian probability fame amongst many others. They're are two graves for William Blake and the story behind that is an interesting one:https://www.theguardian.com/culture/2018/aug/11/how-amateur-sleuths-finally-tracked-down-burial-place-william-blake 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bunhill Fields Burial Ground
**Location:**  Saint Luke's, Finsbury, London Borough of Islington, London, Greater London, England, EC1Y 2BG
**Submitted by:** alwAudio
**Website:** https://www.cityoflondon.gov.uk/things-to-do/city-gardens/find-a-garden/bunhill-fields-burial-ground

### Description
Discovered after listening to the TheThe song 'Some Days I Drink My Coffee by the Grave of William Blake' and a detour on a cycle ride. It contains the graves of many non-conformists, including the aforementioned William Blake, but also of Thomas Bayes, statistician and Bayesian probability fame amongst many others. They're are two graves for William Blake and the story behind that is an interesting one:https://www.theguardian.com/culture/2018/aug/11/how-amateur-sleuths-finally-tracked-down-burial-place-william-blake 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 488
**File:** `content/daytrip/eu/gb/bunhill-fields-burial-ground.md`

Please review this venue submission and edit the content as needed before merging.