### PR TITLE
New: Robeson Gallery from JamesEndresHowell

### DIFF
--- a/content/daytrip/na/us/robeson-gallery.md
+++ b/content/daytrip/na/us/robeson-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/robeson-gallery"
+date: "2025-06-18T04:26:24.012Z"
+poster: "JamesEndresHowell"
+lat: "40.798117"
+lng: "-77.861375"
+location: "Robeson Gallery, HUB Plaza, State College, Pennsylvania, 16802, United States"
+title: "Robeson Gallery"
+external_url: https://studentaffairs.psu.edu/hub/art-galleries
+---
+A frequently-rotating gallery of student artwork in the middle of the student union building.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Robeson Gallery
**Location:** Robeson Gallery, HUB Plaza, State College, Pennsylvania, 16802, United States
**Submitted by:** JamesEndresHowell
**Website:** https://studentaffairs.psu.edu/hub/art-galleries

### Description
A frequently-rotating gallery of student artwork in the middle of the student union building.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 501
**File:** `content/daytrip/na/us/robeson-gallery.md`

Please review this venue submission and edit the content as needed before merging.