### PR TITLE
New: CCC Berlin from debb1046

### DIFF
--- a/content/daytrip/eu/de/ccc-berlin.md
+++ b/content/daytrip/eu/de/ccc-berlin.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/ccc-berlin"
+date: "2025-06-19T11:09:30.496Z"
+poster: "debb1046"
+lat: "52.52194"
+lng: "13.38261"
+location: "Marienstr. 11, 10117 Berlin"
+title: "CCC Berlin"
+external_url: https://berlin.ccc.de/
+---
+Chaos Computer Club Berlin. Hackspace open to the public on Thursday evenings.


### PR DESCRIPTION
## New Venue Submission

**Venue:** CCC Berlin
**Location:** Marienstr. 11, 10117 Berlin
**Submitted by:** debb1046
**Website:** https://berlin.ccc.de/

### Description
Chaos Computer Club Berlin. Hackspace open to the public on Thursday evenings.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 521
**File:** `content/daytrip/eu/de/ccc-berlin.md`

Please review this venue submission and edit the content as needed before merging.