### PR TITLE
New: Westbury White Horse from Trebor

### DIFF
--- a/content/daytrip/eu/gb/westbury-white-horse.md
+++ b/content/daytrip/eu/gb/westbury-white-horse.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/westbury-white-horse"
+date: "2025-06-18T04:24:41.001Z"
+poster: "Trebor"
+lat: "51.26361"
+lng: "-2.14694"
+location: "Bratton Road, Westbury, Wiltshire, BA13 3EP"
+title: "Westbury White Horse"
+external_url: https://www.english-heritage.org.uk/visit/places/bratton-camp-and-white-horse/
+---
+Large white horse near Westbury


### PR DESCRIPTION
## New Venue Submission

**Venue:** Westbury White Horse
**Location:** Bratton Road, Westbury, Wiltshire, BA13 3EP
**Submitted by:** Trebor
**Website:** https://www.english-heritage.org.uk/visit/places/bratton-camp-and-white-horse/

### Description
Large white horse near Westbury

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 497
**File:** `content/daytrip/eu/gb/westbury-white-horse.md`

Please review this venue submission and edit the content as needed before merging.