### PR TITLE
New: Oyfo Techniekmuseum from Oyfo Technology Museum Hengelo

### DIFF
--- a/content/daytrip/eu/nl/oyfo-techniekmuseum.md
+++ b/content/daytrip/eu/nl/oyfo-techniekmuseum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/oyfo-techniekmuseum"
+date: "2025-06-18T09:06:20.349Z"
+poster: "Oyfo Technology Museum Hengelo"
+lat: "52.262553"
+lng: "6.783162"
+location: "Floris Hazemeijerstraat 300  7555 RJ Hengelo"
+title: "Oyfo Techniekmuseum"
+external_url: https://www.oyfotechniekmuseum.nl/
+---
+Step into the amazing world of technology at Oyfo Technology Museum. Housed in the historic Hazemeijer factory in Hengelo, you can explore through interactive games and even get a glimpse of your future in the machine hall. Be an inventor for a day and truly experience Oyfo Technology Museum by getting hands-on!


### PR DESCRIPTION
## New Venue Submission

**Venue:** Oyfo Techniekmuseum
**Location:** Floris Hazemeijerstraat 300  7555 RJ Hengelo
**Submitted by:** Oyfo Technology Museum Hengelo
**Website:** https://www.oyfotechniekmuseum.nl/

### Description
Step into the amazing world of technology at Oyfo Technology Museum. Housed in the historic Hazemeijer factory in Hengelo, you can explore through interactive games and even get a glimpse of your future in the machine hall. Be an inventor for a day and truly experience Oyfo Technology Museum by getting hands-on!

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 511
**File:** `content/daytrip/eu/nl/oyfo-techniekmuseum.md`

Please review this venue submission and edit the content as needed before merging.