### PR TITLE
New: Does Liverpool

### DIFF
--- a/content/daytrip/eu/gb/doesliverpool.md
+++ b/content/daytrip/eu/gb/doesliverpool.md
@@ -1,0 +1,11 @@
+---
+slug: 'daytrip/eu/gb/doesliverpool'
+date: '2025-06-19T09:45:02.506Z'
+lat: '53.4105095'
+lng: '-2.9704659'
+location: '1st Floor, The Tapestry, 68-76 Kempston St, Liverpool L3 8HL'
+title: 'DoES Liverpool'
+external_url: https://doesliverpool.com/
+poster: "TacticalTechyTaky"
+---
+Maker Space which hosts Maker Night events for free frequently, home for the Liverpool LUG meetings.Perfect place to do ad-hoc projects using available equipment(Laser Cutter,3D printer, solder station, etc).


### PR DESCRIPTION
# New Venue Submission
Venue: DoES Liverpool
Location: 1st Floor, The Tapestry, 68-76 Kempston St, Liverpool L3 8HL
Submitted by: TacticalTechyTaky
Website: https://doesliverpool.com

## Description
Maker Space which hosts Maker Night events for free frequently, home for the Liverpool LUG meetings.Perfect place to do ad-hoc projects using available equipment(Laser Cutter,3D printer, solder station, etc).