### PR TITLE
Website Logos

### DIFF
--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -475,7 +475,6 @@ html, body {
 #map .leaflet-popup-content { 
   color: #222; 
   width: 400px;
-  height: 200px;
   line-height: 1.4;
   font-weight: normal;
   font-size: 1em; 

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -67,6 +67,16 @@ async function loadMarkers(L, map) {
                 // If the venue has an external_url add it as a ink to the popup
                 if (v.external_url) {
                     popupText += `&nbsp;&nbsp;<a href="${v.external_url}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>`;
+                    const domain = new URL(v.external_url).hostname;
+                    popupText += `
+                      <br>
+                      <img
+                         src="https://logo.clearbit.com/${domain}"
+                         alt="Site logo"
+                         style="margin-top:8px; max-width:100%; border-radius:4px;"
+                         onerror="this.style.display='none';"
+                       />
+                      `;
                 }
                 // If the venue has a location, append it to the popup text
                 if (v.location) {

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -70,12 +70,14 @@ async function loadMarkers(L, map) {
                     const domain = new URL(v.external_url).hostname;
                     popupText += `
                       <br>
+                      <a href="${v.external_url}" target="_blank" rel="noopener noreferrer">
                       <img
                          src="https://logo.clearbit.com/${domain}"
                          alt="Site logo"
                          style="margin-top:8px; max-width:100%; border-radius:4px;"
                          onerror="this.style.display='none';"
                        />
+                      </a>
                       `;
                 }
                 // If the venue has a location, append it to the popup text

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -72,7 +72,7 @@ async function loadMarkers(L, map) {
                       <br>
                       <a href="${v.external_url}" target="_blank" rel="noopener noreferrer">
                       <img
-                         src="https://logo.clearbit.com/${domain}"
+                         src="https://img.logo.dev/${domain}?token=pk_SBlY0W47S9Ww5wmX2PejKA"
                          alt="Site logo"
                          style="margin-top:8px; max-width:100%; border-radius:4px;"
                          onerror="this.style.display='none';"


### PR DESCRIPTION
# Enhancement: Add Clickable Logos to Venue Popups
**Submitted by:** ifTaylor  
**Purpose:** Adding website metadata to popup.  

## Implementation Details
- Extracts domain name from `v.external_url`
- Embeds a Logo.dev image
- Wraps the image in an anchor element, opening the venue’s site in a new tab
- Remove explicit pop up height, allowing content to set pop up height

## Review Checklist
- [ ] Validate that logo loads successfully
- [ ] Verify fallback behavior when logo is not available (image hides)
- [ ] Confirm layout works across common screen sizes
- [ ] Test popup rendering performance with and without logo

Please review this enhancement and test across several venues.