### PR TITLE
New: Canada Centre for Inland Waters from Paul Drye

### DIFF
--- a/content/daytrip/na/ca/canada-centre-for-inland-waters.md
+++ b/content/daytrip/na/ca/canada-centre-for-inland-waters.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/ca/canada-centre-for-inland-waters"
+date: "2025-06-19T14:46:13.772Z"
+poster: "Paul Drye"
+lat: "43.299404"
+lng: "-79.800991"
+location: " 867 Lakeshore Road, Burlington, Ontario, Canada"
+title: "Canada Centre for Inland Waters"
+external_url: https://profils-profiles.science.gc.ca/en/research-centre/canada-centre-inland-waters
+---
+Only open to the public a few days each year, but if you can catch one of them and you're interested in ecological sciences you can't beat it. Supporting the Canadian federal government's Ministry of the Environment and Climate Change they engage in research about human impacts on lakes, watersheds, and coastal waters.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Canada Centre for Inland Waters
**Location:**  867 Lakeshore Road, Burlington, Ontario, Canada
**Submitted by:** Paul Drye
**Website:** https://profils-profiles.science.gc.ca/en/research-centre/canada-centre-inland-waters

### Description
Only open to the public a few days each year, but if you can catch one of them and you're interested in ecological sciences you can't beat it. Supporting the Canadian federal government's Ministry of the Environment and Climate Change they engage in research about human impacts on lakes, watersheds, and coastal waters.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 144
**File:** `content/daytrip/na/ca/canada-centre-for-inland-waters.md`

Please review this venue submission and edit the content as needed before merging.