### PR TITLE
New: Magnetic Hill from IsleOfManDan

### DIFF
--- a/content/daytrip/eu/im/magnetic-hill.md
+++ b/content/daytrip/eu/im/magnetic-hill.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/im/magnetic-hill"
+date: "2025-06-19T07:43:26.602Z"
+poster: "IsleOfManDan"
+lat: "54.129497"
+lng: "-4.691602"
+location: "On the A27 Ronague Road between Colby and Round Table"
+title: "Magnetic Hill"
+external_url: https://en.wikipedia.org/wiki/List_of_gravity_hills
+---
+A hill where gravity works the wrong way. Bring a football and watch it roll uphill. Or put a vehicle in neutral with the brakes off and be amazed as you roll up the hill!
+
+(There is a stone marking the spot, but the engraving has all but weathered away and it's often lost in the undergrowth.)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Magnetic Hill
**Location:** On the A27 Ronague Road between Colby and Round Table
**Submitted by:** IsleOfManDan
**Website:** https://en.wikipedia.org/wiki/List_of_gravity_hills

### Description
A hill where gravity works the wrong way. Bring a football and watch it roll uphill. Or put a vehicle in neutral with the brakes off and be amazed as you roll up the hill!

(There is a stone marking the spot, but the engraving has all but weathered away and it's often lost in the undergrowth.)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 518
**File:** `content/daytrip/eu/im/magnetic-hill.md`

Please review this venue submission and edit the content as needed before merging.