### PR TITLE
New: East Grinstead Museum from alwAudio

### DIFF
--- a/content/daytrip/eu/gb/east-grinstead-museum.md
+++ b/content/daytrip/eu/gb/east-grinstead-museum.md
@@ -1,0 +1,17 @@
+---
+slug: "daytrip/eu/gb/east-grinstead-museum"
+date: "2025-06-20T13:02:02.421Z"
+poster: "alwAudio"
+lat: "51.124542"
+lng: "-0.006455"
+location: "East Grinstead Museum, Cantelupe Road, Sunnyside, East Grinstead, Mid Sussex, West Sussex, England, RH19 3BJ, United Kingdom"
+title: "East Grinstead Museum"
+external_url: https://www.eastgrinsteadmuseum.org.uk/
+---
+History of East Grinstead plus the Rebuilding Bodies and Souls’ flagship exhibition, opened in 2016 in the 75th anniversary year of the foundation of the Guinea Pig Club
+
+This exhibition tells the story of the birth of reconstructive and plastic surgery in East Grinstead during the Second World War. It focuses on the story through the eyes of the patients and the medical professionals involved. Moreover, this had been the wish of those involved for nearly 70 years:
+
+“One day someone will tell the complete story of Ward III in the way it should be told….”
+
+(“The Maestro’s Message” by Sir Archibald McIndoe in the Guinea Pig magazine, April 1948)


### PR DESCRIPTION
## New Venue Submission

**Venue:** East Grinstead Museum
**Location:** East Grinstead Museum, Cantelupe Road, Sunnyside, East Grinstead, Mid Sussex, West Sussex, England, RH19 3BJ, United Kingdom
**Submitted by:** alwAudio
**Website:** https://www.eastgrinsteadmuseum.org.uk/

### Description
History of East Grinstead plus the Rebuilding Bodies and Souls’ flagship exhibition, opened in 2016 in the 75th anniversary year of the foundation of the Guinea Pig Club

This exhibition tells the story of the birth of reconstructive and plastic surgery in East Grinstead during the Second World War. It focuses on the story through the eyes of the patients and the medical professionals involved. Moreover, this had been the wish of those involved for nearly 70 years:

“One day someone will tell the complete story of Ward III in the way it should be told….”

(“The Maestro’s Message” by Sir Archibald McIndoe in the Guinea Pig magazine, April 1948)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 540
**File:** `content/daytrip/eu/gb/east-grinstead-museum.md`

Please review this venue submission and edit the content as needed before merging.