### PR TITLE
New: Lincolnshire Aviation Heritage Centre from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/lincolnshire-aviation-heritage-centre.md
+++ b/content/daytrip/eu/gb/lincolnshire-aviation-heritage-centre.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/eu/gb/lincolnshire-aviation-heritage-centre"
+date: "2025-06-21T23:37:32.802Z"
+poster: "AndiBing"
+lat: "53.139351"
+lng: "-0.00099"
+location: "Lincolnshire Aviation Heritage Centre, East Kirkby, Lincolnshire, England, PE23 4DE, United Kingdom"
+title: "Lincolnshire Aviation Heritage Centre"
+external_url: https://www.lincsaviation.co.uk/
+---
+RAF Airfield from the Second World War. The museum is home to one of Bomber Command's most iconic aircraft, the Avro Lancaster.
+Avro Lancaster NX611 'Just Jane' is in a taxiable condition.
+
+A highly recommended arrival method is to land at the museum by air.
+https://www.lincsaviation.co.uk/plan-your-visit/flying-in


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lincolnshire Aviation Heritage Centre
**Location:** Lincolnshire Aviation Heritage Centre, East Kirkby, Lincolnshire, England, PE23 4DE, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.lincsaviation.co.uk/

### Description
RAF Airfield from the Second World War. The museum is home to one of Bomber Command's most iconic aircraft, the Avro Lancaster.
Avro Lancaster NX611 'Just Jane' is in a taxiable condition.

A highly recommended arrival method is to land at the museum by air.
https://www.lincsaviation.co.uk/plan-your-visit/flying-in

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Lincolnshire%20Aviation%20Heritage%20Centre%2C%20East%20Kirkby%2C%20Lincolnshire%2C%20England%2C%20PE23%204DE%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Lincolnshire%20Aviation%20Heritage%20Centre%2C%20East%20Kirkby%2C%20Lincolnshire%2C%20England%2C%20PE23%204DE%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 566
**File:** `content/daytrip/eu/gb/lincolnshire-aviation-heritage-centre.md`

Please review this venue submission and edit the content as needed before merging.