### PR TITLE
New: Karnataka Chitrakala Parishath from Pfft

### DIFF
--- a/content/daytrip/as/in/karnataka-chitrakala-parishath.md
+++ b/content/daytrip/as/in/karnataka-chitrakala-parishath.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/in/karnataka-chitrakala-parishath"
+date: "2025-06-22T14:21:56.756Z"
+poster: "Pfft"
+lat: "12.989281"
+lng: "77.580748"
+location: "Karnataka Chitrakala Parishath, Kumara Krupa Road, Srikantan Layout, Vasanth Nagar, Bengaluru, Bangalore North, Bengaluru Urban, Karnataka, 560001, India"
+title: "Karnataka Chitrakala Parishath"
+external_url: https://chitrakalaparishath.org/
+---
+Karnataka Chitrakala Parishath (Kannada: ಕರ್ನಾಟಕ ಚಿತ್ರಕಲಾ ಪರಿಷತ್) is a visual art complex located in Bangalore. The complex has 18 galleries. 13 of these galleries carry a permanent collection of paintings, sculptures and folk art. The other galleries are rented out for exhibitions of works by artists of repute. The folk art collection showcases Mysore paintings and leather puppets. The Parishat runs the College of Fine Arts, a visual arts college. Each January, the Parishath organizes Chitra Santhe, a cultural event showcasing affordable art to the public. The motto of the event is "Art for All". 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Karnataka Chitrakala Parishath
**Location:** Karnataka Chitrakala Parishath, Kumara Krupa Road, Srikantan Layout, Vasanth Nagar, Bengaluru, Bangalore North, Bengaluru Urban, Karnataka, 560001, India
**Submitted by:** Pfft
**Website:** https://chitrakalaparishath.org/

### Description
Karnataka Chitrakala Parishath (Kannada: ಕರ್ನಾಟಕ ಚಿತ್ರಕಲಾ ಪರಿಷತ್) is a visual art complex located in Bangalore. The complex has 18 galleries. 13 of these galleries carry a permanent collection of paintings, sculptures and folk art. The other galleries are rented out for exhibitions of works by artists of repute. The folk art collection showcases Mysore paintings and leather puppets. The Parishat runs the College of Fine Arts, a visual arts college. Each January, the Parishath organizes Chitra Santhe, a cultural event showcasing affordable art to the public. The motto of the event is "Art for All". 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Karnataka%20Chitrakala%20Parishath%2C%20Kumara%20Krupa%20Road%2C%20Srikantan%20Layout%2C%20Vasanth%20Nagar%2C%20Bengaluru%2C%20Bangalore%20North%2C%20Bengaluru%20Urban%2C%20Karnataka%2C%20560001%2C%20India)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Karnataka%20Chitrakala%20Parishath%2C%20Kumara%20Krupa%20Road%2C%20Srikantan%20Layout%2C%20Vasanth%20Nagar%2C%20Bengaluru%2C%20Bangalore%20North%2C%20Bengaluru%20Urban%2C%20Karnataka%2C%20560001%2C%20India)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 572
**File:** `content/daytrip/as/in/karnataka-chitrakala-parishath.md`

Please review this venue submission and edit the content as needed before merging.