### PR TITLE
New: Frietmuseum from MarcN

### DIFF
--- a/content/daytrip/eu/be/frietmuseum.md
+++ b/content/daytrip/eu/be/frietmuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/be/frietmuseum"
+date: "2025-06-18T04:24:08.252Z"
+poster: "MarcN"
+lat: "51.211085"
+lng: "3.223761"
+location: "Vlamingstraat 33, 8000 Bruges, Belgium"
+title: "Frietmuseum"
+external_url: https://frietmuseum.be/
+---
+Exhibition on the history of potatoes and fries: photographs, artwork, historical potato peelers and chip-making machines


### PR DESCRIPTION
## New Venue Submission

**Venue:** Frietmuseum
**Location:** Vlamingstraat 33, 8000 Bruges, Belgium
**Submitted by:** MarcN
**Website:** https://frietmuseum.be/

### Description
Exhibition on the history of potatoes and fries: photographs, artwork, historical potato peelers and chip-making machines

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 496
**File:** `content/daytrip/eu/be/frietmuseum.md`

Please review this venue submission and edit the content as needed before merging.