### PR TITLE
New: Tagebau Hambach from clonejo

### DIFF
--- a/content/daytrip/eu/de/tagebau-hambach.md
+++ b/content/daytrip/eu/de/tagebau-hambach.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/eu/de/tagebau-hambach"
+date: "2025-06-17T06:01:57.616Z"
+poster: "clonejo"
+lat: "50.882582"
+lng: "6.508657"
+location: "Aussichtspunkt "Haus am See" Tagebau Hambach, Bürgeweg, Niederzier, Kreis Düren, 52382, Deutschland"
+title: "Tagebau Hambach"
+external_url: https://www.rwe.com/der-konzern/laender-und-standorte/tagebau-hambach/
+---
+Check out Europe's biggest hole and see Bagger 288's first workplace for yourself!
+
+It's outside, only makes sense with good weather and no fog. Bring binoculars or your telephoto camera.
+
+Not wheelchair accessible, but there is another viewpoint at the opposite side without steps (i think).
+
+A bit to the south you will find an abandoned piece of motorway.

--- a/content/daytrip/eu/de/tagebau-hambach.md
+++ b/content/daytrip/eu/de/tagebau-hambach.md
@@ -4,7 +4,7 @@ date: "2025-06-17T06:01:57.616Z"
 poster: "clonejo"
 lat: "50.882582"
 lng: "6.508657"
-location: "Aussichtspunkt "Haus am See" Tagebau Hambach, Bürgeweg, Niederzier, Kreis Düren, 52382, Deutschland"
+location: "Aussichtspunkt 'Haus am See' Tagebau Hambach, Bürgeweg, Niederzier, Kreis Düren, 52382, Deutschland"
 title: "Tagebau Hambach"
 external_url: https://www.rwe.com/der-konzern/laender-und-standorte/tagebau-hambach/
 ---


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tagebau Hambach
**Location:** Aussichtspunkt "Haus am See" Tagebau Hambach, Bürgeweg, Niederzier, Kreis Düren, 52382, Deutschland
**Submitted by:** clonejo
**Website:** https://www.rwe.com/der-konzern/laender-und-standorte/tagebau-hambach/

### Description
Check out Europe's biggest hole and see Bagger 288's first workplace for yourself!

It's outside, only makes sense with good weather and no fog. Bring binoculars or your telephoto camera.

Not wheelchair accessible, but there is another viewpoint at the opposite side without steps (i think).

A bit to the south you will find an abandoned piece of motorway.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 491
**File:** `content/daytrip/eu/de/tagebau-hambach.md`

Please review this venue submission and edit the content as needed before merging.