### PR TITLE
New: Old Canonical HQ from popey

### DIFF
--- a/content/daytrip/eu/gb/old-canonical-hq.md
+++ b/content/daytrip/eu/gb/old-canonical-hq.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/old-canonical-hq"
+date: "2025-06-19T14:31:23.020Z"
+poster: "popey"
+lat: "51.506045"
+lng: "-0.099714"
+location: "Blue Fin Building, Southwark Street, London"
+title: "Old Canonical HQ"
+external_url: https://canonical.com/
+---
+This is just a test - do not merge.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Old Canonical HQ
**Location:** Blue Fin Building, Southwark Street, London
**Submitted by:** popey
**Website:** https://canonical.com/

### Description
This is just a test - do not merge.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 19
**File:** `content/daytrip/eu/gb/old-canonical-hq.md`

Please review this venue submission and edit the content as needed before merging.