### PR TITLE
New: Energiebunker in Wilhelmsburg from hh

### DIFF
--- a/content/daytrip/eu/de/energiebunker-in-wilhelmsburg.md
+++ b/content/daytrip/eu/de/energiebunker-in-wilhelmsburg.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/energiebunker-in-wilhelmsburg"
+date: "2025-06-18T15:57:21.406Z"
+poster: "hh"
+lat: "53.510069"
+lng: "9.989662"
+location: " Neuhöfer Straße 7,  21107 Hamburg  "
+title: "Energiebunker in Wilhelmsburg"
+external_url: https://unternehmen.hamburger-energiewerke.de/energiewende/energiebunker
+---
+This large flack tower bunker was converted to a district hearing storage and source. Tours detail the history and technology.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Energiebunker in Wilhelmsburg
**Location:**  Neuhöfer Straße 7,  21107 Hamburg  
**Submitted by:** hh
**Website:** https://unternehmen.hamburger-energiewerke.de/energiewende/energiebunker

### Description
This large flack tower bunker was converted to a district hearing storage and source. Tours detail the history and technology.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 516
**File:** `content/daytrip/eu/de/energiebunker-in-wilhelmsburg.md`

Please review this venue submission and edit the content as needed before merging.