### PR TITLE
New: The Singing Ringing Tree from Phil Clifford

### DIFF
--- a/content/daytrip/eu/gb/the-singing-ringing-tree.md
+++ b/content/daytrip/eu/gb/the-singing-ringing-tree.md
@@ -1,0 +1,12 @@
+---
+slug: "daytrip/eu/gb/the-singing-ringing-tree"
+date: "2025-06-21T12:44:50.143Z"
+poster: "Phil Clifford"
+lat: "53.756635"
+lng: "-2.227228"
+location: "The Singing Ringing Tree, Crown Point Road, Cliviger, Burnley, Lancashire, England, BB11 3QS"
+title: "The Singing Ringing Tree"
+external_url: https://www.visitlancashire.com/things-to-do/singing-ringing-tree-panopticon-p66560
+---
+An unique viewpoint sculpture worth seeking out on a blustery day.
+A collection of tuned steel pipes depict a windswept moorland tree while also harnessing the moving air to create a soundscape.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Singing Ringing Tree
**Location:** The Singing Ringing Tree, Crown Point Road, Cliviger, Burnley, Lancashire, England, BB11 3QS
**Submitted by:** Phil Clifford
**Website:** https://www.visitlancashire.com/things-to-do/singing-ringing-tree-panopticon-p66560

### Description
An unique viewpoint sculpture worth seeking out on a blustery day.
A collection of tuned steel pipes depict a windswept moorland tree while also harnessing the moving air to create a soundscape.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=The%20Singing%20Ringing%20Tree%2C%20Crown%20Point%20Road%2C%20Cliviger%2C%20Burnley%2C%20Lancashire%2C%20England%2C%20BB11%203QS)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=The%20Singing%20Ringing%20Tree%2C%20Crown%20Point%20Road%2C%20Cliviger%2C%20Burnley%2C%20Lancashire%2C%20England%2C%20BB11%203QS)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 557
**File:** `content/daytrip/eu/gb/the-singing-ringing-tree.md`

Please review this venue submission and edit the content as needed before merging.