### PR TITLE
New: WWII Sound Mirror from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/wwii-sound-mirror.md
+++ b/content/daytrip/eu/gb/wwii-sound-mirror.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/wwii-sound-mirror"
+date: "2025-06-17T10:30:58.933Z"
+poster: "alwAudio"
+lat: "51.101721"
+lng: "1.243651"
+location: "WWII Sound Mirror, Old Folkestone Road, Hougham Without, Dover, Kent, England, CT15 7AE"
+title: "WWII Sound Mirror"
+external_url: https://webapps.kent.gov.uk/KCC.ExploringKentsPast.Web.Sites.Public/SingleResult.aspx?uid=%27mke17880%27
+---
+WWII Sound Mirror, one of a few along the Kent coast.


### PR DESCRIPTION
## New Venue Submission

**Venue:** WWII Sound Mirror
**Location:** WWII Sound Mirror, Old Folkestone Road, Hougham Without, Dover, Kent, England, CT15 7AE
**Submitted by:** alwAudio
**Website:** https://webapps.kent.gov.uk/KCC.ExploringKentsPast.Web.Sites.Public/SingleResult.aspx?uid=%27mke17880%27

### Description
WWII Sound Mirror, one of a few along the Kent coast.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 494
**File:** `content/daytrip/eu/gb/wwii-sound-mirror.md`

Please review this venue submission and edit the content as needed before merging.