### PR TITLE
New: SS City of Milwaukee from Shastao

### DIFF
--- a/content/daytrip/na/us/ss-city-of-milwaukee.md
+++ b/content/daytrip/na/us/ss-city-of-milwaukee.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/ss-city-of-milwaukee"
+date: "2025-06-20T20:50:18.071Z"
+poster: "Shastao"
+lat: "44.259373"
+lng: "-86.314896"
+location: "SS City of Milwaukee, Joslin Cove Drive, Manistee, Manistee County, Michigan, 49626, United States"
+title: "SS City of Milwaukee"
+external_url: https://www.carferry.com/
+---
+Railroad car ferry built in 1930 on display as a museum with tours, as well as a WWII era Coast Guard buoy tender (Acacia)


### PR DESCRIPTION
## New Venue Submission

**Venue:** SS City of Milwaukee
**Location:** SS City of Milwaukee, Joslin Cove Drive, Manistee, Manistee County, Michigan, 49626, United States
**Submitted by:** Shastao
**Website:** https://www.carferry.com/

### Description
Railroad car ferry built in 1930 on display as a museum with tours, as well as a WWII era Coast Guard buoy tender (Acacia)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 541
**File:** `content/daytrip/na/us/ss-city-of-milwaukee.md`

Please review this venue submission and edit the content as needed before merging.