### PR TITLE
New: The Bentwaters Cold War Museum from Matthew

### DIFF
--- a/content/daytrip/eu/gb/the-bentwaters-cold-war-museum.md
+++ b/content/daytrip/eu/gb/the-bentwaters-cold-war-museum.md
@@ -1,0 +1,14 @@
+---
+slug: "daytrip/eu/gb/the-bentwaters-cold-war-museum"
+date: "2025-06-20T06:54:01.317Z"
+poster: "Matthew"
+lat: "52.131445"
+lng: "1.431978"
+location: "Building 134, Bentwaters Park, Woodbridge IP12 2TW"
+title: "The Bentwaters Cold War Museum"
+external_url: https://bcwm.org.uk/
+---
+The Bentwaters Cold War Museum is housed in a former USAF hardened command post building, the only one of its kind open to the public in Europe. This isn't just some converted hangar - it's the actual bunker where they would have coordinated nuclear deterrence operations during the Cold War.
+What makes it properly nerdy is that volunteers spent three years restoring the main War Operations Room and Battle Cabin to their original condition, complete with decontamination showers and airlocks meant to keep personnel safe in the event of nuclear war. You're literally walking through a facility designed to function during World War III.
+The 81st Fighter Wing was based here for over 40 years from 1951-1993, operating everything from F-86 Sabres to A-10 Warthogs. Outside there's a decent collection of actual aircraft including a Fairchild A-10 Thunderbolt, Hawker Hunter, McDonnell Douglas Phantom, and Bristol Bloodhound missile.
+They're only open certain Sundays (check the website)


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Bentwaters Cold War Museum
**Location:** Building 134, Bentwaters Park, Woodbridge IP12 2TW
**Submitted by:** Matthew
**Website:** https://bcwm.org.uk/

### Description
The Bentwaters Cold War Museum is housed in a former USAF hardened command post building, the only one of its kind open to the public in Europe. This isn't just some converted hangar - it's the actual bunker where they would have coordinated nuclear deterrence operations during the Cold War.
What makes it properly nerdy is that volunteers spent three years restoring the main War Operations Room and Battle Cabin to their original condition, complete with decontamination showers and airlocks meant to keep personnel safe in the event of nuclear war. You're literally walking through a facility designed to function during World War III.
The 81st Fighter Wing was based here for over 40 years from 1951-1993, operating everything from F-86 Sabres to A-10 Warthogs. Outside there's a decent collection of actual aircraft including a Fairchild A-10 Thunderbolt, Hawker Hunter, McDonnell Douglas Phantom, and Bristol Bloodhound missile.
They're only open certain Sundays (check the website)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 537
**File:** `content/daytrip/eu/gb/the-bentwaters-cold-war-museum.md`

Please review this venue submission and edit the content as needed before merging.