### PR TITLE
New: Pasto Agricultural Museum from JamesEndresHowell

### DIFF
--- a/content/daytrip/na/us/pasto-agricultural-museum.md
+++ b/content/daytrip/na/us/pasto-agricultural-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/pasto-agricultural-museum"
+date: "2025-06-18T04:26:32.382Z"
+poster: "JamesEndresHowell"
+lat: "40.705501"
+lng: "-77.960255"
+location: "2710 West Pine Grove Road, Ferguson Twp, Pennsylvania, 16865, United States"
+title: "Pasto Agricultural Museum"
+external_url: https://agsci.psu.edu/pasto/plan-your-visit
+---
+Visits by appointment. Check for special events.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Pasto Agricultural Museum
**Location:** 2710 West Pine Grove Road, Ferguson Twp, Pennsylvania, 16865, United States
**Submitted by:** JamesEndresHowell
**Website:** https://agsci.psu.edu/pasto/plan-your-visit

### Description
Visits by appointment. Check for special events.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 502
**File:** `content/daytrip/na/us/pasto-agricultural-museum.md`

Please review this venue submission and edit the content as needed before merging.