### PR TITLE
New: Tyneham Village from Filbert

### DIFF
--- a/content/daytrip/eu/gb/tyneham-village.md
+++ b/content/daytrip/eu/gb/tyneham-village.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/tyneham-village"
+date: "2025-06-18T07:45:18.874Z"
+poster: "Filbert"
+lat: "50.621996"
+lng: "-2.169476"
+location: "Tyneham, Tyneham Range Walks, Steeple with Tyneham, Dorset, England, BH20 5QF, United Kingdom"
+title: "Tyneham Village"
+external_url: https://www.visit-dorset.com/listing/tyneham-village/13633301/
+---
+The village where time stopped in 1943. The Village was evacuated in December 1943 during WWII and has been deserted ever since.
+
+An interesting place to spend an hour wandering round, then enjoy the views across the ranges (if the roads are open!) afterwards. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tyneham Village
**Location:** Tyneham, Tyneham Range Walks, Steeple with Tyneham, Dorset, England, BH20 5QF, United Kingdom
**Submitted by:** Filbert
**Website:** https://www.visit-dorset.com/listing/tyneham-village/13633301/

### Description
The village where time stopped in 1943. The Village was evacuated in December 1943 during WWII and has been deserted ever since.

An interesting place to spend an hour wandering round, then enjoy the views across the ranges (if the roads are open!) afterwards. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 509
**File:** `content/daytrip/eu/gb/tyneham-village.md`

Please review this venue submission and edit the content as needed before merging.