### PR TITLE
New: TOTO Toilet Museum from Adam

### DIFF
--- a/content/daytrip/as/jp/toto-toilet-museum.md
+++ b/content/daytrip/as/jp/toto-toilet-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/jp/toto-toilet-museum"
+date: "2025-06-18T07:46:16.351Z"
+poster: "Adam"
+lat: "33.872401"
+lng: "130.872196"
+location: "TOTO Museum, Nakashima 2-chome, Kokura-Kita Ward, Kitakyushu, Fukuoka Prefecture, 803-0814, Japan"
+title: "TOTO Toilet Museum"
+external_url: https://jp.toto.com/en/knowledge/visit/museum/
+---
+Learn all about the history and products of the company that made Japanese toilets famous, and see exhibitions from the early days making tableware, to the various toilet models through the ages. Of course, you can use the latest model while you're there.


### PR DESCRIPTION
## New Venue Submission

**Venue:** TOTO Toilet Museum
**Location:** TOTO Museum, Nakashima 2-chome, Kokura-Kita Ward, Kitakyushu, Fukuoka Prefecture, 803-0814, Japan
**Submitted by:** Adam
**Website:** https://jp.toto.com/en/knowledge/visit/museum/

### Description
Learn all about the history and products of the company that made Japanese toilets famous, and see exhibitions from the early days making tableware, to the various toilet models through the ages. Of course, you can use the latest model while you're there.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 510
**File:** `content/daytrip/as/jp/toto-toilet-museum.md`

Please review this venue submission and edit the content as needed before merging.