### PR TITLE
New: Mechanisch Erfgoed Centrum from Frederik Dekker

### DIFF
--- a/content/daytrip/eu/nl/mechanisch-erfgoed-centrum.md
+++ b/content/daytrip/eu/nl/mechanisch-erfgoed-centrum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/nl/mechanisch-erfgoed-centrum"
+date: "2025-06-18T15:48:39.665Z"
+poster: "Frederik Dekker"
+lat: "52.518584"
+lng: "5.658925"
+location: "Dronterweg 29, 8251 PA, Dronten, The Netherlands"
+title: "Mechanisch Erfgoed Centrum"
+external_url: https://www.mecmuseum.nl/
+---
+Museum with a large collection of machines and steam engines. Housed in a former bus garage from Nijmegen.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Mechanisch Erfgoed Centrum
**Location:** Dronterweg 29, 8251 PA, Dronten, The Netherlands
**Submitted by:** Frederik Dekker
**Website:** https://www.mecmuseum.nl/

### Description
Museum with a large collection of machines and steam engines. Housed in a former bus garage from Nijmegen.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 515
**File:** `content/daytrip/eu/nl/mechanisch-erfgoed-centrum.md`

Please review this venue submission and edit the content as needed before merging.