### PR TITLE
New: Volkssternwarte München. Public Observatory from Iαη 🍺

### DIFF
--- a/content/daytrip/eu/de/volkssternwarte-mnchen-public-observatory.md
+++ b/content/daytrip/eu/de/volkssternwarte-mnchen-public-observatory.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/de/volkssternwarte-mnchen-public-observatory"
+date: "2025-06-22T14:14:19.581Z"
+poster: "Iαη 🍺"
+lat: "48.122045"
+lng: "11.607024"
+location: "Zugang Volkssternwarte München, Ludwig-Jung-Straße, Echarding, Berg am Laim, Munich, Bavaria, 81671, Germany"
+title: "Volkssternwarte München. Public Observatory"
+external_url: https://sternwarte-muenchen.de/en/
+---
+You can see space from Munich! Book a tour of the observatory


### PR DESCRIPTION
## New Venue Submission

**Venue:** Volkssternwarte München. Public Observatory
**Location:** Zugang Volkssternwarte München, Ludwig-Jung-Straße, Echarding, Berg am Laim, Munich, Bavaria, 81671, Germany
**Submitted by:** Iαη 🍺
**Website:** https://sternwarte-muenchen.de/en/

### Description
You can see space from Munich! Book a tour of the observatory

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Zugang%20Volkssternwarte%20M%C3%BCnchen%2C%20Ludwig-Jung-Stra%C3%9Fe%2C%20Echarding%2C%20Berg%20am%20Laim%2C%20Munich%2C%20Bavaria%2C%2081671%2C%20Germany)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Zugang%20Volkssternwarte%20M%C3%BCnchen%2C%20Ludwig-Jung-Stra%C3%9Fe%2C%20Echarding%2C%20Berg%20am%20Laim%2C%20Munich%2C%20Bavaria%2C%2081671%2C%20Germany)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 578
**File:** `content/daytrip/eu/de/volkssternwarte-mnchen-public-observatory.md`

Please review this venue submission and edit the content as needed before merging.