### PR TITLE
New: Earth and Mineral Sciences Museum and Art Gallery from JamesEndresHowell

### DIFF
--- a/content/daytrip/na/us/earth-and-mineral-sciences-museum-and-art-gallery.md
+++ b/content/daytrip/na/us/earth-and-mineral-sciences-museum-and-art-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/earth-and-mineral-sciences-museum-and-art-gallery"
+date: "2025-06-18T04:26:15.599Z"
+poster: "JamesEndresHowell"
+lat: "40.794143"
+lng: "-77.865447"
+location: "EMS Museum and Art Gallery, North Burrowes Road, State College, Pennsylvania, 16801, United States"
+title: "Earth and Mineral Sciences Museum and Art Gallery"
+external_url: https://museum.ems.psu.edu/visit
+---
+Both historical artifacts/art and geological samples from Pennsylvania's geology and mining history.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Earth and Mineral Sciences Museum and Art Gallery
**Location:** EMS Museum and Art Gallery, North Burrowes Road, State College, Pennsylvania, 16801, United States
**Submitted by:** JamesEndresHowell
**Website:** https://museum.ems.psu.edu/visit

### Description
Both historical artifacts/art and geological samples from Pennsylvania's geology and mining history.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 500
**File:** `content/daytrip/na/us/earth-and-mineral-sciences-museum-and-art-gallery.md`

Please review this venue submission and edit the content as needed before merging.