### PR TITLE
New: Gottlieb-Daimler-Gedenkstätte from debb1046

### DIFF
--- a/content/daytrip/eu/de/gottlieb-daimler-gedenksttte.md
+++ b/content/daytrip/eu/de/gottlieb-daimler-gedenksttte.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/gottlieb-daimler-gedenksttte"
+date: "2025-06-19T13:51:24.841Z"
+poster: "debb1046"
+lat: "48.807201"
+lng: "9.22506"
+location: "Taubenheimstraße 13, 70372 Stuttgart, Germany"
+title: "Gottlieb-Daimler-Gedenkstätte"
+external_url: https://www.stuttgart-tourist.de/en/a-daimler-memorial-sight
+---
+Garden shed where Daimler and Maybach developed one of the first gasoline engines used in a vehicle.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Gottlieb-Daimler-Gedenkstätte
**Location:** Taubenheimstraße 13, 70372 Stuttgart, Germany
**Submitted by:** debb1046
**Website:** https://www.stuttgart-tourist.de/en/a-daimler-memorial-sight

### Description
Garden shed where Daimler and Maybach developed one of the first gasoline engines used in a vehicle.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 529
**File:** `content/daytrip/eu/de/gottlieb-daimler-gedenksttte.md`

Please review this venue submission and edit the content as needed before merging.