### PR TITLE
New: Watermouth Castle & Family Theme Park from WeeBitShifty

### DIFF
--- a/content/daytrip/eu/gb/watermouth-castle-family-theme-park.md
+++ b/content/daytrip/eu/gb/watermouth-castle-family-theme-park.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/watermouth-castle-family-theme-park"
+date: "2025-06-22T08:55:48.332Z"
+poster: "WeeBitShifty"
+lat: "51.21199"
+lng: "-4.07058"
+location: "A399 between Combe Martin and Illfracombe"
+title: "Watermouth Castle & Family Theme Park"
+external_url: https://www.watermouthcastle.com
+---
+The Theme Park is your typical, boring Kid's Play stuff but the 'house' is a treasure trove of nerdy 'old timey' curios. Hilariously odd. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Watermouth Castle & Family Theme Park
**Location:** A399 between Combe Martin and Illfracombe
**Submitted by:** WeeBitShifty
**Website:** https://www.watermouthcastle.com

### Description
The Theme Park is your typical, boring Kid's Play stuff but the 'house' is a treasure trove of nerdy 'old timey' curios. Hilariously odd. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=A399%20between%20Combe%20Martin%20and%20Illfracombe)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=A399%20between%20Combe%20Martin%20and%20Illfracombe)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 563
**File:** `content/daytrip/eu/gb/watermouth-castle-family-theme-park.md`

Please review this venue submission and edit the content as needed before merging.