### PR TITLE
New: Kirkcudbright Galleries from Phil Clifford

### DIFF
--- a/content/daytrip/eu/gb/kirkcudbright-galleries.md
+++ b/content/daytrip/eu/gb/kirkcudbright-galleries.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/kirkcudbright-galleries"
+date: "2025-06-21T12:35:05.013Z"
+poster: "Phil Clifford"
+lat: "54.835977"
+lng: "-4.049892"
+location: "Kirkcudbright Galleries, Church Place, Kirkcudbright, Dumfries and Galloway, Scotland, DG6 4AA"
+title: "Kirkcudbright Galleries"
+external_url: https://www.kirkcudbrightgalleries.org.uk/
+---
+The reference point that sets this Artists' Town in context and also a great cafe. Regular special events and exhibitions so it is always worth a visit. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Kirkcudbright Galleries
**Location:** Kirkcudbright Galleries, Church Place, Kirkcudbright, Dumfries and Galloway, Scotland, DG6 4AA
**Submitted by:** Phil Clifford
**Website:** https://www.kirkcudbrightgalleries.org.uk/

### Description
The reference point that sets this Artists' Town in context and also a great cafe. Regular special events and exhibitions so it is always worth a visit. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Kirkcudbright%20Galleries%2C%20Church%20Place%2C%20Kirkcudbright%2C%20Dumfries%20and%20Galloway%2C%20Scotland%2C%20DG6%204AA)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Kirkcudbright%20Galleries%2C%20Church%20Place%2C%20Kirkcudbright%2C%20Dumfries%20and%20Galloway%2C%20Scotland%2C%20DG6%204AA)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 556
**File:** `content/daytrip/eu/gb/kirkcudbright-galleries.md`

Please review this venue submission and edit the content as needed before merging.