### PR TITLE
New: Sir Frank Whittle Memorial from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/sir-frank-whittle-memorial.md
+++ b/content/daytrip/eu/gb/sir-frank-whittle-memorial.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/sir-frank-whittle-memorial"
+date: "2025-06-22T00:07:38.742Z"
+poster: "AndiBing"
+lat: "51.284924"
+lng: "-0.779085"
+location: "Ively Road, Farnborough, England. United Kingdom"
+title: "Sir Frank Whittle Memorial"
+external_url: https://www.geograph.org.uk/photo/6577520
+---
+The Ively Roundabout, at the junction of Elles Road and Ively Road, features a replica of a  [Gloster E.28/39](https://en.wikipedia.org/wiki/Gloster_E.28/39), in tribute to [Sir Frank Whittle](https://en.wikipedia.org/wiki/Frank_Whittle), the inventor of the jet engine.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sir Frank Whittle Memorial
**Location:** Ively Road, Farnborough, England. United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.geograph.org.uk/photo/6577520

### Description
The Ively Roundabout, at the junction of Elles Road and Ively Road, features a replica of a  [Gloster E.28/39](https://en.wikipedia.org/wiki/Gloster_E.28/39), in tribute to [Sir Frank Whittle](https://en.wikipedia.org/wiki/Frank_Whittle), the inventor of the jet engine.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Ively%20Road%2C%20Farnborough%2C%20England.%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Ively%20Road%2C%20Farnborough%2C%20England.%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 567
**File:** `content/daytrip/eu/gb/sir-frank-whittle-memorial.md`

Please review this venue submission and edit the content as needed before merging.