### PR TITLE
New: Tempelhof Airport from debb1046

### DIFF
--- a/content/daytrip/eu/de/tempelhof-airport.md
+++ b/content/daytrip/eu/de/tempelhof-airport.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/tempelhof-airport"
+date: "2025-06-19T14:46:15.883Z"
+poster: "debb1046"
+lat: "52.480649"
+lng: "13.388919"
+location: "Flughafen Tempelhof, Platz der Luftbrücke,  12101 Berlin, , Germany"
+title: "Tempelhof Airport"
+external_url: https://www.thf-berlin.de/en/
+---
+Berlin Tempelhof airport. In use from the 1920s to 2008. The buildings currently still standing were constructed in the 1930s. Heavily used for the Berlin Airlift during the cold war. The airfield and runways are open to the public and used for jogging, cycling, in-line skating etc.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tempelhof Airport
**Location:** Flughafen Tempelhof, Platz der Luftbrücke,  12101 Berlin, , Germany
**Submitted by:** debb1046
**Website:** https://www.thf-berlin.de/en/

### Description
Berlin Tempelhof airport. In use from the 1920s to 2008. The buildings currently still standing were constructed in the 1930s. Heavily used for the Berlin Airlift during the cold war. The airfield and runways are open to the public and used for jogging, cycling, in-line skating etc.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 530
**File:** `content/daytrip/eu/de/tempelhof-airport.md`

Please review this venue submission and edit the content as needed before merging.