### PR TITLE
New: Dumfries and Galloway Aviation Museum from hiraethmarkb

### DIFF
--- a/content/daytrip/eu/gb/dumfries-and-galloway-aviation-museum.md
+++ b/content/daytrip/eu/gb/dumfries-and-galloway-aviation-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/dumfries-and-galloway-aviation-museum"
+date: "2025-06-21T05:00:49.515Z"
+poster: "hiraethmarkb"
+lat: "55.090884"
+lng: "-3.568747"
+location: "Dumfries and Galloway Aviation Museum, Tinwald Downs Road, Heathhall, Dumfries, Scotland, DG1 3SS"
+title: "Dumfries and Galloway Aviation Museum"
+external_url: https://www.dumfriesaviationmuseum.com/
+---
+Situated on the site of the wartime RAF Dumfries airfield, the collection of aircraft includes the Loch Doon Spitfire, and a collection of Airborne Forces exhibits.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Dumfries and Galloway Aviation Museum
**Location:** Dumfries and Galloway Aviation Museum, Tinwald Downs Road, Heathhall, Dumfries, Scotland, DG1 3SS
**Submitted by:** hiraethmarkb
**Website:** https://www.dumfriesaviationmuseum.com/

### Description
Situated on the site of the wartime RAF Dumfries airfield, the collection of aircraft includes the Loch Doon Spitfire, and a collection of Airborne Forces exhibits.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 551
**File:** `content/daytrip/eu/gb/dumfries-and-galloway-aviation-museum.md`

Please review this venue submission and edit the content as needed before merging.