### PR TITLE
New: Fortresse Holland from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/fortresse-holland.md
+++ b/content/daytrip/eu/nl/fortresse-holland.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/fortresse-holland"
+date: "2025-06-18T07:34:56.353Z"
+poster: "Frederik Dekker"
+lat: "51.828934"
+lng: "4.12807"
+location: "Dokweg 5, 3221 AE, Hellevoetsluis, The Netherlands"
+title: "Fortresse Holland"
+external_url: https://fortresseholland.nl/
+---
+Open air museum about the time when the town of Hellevoetsluis was a Dutch naval base. Featuring a dry-dock, museum vessels and exhibitions about fortifications.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fortresse Holland
**Location:** Dokweg 5, 3221 AE, Hellevoetsluis, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://fortresseholland.nl/

### Description
Open air museum about the time when the town of Hellevoetsluis was a Dutch naval base. Featuring a dry-dock, museum vessels and exhibitions about fortifications.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 507
**File:** `content/daytrip/eu/nl/fortresse-holland.md`

Please review this venue submission and edit the content as needed before merging.