### PR TITLE
New: The Frost Entomological Museum from JamesEndresHowell

### DIFF
--- a/content/daytrip/na/us/the-frost-entomological-museum.md
+++ b/content/daytrip/na/us/the-frost-entomological-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/the-frost-entomological-museum"
+date: "2025-06-18T04:25:21.254Z"
+poster: "JamesEndresHowell"
+lat: "40.80296"
+lng: "-77.862405"
+location: "Frost Entomological Museum, Curtin Road, State College, Pennsylvania, 16802, United States"
+title: "The Frost Entomological Museum"
+external_url: https://ento.psu.edu/about/facilities/frost/visit-the-museum
+---
+Free to the public! It's a tiny space, so contact them if you have a large group. Follow the link for current hours.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Frost Entomological Museum
**Location:** Frost Entomological Museum, Curtin Road, State College, Pennsylvania, 16802, United States
**Submitted by:** JamesEndresHowell
**Website:** https://ento.psu.edu/about/facilities/frost/visit-the-museum

### Description
Free to the public! It's a tiny space, so contact them if you have a large group. Follow the link for current hours.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 498
**File:** `content/daytrip/na/us/the-frost-entomological-museum.md`

Please review this venue submission and edit the content as needed before merging.