### PR TITLE
New: Osaka Aquarium Kaiyukan from esmepotatoes

### DIFF
--- a/content/daytrip/as/jp/osaka-aquarium-kaiyukan.md
+++ b/content/daytrip/as/jp/osaka-aquarium-kaiyukan.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/jp/osaka-aquarium-kaiyukan"
+date: "2025-06-19T18:24:23.430Z"
+poster: "esmepotatoes"
+lat: "34.654546"
+lng: "135.428921"
+location: "Osaka Aquarium Kaiyukan, 北海岸通 Kaigandori 1-chome, Minato District"
+title: "Osaka Aquarium Kaiyukan"
+external_url: https://www.kaiyukan.com/
+---
+Ever wanted to visit the aquarium bit in Animal Crossing: New Horizons in real life? Well you could visit the visual inspiration for the Museum’s fish collection — and probably find yourself quoting a few punny references as you find yourself identifying the fishes in the exhibit 🙂


### PR DESCRIPTION
## New Venue Submission

**Venue:** Osaka Aquarium Kaiyukan
**Location:** Osaka Aquarium Kaiyukan, 北海岸通 Kaigandori 1-chome, Minato District
**Submitted by:** esmepotatoes
**Website:** https://www.kaiyukan.com/

### Description
Ever wanted to visit the aquarium bit in Animal Crossing: New Horizons in real life? Well you could visit the visual inspiration for the Museum’s fish collection — and probably find yourself quoting a few punny references as you find yourself identifying the fishes in the exhibit 🙂

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 534
**File:** `content/daytrip/as/jp/osaka-aquarium-kaiyukan.md`

Please review this venue submission and edit the content as needed before merging.