### PR TITLE
New: Fleet Pond from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/fleet-pond.md
+++ b/content/daytrip/eu/gb/fleet-pond.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/fleet-pond"
+date: "2025-06-21T18:09:56.278Z"
+poster: "AndiBing"
+lat: "51.288753"
+lng: "-0.822715"
+location: "Fleet Pond, Fleet, Hart, Hampshire, England, United Kingdom"
+title: "Fleet Pond"
+external_url: https://www.hart.gov.uk/fleet-pond
+---
+The [largest freshwater lake in Hampshire](https://en.wikipedia.org/wiki/Fleet_Pond). The site is over 50 hectares in size and is designated a [Site of Special Scientific Interest (SSSI)](https://en.wikipedia.org/wiki/Site_of_Special_Scientific_Interest).


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fleet Pond
**Location:** Fleet Pond, Fleet, Hart, Hampshire, England, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.hart.gov.uk/fleet-pond

### Description
The [largest freshwater lake in Hampshire](https://en.wikipedia.org/wiki/Fleet_Pond). The site is over 50 hectares in size and is designated a [Site of Special Scientific Interest (SSSI)](https://en.wikipedia.org/wiki/Site_of_Special_Scientific_Interest).

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Fleet%20Pond%2C%20Fleet%2C%20Hart%2C%20Hampshire%2C%20England%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Fleet%20Pond%2C%20Fleet%2C%20Hart%2C%20Hampshire%2C%20England%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 564
**File:** `content/daytrip/eu/gb/fleet-pond.md`

Please review this venue submission and edit the content as needed before merging.