### PR TITLE
New: Museum of Lead Mining from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/museum-of-lead-mining.md
+++ b/content/daytrip/eu/gb/museum-of-lead-mining.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/museum-of-lead-mining"
+date: "2025-06-21T05:00:16.883Z"
+poster: "hiraethmarkb"
+lat: "55.397185"
+lng: "-3.780183"
+location: "Museum of Lead Mining, Toll Brae, Wanlockhead, Dumfries and Galloway, Scotland, ML12 6UT, United Kingdom"
+title: "Museum of Lead Mining"
+external_url: https://www.leadminingmuseum.co.uk/visit/
+---
+Underground tour of a former working mine, in an area known for it's Lead mining and Gold panning.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Museum of Lead Mining
**Location:** Museum of Lead Mining, Toll Brae, Wanlockhead, Dumfries and Galloway, Scotland, ML12 6UT, United Kingdom
**Submitted by:** hiraethmarkb
**Website:** https://www.leadminingmuseum.co.uk/visit/

### Description
Underground tour of a former working mine, in an area known for it's Lead mining and Gold panning.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 547
**File:** `content/daytrip/eu/gb/museum-of-lead-mining.md`

Please review this venue submission and edit the content as needed before merging.