### PR TITLE
New: Centre for Alternative Technology from Robyn Vaughan-Williams

### DIFF
--- a/content/daytrip/eu/gb/centre-for-alternative-technology.md
+++ b/content/daytrip/eu/gb/centre-for-alternative-technology.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/centre-for-alternative-technology"
+date: "2025-06-19T15:01:55.655Z"
+poster: "Robyn Vaughan-Williams"
+lat: "52.622982"
+lng: "-3.83999"
+location: "Llwyngwern Quarry, Pantperthog, Machynlleth SY20 9AZ"
+title: "Centre for Alternative Technology"
+external_url: https://cat.org.uk/
+---
+World-renowned eco centre that research and supports greener ways of living. Features water balast funicular railway.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Centre for Alternative Technology
**Location:**  Llwyngwern Quarry, Pantperthog, Machynlleth SY20 9AZ
**Submitted by:** Robyn Vaughan-Williams
**Website:** https://cat.org.uk/

### Description
World-renowned eco centre that research and supports greener ways of living. Features water balast funicular railway.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 532
**File:** `content/daytrip/eu/gb/centre-for-alternative-technology.md`

Please review this venue submission and edit the content as needed before merging.