### PR TITLE
New: Yorkshire Sculpture Park from Phil Clifford

### DIFF
--- a/content/daytrip/eu/gb/yorkshire-sculpture-park.md
+++ b/content/daytrip/eu/gb/yorkshire-sculpture-park.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/yorkshire-sculpture-park"
+date: "2025-06-21T11:22:37.312Z"
+poster: "Phil Clifford"
+lat: "53.61197"
+lng: "-1.565277"
+location: "Yorkshire Sculpture Park, Huddersfield Road, West Bretton, Wakefield, WF4 4UG, England"
+title: "Yorkshire Sculpture Park"
+external_url: https://ysp.org.uk/
+---
+Beautiful parkland walks, a fabulous collection of sculpture, exhibitions, galleries and learning centre.  


### PR DESCRIPTION
## New Venue Submission

**Venue:** Yorkshire Sculpture Park
**Location:** Yorkshire Sculpture Park, Huddersfield Road, West Bretton, Wakefield, WF4 4UG, England
**Submitted by:** Phil Clifford
**Website:** https://ysp.org.uk/

### Description
Beautiful parkland walks, a fabulous collection of sculpture, exhibitions, galleries and learning centre.  

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 555
**File:** `content/daytrip/eu/gb/yorkshire-sculpture-park.md`

Please review this venue submission and edit the content as needed before merging.