### PR TITLE
New: Cup Noodles Museum Yokohama from esmepotatoes

### DIFF
--- a/content/daytrip/as/jp/cup-noodles-museum-yokohama.md
+++ b/content/daytrip/as/jp/cup-noodles-museum-yokohama.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/jp/cup-noodles-museum-yokohama"
+date: "2025-06-19T09:13:51.344Z"
+poster: "esmepotatoes"
+lat: "35.455486"
+lng: "139.638881"
+location: "CUPNOODLES MUSEUM, 4, Shinko 2-chome, Naka Ward, Yokohama, Kanagawa Prefecture, 231-0001, Japan"
+title: "Cup Noodles Museum Yokohama"
+external_url: https://www.cupnoodles-museum.jp/en/yokohama/
+---
+Why not visit the (approximate) birthplace of the Japanese instant noodle, visit a wonderful area with lots of history, and come out with your own custom made instant noodle (which can be turned into an adorable floating balloon in the end) 😛 Lots of quirky and authentic instant noodles that are harder to get out of the region for purchase for souvenirs as well. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Cup Noodles Museum Yokohama
**Location:** CUPNOODLES MUSEUM, 4, Shinko 2-chome, Naka Ward, Yokohama, Kanagawa Prefecture, 231-0001, Japan
**Submitted by:** esmepotatoes
**Website:** https://www.cupnoodles-museum.jp/en/yokohama/

### Description
Why not visit the (approximate) birthplace of the Japanese instant noodle, visit a wonderful area with lots of history, and come out with your own custom made instant noodle (which can be turned into an adorable floating balloon in the end) 😛 Lots of quirky and authentic instant noodles that are harder to get out of the region for purchase for souvenirs as well. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 520
**File:** `content/daytrip/as/jp/cup-noodles-museum-yokohama.md`

Please review this venue submission and edit the content as needed before merging.