### PR TITLE
New: National Slate Muesueum  from Robyn Vaughan-Williams

### DIFF
--- a/content/daytrip/eu/gb/national-slate-museum.md
+++ b/content/daytrip/eu/gb/national-slate-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/national-slate-museum"
+date: "2025-06-19T16:31:21.824Z"
+poster: "Robyn Vaughan-Williams"
+lat: "53.121384"
+lng: "-4.11541"
+location: " Llanberis, Caernarfon LL55 4TY"
+title: "National Slate Museum"
+external_url: https://museum.wales/slate/
+---
+Museum featuring the 19th-century workshops of the now disused Dinorwic quarry.


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Slate Muesueum 
**Location:**  Llanberis, Caernarfon LL55 4TY
**Submitted by:** Robyn Vaughan-Williams
**Website:** https://museum.wales/slate/

### Description
Museum featuring the 19th-century workshops of the now disused Dinorwic quarry.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 533
**File:** `content/daytrip/eu/gb/national-slate-museum.md`

Please review this venue submission and edit the content as needed before merging.