### PR TITLE
New: Dutch Pinball Museum from MarcN

### DIFF
--- a/content/daytrip/eu/nl/dutch-pinball-museum.md
+++ b/content/daytrip/eu/nl/dutch-pinball-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/dutch-pinball-museum"
+date: "2025-06-18T04:23:44.520Z"
+poster: "MarcN"
+lat: "51.908007"
+lng: "4.448844"
+location: "Voorhaven 12, 3024 RM Rotterdam, Netherlands "
+title: "Dutch Pinball Museum"
+external_url: https://dutchpinballmuseum.com/
+---
+Collection of more than 100 playable pinball machines. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dutch Pinball Museum
**Location:** Voorhaven 12, 3024 RM Rotterdam, Netherlands 
**Submitted by:** MarcN
**Website:** https://dutchpinballmuseum.com/

### Description
Collection of more than 100 playable pinball machines. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 495
**File:** `content/daytrip/eu/nl/dutch-pinball-museum.md`

Please review this venue submission and edit the content as needed before merging.