### PR TITLE
New: Lakeland Motor Museum from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/lakeland-motor-museum.md
+++ b/content/daytrip/eu/gb/lakeland-motor-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/lakeland-motor-museum"
+date: "2025-06-21T05:00:41.392Z"
+poster: "hiraethmarkb"
+lat: "54.258766"
+lng: "-2.989245"
+location: "Lakeland Motor Museum, Haverthwaite, Backbarrow, Westmorland and Furness, England, LA12 8TA"
+title: "Lakeland Motor Museum"
+external_url: https://www.lakelandmotormuseum.co.uk/
+---
+Among many examples of motoring history, features a dedicated display of the cars and boats (replicas) made famous by Sir Malcolm and Donald Campbell.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lakeland Motor Museum
**Location:** Lakeland Motor Museum, Haverthwaite, Backbarrow, Westmorland and Furness, England, LA12 8TA
**Submitted by:** hiraethmarkb
**Website:** https://www.lakelandmotormuseum.co.uk/

### Description
Among many examples of motoring history, features a dedicated display of the cars and boats (replicas) made famous by Sir Malcolm and Donald Campbell.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 550
**File:** `content/daytrip/eu/gb/lakeland-motor-museum.md`

Please review this venue submission and edit the content as needed before merging.