### PR TITLE
New: Wilhelm-Foerster-Sternwarte from debb1046

### DIFF
--- a/content/daytrip/eu/de/wilhelm-foerster-sternwarte.md
+++ b/content/daytrip/eu/de/wilhelm-foerster-sternwarte.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/wilhelm-foerster-sternwarte"
+date: "2025-06-19T12:31:53.173Z"
+poster: "debb1046"
+lat: "52.457405"
+lng: "13.351286"
+location: "Munsterdamm 86, 12157 Berlin"
+title: "Wilhelm-Foerster-Sternwarte"
+external_url: https://www.planetarium.berlin/wilhelm-foerster-sternwarte
+---
+Observatory located on a small hill. Often open to the public on Friday and Saturday nights (Ticket required).


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wilhelm-Foerster-Sternwarte
**Location:** Munsterdamm 86, 12157 Berlin
**Submitted by:** debb1046
**Website:** https://www.planetarium.berlin/wilhelm-foerster-sternwarte

### Description
Observatory located on a small hill. Often open to the public on Friday and Saturday nights (Ticket required).

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 524
**File:** `content/daytrip/eu/de/wilhelm-foerster-sternwarte.md`

Please review this venue submission and edit the content as needed before merging.