### PR TITLE
New: RAF Air Defence Radar Museum from Matthew

### DIFF
--- a/content/daytrip/eu/gb/raf-air-defence-radar-museum.md
+++ b/content/daytrip/eu/gb/raf-air-defence-radar-museum.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/gb/raf-air-defence-radar-museum"
+date: "2025-06-20T06:54:21.141Z"
+poster: "Matthew"
+lat: "52.71312"
+lng: "1.471637"
+location: " RAF Air Defence Radar Museum, Birds Ln, Norwich NR12 8YB"
+title: "RAF Air Defence Radar Museum"
+external_url: https://www.radarmuseum.co.uk/
+---
+The RAF Air Defence Radar Museum sits in the original Grade II listed 1942 radar operations building at Neatishead - one of the oldest radar stations in the world that's been monitoring UK airspace since 1941. What makes this place special is that you're literally standing in the rooms where they tracked enemy aircraft during WWII and Soviet spy planes during the Cold War.
+The real highlight is the complete Cold War Operations Room, preserved exactly as it was when they decommissioned it in 2004. This is where fighter controllers would scramble jets to intercept aerial intruders during the tensest moments of the Cold War. The original radar equipment is still there, complete with the plotting boards and communication systems they used to coordinate air defence.


### PR DESCRIPTION
## New Venue Submission

**Venue:** RAF Air Defence Radar Museum
**Location:**  RAF Air Defence Radar Museum, Birds Ln, Norwich NR12 8YB
**Submitted by:** Matthew
**Website:** https://www.radarmuseum.co.uk/

### Description
The RAF Air Defence Radar Museum sits in the original Grade II listed 1942 radar operations building at Neatishead - one of the oldest radar stations in the world that's been monitoring UK airspace since 1941. What makes this place special is that you're literally standing in the rooms where they tracked enemy aircraft during WWII and Soviet spy planes during the Cold War.
The real highlight is the complete Cold War Operations Room, preserved exactly as it was when they decommissioned it in 2004. This is where fighter controllers would scramble jets to intercept aerial intruders during the tensest moments of the Cold War. The original radar equipment is still there, complete with the plotting boards and communication systems they used to coordinate air defence.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 538
**File:** `content/daytrip/eu/gb/raf-air-defence-radar-museum.md`

Please review this venue submission and edit the content as needed before merging.