### PR TITLE
New: Woodbridge Tide Mill from Matthew

### DIFF
--- a/content/daytrip/eu/gb/woodbridge-tide-mill.md
+++ b/content/daytrip/eu/gb/woodbridge-tide-mill.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/woodbridge-tide-mill"
+date: "2025-06-20T06:30:56.554Z"
+poster: "Matthew"
+lat: "52.090171"
+lng: "1.320967"
+location: "Woodbridge Tide Mill Museum, Tide Mill Way, Woodbridge, Suffolk"
+title: "Woodbridge Tide Mill"
+external_url: https://woodbridgetidemill.org.uk/
+---
+Woodbridge Tide Mill is one of those brilliantly simple pieces of engineering. It's a working flour mill that's been grinding grain using nothing but the River Deben's tides for centuries.
+What makes this one special is that it's still actually working - the wheel turns and you can buy flour that was ground there. Most other tide mills around the coast are either ruins or static museum displays.
+It's right in Woodbridge town center, so you can easily combine it with wandering the quayside and checking out the boats. Worth timing your visit for when they're actually milling if you want to see the whole mechanism in action.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Woodbridge Tide Mill
**Location:** Woodbridge Tide Mill Museum, Tide Mill Way, Woodbridge, Suffolk
**Submitted by:** Matthew
**Website:** https://woodbridgetidemill.org.uk/

### Description
Woodbridge Tide Mill is one of those brilliantly simple pieces of engineering. It's a working flour mill that's been grinding grain using nothing but the River Deben's tides for centuries.
What makes this one special is that it's still actually working - the wheel turns and you can buy flour that was ground there. Most other tide mills around the coast are either ruins or static museum displays.
It's right in Woodbridge town center, so you can easily combine it with wandering the quayside and checking out the boats. Worth timing your visit for when they're actually milling if you want to see the whole mechanism in action.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 536
**File:** `content/daytrip/eu/gb/woodbridge-tide-mill.md`

Please review this venue submission and edit the content as needed before merging.