### PR TITLE
New: Lake Superior Railroad Museum from nothingneko

### DIFF
--- a/content/daytrip/na/us/lake-superior-railroad-museum.md
+++ b/content/daytrip/na/us/lake-superior-railroad-museum.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/na/us/lake-superior-railroad-museum"
+date: "2025-06-22T08:56:01.458Z"
+poster: "nothingneko"
+lat: "46.780931"
+lng: "-92.104096"
+location: "Lake Superior Railroad Museum, 506 West Michigan Street, Duluth, Minnesota, 55802, United States"
+title: "Lake Superior Railroad Museum"
+external_url: https://lsrm.org/
+---
+This museum features a giant room full of rows and rows of full size trains, many you can climb onboard and walk through. The museum is very well interpreted and features interpretation around Hobos (train hitchhikers) and life around trains.
+
+During off hours, the museum is relatively sensory friendly, but it can be very hot and stagnant, and clearances onboard trains can be tight.
+
+ Tickets are $14 for adults, $7 for children under 13. There is a $1 discount for active duty military and veterans, and some staff members will give a $4 discount to students with ID.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lake Superior Railroad Museum
**Location:** Lake Superior Railroad Museum, 506 West Michigan Street, Duluth, Minnesota, 55802, United States
**Submitted by:** nothingneko
**Website:** https://lsrm.org/

### Description
This museum features a giant room full of rows and rows of full size trains, many you can climb onboard and walk through. The museum is very well interpreted and features interpretation around Hobos (train hitchhikers) and life around trains.

During off hours, the museum is relatively sensory friendly, but it can be very hot and stagnant, and clearances onboard trains can be tight.

 Tickets are $14 for adults, $7 for children under 13. There is a $1 discount for active duty military and veterans, and some staff members will give a $4 discount to students with ID.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Lake%20Superior%20Railroad%20Museum%2C%20506%20West%20Michigan%20Street%2C%20Duluth%2C%20Minnesota%2C%2055802%2C%20United%20States)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Lake%20Superior%20Railroad%20Museum%2C%20506%20West%20Michigan%20Street%2C%20Duluth%2C%20Minnesota%2C%2055802%2C%20United%20States)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 565
**File:** `content/daytrip/na/us/lake-superior-railroad-museum.md`

Please review this venue submission and edit the content as needed before merging.