### PR TITLE
New: Aberystwyth Cliff Railway from Robyn Vaughan-Williams

### DIFF
--- a/content/daytrip/eu/gb/aberystwyth-cliff-railway.md
+++ b/content/daytrip/eu/gb/aberystwyth-cliff-railway.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/aberystwyth-cliff-railway"
+date: "2025-06-19T15:01:20.527Z"
+poster: "Robyn Vaughan-Williams"
+lat: "52.424329"
+lng: "-4.082773"
+location: "Cliff Railway House, Cliff Terrace, Aberystwyth SY23 2DN"
+title: "Aberystwyth Cliff Railway"
+external_url: https://aberystwythcliffrailway.co.uk/
+---
+Seaside 778 feet long funicular railway, opened 1896.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Aberystwyth Cliff Railway
**Location:** Cliff Railway House, Cliff Terrace, Aberystwyth SY23 2DN
**Submitted by:** Robyn Vaughan-Williams
**Website:** https://aberystwythcliffrailway.co.uk/

### Description
Seaside 778 feet long funicular railway, opened 1896.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 531
**File:** `content/daytrip/eu/gb/aberystwyth-cliff-railway.md`

Please review this venue submission and edit the content as needed before merging.