### PR TITLE
New: Unst Boat Haven from Sarah Dal

### DIFF
--- a/content/daytrip/eu/gb/unst-boat-haven.md
+++ b/content/daytrip/eu/gb/unst-boat-haven.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/unst-boat-haven"
+date: "2025-06-16T21:41:00.159Z"
+poster: "Sarah Dal"
+lat: "60.7884107"
+lng: "-0.830132"
+location: "Haroldswick, Unst ZE2 9ED"
+title: "Unst Boat Haven"
+external_url: https://unstheritage.co.uk/boat-haven/
+---
+Museum of Shetland's relationship with the sea


### PR DESCRIPTION
## New Venue Submission

**Venue:** Unst Boat Haven
**Location:** Haroldswick, Unst ZE2 9ED
**Submitted by:** Sarah Dal
**Website:** https://unstheritage.co.uk/boat-haven/

### Description
Museum of Shetland's relationship with the sea

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 490
**File:** `content/daytrip/eu/gb/unst-boat-haven.md`

Please review this venue submission and edit the content as needed before merging.