### PR TITLE
New: Discovery Space from JamesEndresHowell

### DIFF
--- a/content/daytrip/na/us/discovery-space.md
+++ b/content/daytrip/na/us/discovery-space.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/discovery-space"
+date: "2025-06-18T04:26:54.193Z"
+poster: "JamesEndresHowell"
+lat: "40.802089"
+lng: "-77.882294"
+location: "1224 North Atherton Street, State College, Pennsylvania, 16803, United States"
+title: "Discovery Space"
+external_url: https://discoveryspace.org/visit/admission/
+---
+Children's science museum. If you're a member of your local science museum in the Association of Science-Technology Centers (ASTC) Passport Program, you may be eligible for free admission! 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Discovery Space
**Location:** 1224 North Atherton Street, State College, Pennsylvania, 16803, United States
**Submitted by:** JamesEndresHowell
**Website:** https://discoveryspace.org/visit/admission/

### Description
Children's science museum. If you're a member of your local science museum in the Association of Science-Technology Centers (ASTC) Passport Program, you may be eligible for free admission! 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 504
**File:** `content/daytrip/na/us/discovery-space.md`

Please review this venue submission and edit the content as needed before merging.