### PR TITLE
New: Ipswich Transport Museum from Matthew

### DIFF
--- a/content/daytrip/eu/gb/ipswich-transport-museum.md
+++ b/content/daytrip/eu/gb/ipswich-transport-museum.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/gb/ipswich-transport-museum"
+date: "2025-06-20T06:30:27.602Z"
+poster: "Matthew"
+lat: "52.040506"
+lng: "1.196497"
+location: "The Old Trolleybus Depot Cobham Road Ipswich, Suffolk IP3 9JD "
+title: "Ipswich Transport Museum"
+external_url: https://www.ipswichtransportmuseum.co.uk/
+---
+Ipswich Transport Museum houses over 100 vehicles and engineering pieces with local connections - basically everything that moved people around this part of Suffolk or got built here over the decades. What started as one preserved bus 50 years ago has quietly become one of the more complete regional transport collections, looked after by volunteers who actually know their stuff.
+They're not open daily so check before you go, but when they do run special events you can sometimes get rides on the restored vehicles around town. Worth a look if you're into seeing how local transport networks actually worked, rather than just reading about them.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ipswich Transport Museum
**Location:** The Old Trolleybus Depot Cobham Road Ipswich, Suffolk IP3 9JD 
**Submitted by:** Matthew
**Website:** https://www.ipswichtransportmuseum.co.uk/

### Description
Ipswich Transport Museum houses over 100 vehicles and engineering pieces with local connections - basically everything that moved people around this part of Suffolk or got built here over the decades. What started as one preserved bus 50 years ago has quietly become one of the more complete regional transport collections, looked after by volunteers who actually know their stuff.
They're not open daily so check before you go, but when they do run special events you can sometimes get rides on the restored vehicles around town. Worth a look if you're into seeing how local transport networks actually worked, rather than just reading about them.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 535
**File:** `content/daytrip/eu/gb/ipswich-transport-museum.md`

Please review this venue submission and edit the content as needed before merging.