### PR TITLE
New: Tullie House Museum & Art Gallery from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/tullie-house-museum-art-gallery.md
+++ b/content/daytrip/eu/gb/tullie-house-museum-art-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/tullie-house-museum-art-gallery"
+date: "2025-06-20T21:07:05.077Z"
+poster: "hiraethmarkb"
+lat: "54.895462"
+lng: "-2.940385"
+location: "Tullie House, Abbey Street, Caldewgate, Carlisle, Cumberland, England, CA3 8UH, United Kingdom"
+title: "Tullie House Museum & Art Gallery"
+external_url: https://tullie.org.uk/
+---
+Tullie House has been part of the fabric of life in Carlisle since 1893, having been referred to as “Carlisle’s first learning centre”, long before the city gained a university.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Tullie House Museum & Art Gallery
**Location:** Tullie House, Abbey Street, Caldewgate, Carlisle, Cumberland, England, CA3 8UH, United Kingdom
**Submitted by:** hiraethmarkb
**Website:** https://tullie.org.uk/

### Description
Tullie House has been part of the fabric of life in Carlisle since 1893, having been referred to as “Carlisle’s first learning centre”, long before the city gained a university.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 543
**File:** `content/daytrip/eu/gb/tullie-house-museum-art-gallery.md`

Please review this venue submission and edit the content as needed before merging.