### PR TITLE
New: Arcadia Retro Arcade & Pinball Emporia from DigiGeekNZ

### DIFF
--- a/content/daytrip/oc/nz/arcadia-retro-arcade-pinball-emporia.md
+++ b/content/daytrip/oc/nz/arcadia-retro-arcade-pinball-emporia.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/oc/nz/arcadia-retro-arcade-pinball-emporia"
+date: "2025-06-19T07:42:57.523Z"
+poster: "DigiGeekNZ"
+lat: "-43.535003"
+lng: "172.645956"
+location: "Arcadia Retro Arcade & Pinball Emporia, Barbadoes Street, Christchurch Central, Linwood-Central-Heathcote Community, Christchurch, Christchurch City, 8011, New Zealand"
+title: "Arcadia Retro Arcade & Pinball Emporia"
+external_url: https://travel.geek.nz/food/christchurch-to-do-and-see/#having-fun-while-staying-in
+---
+Classic arcade games and pinball machines.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Arcadia Retro Arcade & Pinball Emporia
**Location:** Arcadia Retro Arcade & Pinball Emporia, Barbadoes Street, Christchurch Central, Linwood-Central-Heathcote Community, Christchurch, Christchurch City, 8011, New Zealand
**Submitted by:** DigiGeekNZ
**Website:** https://travel.geek.nz/food/christchurch-to-do-and-see/#having-fun-while-staying-in

### Description
Classic arcade games and pinball machines.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 517
**File:** `content/daytrip/oc/nz/arcadia-retro-arcade-pinball-emporia.md`

Please review this venue submission and edit the content as needed before merging.