### PR TITLE
New: Shepherd Neame Visitor Centre from Valentin

### DIFF
--- a/content/daytrip/eu/gb/shepherd-neame-visitor-centre.md
+++ b/content/daytrip/eu/gb/shepherd-neame-visitor-centre.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/shepherd-neame-visitor-centre"
+date: "2025-06-21T10:28:08.272Z"
+poster: "Valentin"
+lat: "51.31671"
+lng: "0.891679"
+location: "Shepherd Neame Visitor Centre, Partridge Lane, The Brents, Faversham, Ospringe, Borough of Swale, Kent, England, ME13 7AN, United Kingdom"
+title: "Shepherd Neame Visitor Centre"
+external_url: https://www.shepherdneame.co.uk/
+---
+Britain's oldest brewer. Brewery tours. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Shepherd Neame Visitor Centre
**Location:** Shepherd Neame Visitor Centre, Partridge Lane, The Brents, Faversham, Ospringe, Borough of Swale, Kent, England, ME13 7AN, United Kingdom
**Submitted by:** Valentin
**Website:** https://www.shepherdneame.co.uk/

### Description
Britain's oldest brewer. Brewery tours. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 554
**File:** `content/daytrip/eu/gb/shepherd-neame-visitor-centre.md`

Please review this venue submission and edit the content as needed before merging.