### PR TITLE
Feat: Enable giscus comments

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,7 +33,22 @@ relativeURLs = true
   service = 'GitHub'
   urlPatternEdit = 'https://github.com/%s/%s/edit/%s/%s'
   urlPatternView = 'https://github.com/%s/%s/blob/%s/%s'
-
+  
+[params.giscus]
+    repo = "nerdydaytrips/website"
+    repoID = "R_kgDOOu4FrA"
+    category = "Venues"
+    categoryID = "DIC_kwDOOu4FrM4Crptl"
+    mapping = "url"
+    strict = "0"
+    reactionsEnabled = "1"
+    emitMetadata = "0"
+    inputPosition = "top"
+    theme = "transparent_dark"
+    lang = "en"
+    loading = "lazy"
+    crossorigin = "anonymous"
+    
 [frontmatter]
   lastmod = ["lastmod", ":git", "date", "publishDate"]
 


### PR DESCRIPTION
This adds the necessary configuration to allow visitors to comment on venues.
Visitors will need a GitHub account. 