### PR TITLE
New: Talyllyn Railway and Narrow Gauge Railway Museum from Cassolotl

### DIFF
--- a/content/daytrip/eu/gb/talyllyn-railway-and-narrow-gauge-railway-museum.md
+++ b/content/daytrip/eu/gb/talyllyn-railway-and-narrow-gauge-railway-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/talyllyn-railway-and-narrow-gauge-railway-museum"
+date: "2025-06-21T13:02:10.900Z"
+poster: "Cassolotl"
+lat: "52.58358"
+lng: "-4.089076"
+location: "Wharf Station, Tywyn, Gwynedd, LL36 9EY"
+title: "Talyllyn Railway and Narrow Gauge Railway Museum"
+external_url: https://www.talyllyn.co.uk
+---
+It's a lovingly restored tiny steam train that goes around lots of really cool natureful places. The station in Tywyn also has a really good steam railway museum and a little cafe.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Talyllyn Railway and Narrow Gauge Railway Museum
**Location:** Wharf Station, Tywyn, Gwynedd, LL36 9EY
**Submitted by:** Cassolotl
**Website:** https://www.talyllyn.co.uk

### Description
It's a lovingly restored tiny steam train that goes around lots of really cool natureful places. The station in Tywyn also has a really good steam railway museum and a little cafe.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Wharf%20Station%2C%20Tywyn%2C%20Gwynedd%2C%20LL36%209EY)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Wharf%20Station%2C%20Tywyn%2C%20Gwynedd%2C%20LL36%209EY)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 561
**File:** `content/daytrip/eu/gb/talyllyn-railway-and-narrow-gauge-railway-museum.md`

Please review this venue submission and edit the content as needed before merging.