### PR TITLE
New: National Museum of Flight from Isaac

### DIFF
--- a/content/daytrip/eu/gb/national-museum-of-flight.md
+++ b/content/daytrip/eu/gb/national-museum-of-flight.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/national-museum-of-flight"
+date: "2025-06-21T05:00:57.458Z"
+poster: "Isaac"
+lat: "55.995466"
+lng: "-2.720302"
+location: "National Museum of Flight, B1377, East Fortune, East Lothian, Scotland, EH39 5BT, United Kingdom"
+title: "National Museum of Flight"
+external_url: https://www.nms.ac.uk/national-museum-of-flight
+---
+Got one of the only public Concordes in the world, plus massive collections of civilian and military aviation, a de Havilland Comet and an Avro Vulcan


### PR DESCRIPTION
## New Venue Submission

**Venue:** National Museum of Flight
**Location:** National Museum of Flight, B1377, East Fortune, East Lothian, Scotland, EH39 5BT, United Kingdom
**Submitted by:** Isaac
**Website:** https://www.nms.ac.uk/national-museum-of-flight

### Description
Got one of the only public Concordes in the world, plus massive collections of civilian and military aviation, a de Havilland Comet and an Avro Vulcan

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 552
**File:** `content/daytrip/eu/gb/national-museum-of-flight.md`

Please review this venue submission and edit the content as needed before merging.