### PR TITLE
New: Venkatappa Art Gallery from Pfft

### DIFF
--- a/content/daytrip/as/in/venkatappa-art-gallery.md
+++ b/content/daytrip/as/in/venkatappa-art-gallery.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/in/venkatappa-art-gallery"
+date: "2025-06-22T14:21:29.550Z"
+poster: "Pfft"
+lat: "12.974461"
+lng: "77.595206"
+location: "Venkatappa Art Gallery, Kasturba Road, Bengaluru, Karnataka, 560001, India"
+title: "Venkatappa Art Gallery"
+external_url: https://archaeology.karnataka.gov.in/page/Government+Museums/Venkatappa+Art+Gallery+Bengaluru/en
+---
+Venkatappa Art Gallery came into being with the foundation stone being laid by the then Chief Minister S.Nijalingappa on 24 November 1967. It took a long time to complete. Artists who were frustrated with the delays went on an innovative protest on the footpath in front of Bible Society demanding the gallery space be finished in 1971. Artists included G.S Shenoy, Bhaskar Rao, Ramesh Rao, Acharya and Punam Chattaya. The building was finally completed in 1975


### PR DESCRIPTION
## New Venue Submission

**Venue:** Venkatappa Art Gallery
**Location:** Venkatappa Art Gallery, Kasturba Road, Bengaluru, Karnataka, 560001, India
**Submitted by:** Pfft
**Website:** https://archaeology.karnataka.gov.in/page/Government+Museums/Venkatappa+Art+Gallery+Bengaluru/en

### Description
Venkatappa Art Gallery came into being with the foundation stone being laid by the then Chief Minister S.Nijalingappa on 24 November 1967. It took a long time to complete. Artists who were frustrated with the delays went on an innovative protest on the footpath in front of Bible Society demanding the gallery space be finished in 1971. Artists included G.S Shenoy, Bhaskar Rao, Ramesh Rao, Acharya and Punam Chattaya. The building was finally completed in 1975

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Venkatappa%20Art%20Gallery%2C%20Kasturba%20Road%2C%20Bengaluru%2C%20Karnataka%2C%20560001%2C%20India)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Venkatappa%20Art%20Gallery%2C%20Kasturba%20Road%2C%20Bengaluru%2C%20Karnataka%2C%20560001%2C%20India)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 571
**File:** `content/daytrip/as/in/venkatappa-art-gallery.md`

Please review this venue submission and edit the content as needed before merging.