### PR TITLE
New: Sweetheart Abbey from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/sweetheart-abbey.md
+++ b/content/daytrip/eu/gb/sweetheart-abbey.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/sweetheart-abbey"
+date: "2025-06-21T04:59:58.346Z"
+poster: "hiraethmarkb"
+lat: "54.980045"
+lng: "-3.619032"
+location: "Sweetheart Abbey, Dumfries, New Abbey, Dumfries and Galloway, Scotland, DG2 8BU, United Kingdom"
+title: "Sweetheart Abbey"
+external_url: https://en.wikipedia.org/wiki/Sweetheart_Abbey
+---
+Originally named Dulce Cor by the Cistercian monks who inhabited the abbey. It's more commonly known as Sweetheart Abbey, having been founded by Lady Dervorguilla of Galloway in tribute to her beloved husband, John de Balliol.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sweetheart Abbey
**Location:** Sweetheart Abbey, Dumfries, New Abbey, Dumfries and Galloway, Scotland, DG2 8BU, United Kingdom
**Submitted by:** hiraethmarkb
**Website:** https://en.wikipedia.org/wiki/Sweetheart_Abbey

### Description
Originally named Dulce Cor by the Cistercian monks who inhabited the abbey. It's more commonly known as Sweetheart Abbey, having been founded by Lady Dervorguilla of Galloway in tribute to her beloved husband, John de Balliol.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 546
**File:** `content/daytrip/eu/gb/sweetheart-abbey.md`

Please review this venue submission and edit the content as needed before merging.