### PR TITLE
New: Computermuseum der Informatik from debb1046

### DIFF
--- a/content/daytrip/eu/de/computermuseum-der-informatik.md
+++ b/content/daytrip/eu/de/computermuseum-der-informatik.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/computermuseum-der-informatik"
+date: "2025-06-19T13:51:16.559Z"
+poster: "debb1046"
+lat: "48.744855"
+lng: "9.106896"
+location: "Universitätsstr. 38 70569 Stuttgart-Vaihingen, Germany"
+title: "Computermuseum der Informatik"
+external_url: https://www.f05.uni-stuttgart.de/informatik/fachbereich/computermuseum/
+---
+Collection of calculators and computers (including one powered by vacuum tubes/valves). Most of them still working. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Computermuseum der Informatik
**Location:** Universitätsstr. 38 70569 Stuttgart-Vaihingen, Germany
**Submitted by:** debb1046
**Website:** https://www.f05.uni-stuttgart.de/informatik/fachbereich/computermuseum/

### Description
Collection of calculators and computers (including one powered by vacuum tubes/valves). Most of them still working. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 528
**File:** `content/daytrip/eu/de/computermuseum-der-informatik.md`

Please review this venue submission and edit the content as needed before merging.