### PR TITLE
New: Volkssterrenwacht Urania  from AlainG

### DIFF
--- a/content/daytrip/eu/be/volkssterrenwacht-urania.md
+++ b/content/daytrip/eu/be/volkssterrenwacht-urania.md
@@ -1,11 +1,11 @@
 ---
-slug: "daytrip/eu/be/volkssterrenwacht-urania-"
+slug: "daytrip/eu/be/volkssterrenwacht-urania"
 date: "2025-06-22T09:49:56.263Z"
 poster: "AlainG"
 lat: "51.144639"
 lng: "4.465591"
 location: "Jozef Mattheessensstraat 60 - Hove"
-title: "Volkssterrenwacht Urania "
+title: "Volkssterrenwacht Urania"
 external_url: https://www.urania.be
 ---
 Public observatory with events and tours for the public. Planetarium events. Get your tickets online! 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Volkssterrenwacht Urania 
**Location:** Jozef Mattheessensstraat 60 - Hove
**Submitted by:** AlainG
**Website:** https://www.urania.be

### Description
Public observatory with events and tours for the public. Planetarium events. Get your tickets online! 

Night sky with 40-cm telescope every Friday night !

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Jozef%20Mattheessensstraat%2060%20-%20Hove)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Jozef%20Mattheessensstraat%2060%20-%20Hove)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 569
**File:** `content/daytrip/eu/be/volkssterrenwacht-urania-.md`

Please review this venue submission and edit the content as needed before merging.