### PR TITLE
New: Sick To Death from TacticalTechyTaky

### DIFF
--- a/content/daytrip/eu/gb/sick-to-death.md
+++ b/content/daytrip/eu/gb/sick-to-death.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/sick-to-death"
+date: "2025-06-19T09:13:24.908Z"
+poster: "TacticalTechyTaky"
+lat: "53.18867"
+lng: "-2.890771"
+location: "Sick To Death, Pepper Street, Handbridge, Chester, England, CH1 1DW, United Kingdom"
+title: "Sick To Death"
+external_url: https://sicktodeath.org/
+---
+A rather interesting small museum dedicated to the history of medicine. Tour is roughly 45 mins long.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sick To Death
**Location:** Sick To Death, Pepper Street, Handbridge, Chester, England, CH1 1DW, United Kingdom
**Submitted by:** TacticalTechyTaky
**Website:** https://sicktodeath.org/

### Description
A rather interesting small museum dedicated to the history of medicine. Tour is roughly 45 mins long.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 519
**File:** `content/daytrip/eu/gb/sick-to-death.md`

Please review this venue submission and edit the content as needed before merging.