### PR TITLE
New: Morpeth Chantry Bagpipe Museum from Sarah Dal

### DIFF
--- a/content/daytrip/eu/gb/morpeth-chantry-bagpipe-museum.md
+++ b/content/daytrip/eu/gb/morpeth-chantry-bagpipe-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/morpeth-chantry-bagpipe-museum"
+date: "2025-06-17T10:31:22.202Z"
+poster: "Sarah Dal"
+lat: "55.166851"
+lng: "-1.686814"
+location: "Morpeth Chantry Bagpipe Museum, Chantry Place, High Stanners, Morpeth, Northumberland, NE61 1PD"
+title: "Morpeth Chantry Bagpipe Museum"
+external_url: https://museumsnorthumberland.org.uk/morpeth-chantry-bagpipe-museum/
+---
+Small museum dedicated to the Northumbrian small pipes and other examples of bagpipe instruments from across the world


### PR DESCRIPTION
## New Venue Submission

**Venue:** Morpeth Chantry Bagpipe Museum
**Location:** Morpeth Chantry Bagpipe Museum, Chantry Place, High Stanners, Morpeth, Northumberland, NE61 1PD
**Submitted by:** Sarah Dal
**Website:** https://museumsnorthumberland.org.uk/morpeth-chantry-bagpipe-museum/

### Description
Small museum dedicated to the Northumbrian small pipes and other examples of bagpipe instruments from across the world

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 493
**File:** `content/daytrip/eu/gb/morpeth-chantry-bagpipe-museum.md`

Please review this venue submission and edit the content as needed before merging.