### PR TITLE
New: Schiffshebewerk Niederfinow from debb1046

### DIFF
--- a/content/daytrip/eu/de/schiffshebewerk-niederfinow.md
+++ b/content/daytrip/eu/de/schiffshebewerk-niederfinow.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/schiffshebewerk-niederfinow"
+date: "2025-06-19T13:51:08.097Z"
+poster: "debb1046"
+lat: "52.849132"
+lng: "13.941659"
+location: "Hebewerkstr. 70a, 16248 Niederfinow"
+title: "Schiffshebewerk Niederfinow"
+external_url: https://schiffshebewerk-niederfinow.com/en/
+---
+Old boat lift dating back to 1934 next to a new one from 2022.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Schiffshebewerk Niederfinow
**Location:** Hebewerkstr. 70a, 16248 Niederfinow
**Submitted by:** debb1046
**Website:** https://schiffshebewerk-niederfinow.com/en/

### Description
Old boat lift dating back to 1934 next to a new one from 2022.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 527
**File:** `content/daytrip/eu/de/schiffshebewerk-niederfinow.md`

Please review this venue submission and edit the content as needed before merging.