### PR TITLE
New: Arcade Archive from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/arcade-archive.md
+++ b/content/daytrip/eu/gb/arcade-archive.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/arcade-archive"
+date: "2025-06-21T05:00:32.827Z"
+poster: "hiraethmarkb"
+lat: "51.720534"
+lng: "-2.159386"
+location: "Arcade Archive, Chalford, Stroud, Gloucestershire, England, GL6 8PR, United Kingdom"
+title: "Arcade Archive"
+external_url: https://www.retrocollective.co.uk/arcade-archive.php
+---
+A marvel for retro arcade fans. Part of the Retro Collective.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Arcade Archive
**Location:** Arcade Archive, Chalford, Stroud, Gloucestershire, England, GL6 8PR, United Kingdom
**Submitted by:** hiraethmarkb
**Website:** https://www.retrocollective.co.uk/arcade-archive.php

### Description
A marvel for retro arcade fans. Part of the Retro Collective.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 549
**File:** `content/daytrip/eu/gb/arcade-archive.md`

Please review this venue submission and edit the content as needed before merging.