### PR TITLE
New: Alan Turing statue from Mark

### DIFF
--- a/content/daytrip/eu/gb/alan-turing-statue.md
+++ b/content/daytrip/eu/gb/alan-turing-statue.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/alan-turing-statue"
+date: "2025-06-20T13:01:25.425Z"
+poster: "Mark"
+lat: "53.47672"
+lng: "-2.235975"
+location: "Sackville Gardens, Sackville Street, Manchester"
+title: "Alan Turing statue"
+external_url: https://www.manchester.gov.uk/directory_record/439818/sackville_gardens/category/301/all_parks_playgrounds_and_open_spaces
+---
+A memorial to computing pioneer Alan Turing, featuring a statue of Turing sitting on a bench, and a board detailing his life.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Alan Turing statue
**Location:** Sackville Gardens, Sackville Street, Manchester
**Submitted by:** Mark
**Website:** https://www.manchester.gov.uk/directory_record/439818/sackville_gardens/category/301/all_parks_playgrounds_and_open_spaces

### Description
A memorial to computing pioneer Alan Turing, featuring a statue of Turing sitting on a bench, and a board detailing his life.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 539
**File:** `content/daytrip/eu/gb/alan-turing-statue.md`

Please review this venue submission and edit the content as needed before merging.