### PR TITLE
New: Jawaharlal Nehru Planetarium from Pfft

### DIFF
--- a/content/daytrip/as/in/jawaharlal-nehru-planetarium.md
+++ b/content/daytrip/as/in/jawaharlal-nehru-planetarium.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/as/in/jawaharlal-nehru-planetarium"
+date: "2025-06-22T14:22:17.133Z"
+poster: "Pfft"
+lat: "12.984549"
+lng: "77.589869"
+location: "Jawaharlal Nehru Planetarium, Raj Bhavan Road Cycle Lane, Fair Field Layout, Vasanth Nagar, Bengaluru, Bangalore North, Bengaluru Urban, Karnataka, 560001, India"
+title: "Jawaharlal Nehru Planetarium"
+external_url: https://taralaya.karnataka.gov.in/25/overview/en
+---
+Started in 1989, the JNP has emerged as a premier institution devoted to science popularization and non formal science education in India. It attracts over 3 lakh visitors annually, majority of whom are students. It is equipped with a large 15 M dome and a state of the art hybrid projection system installed and commissioned in 2017. The JNP organizes several interesting programmes aimed at school students and general public. These are: monthly star gazing, science club activities, science movies, Sky-theatre shows every day, viewing of astronomical events etc.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Jawaharlal Nehru Planetarium
**Location:** Jawaharlal Nehru Planetarium, Raj Bhavan Road Cycle Lane, Fair Field Layout, Vasanth Nagar, Bengaluru, Bangalore North, Bengaluru Urban, Karnataka, 560001, India
**Submitted by:** Pfft
**Website:** https://taralaya.karnataka.gov.in/25/overview/en

### Description
Started in 1989, the JNP has emerged as a premier institution devoted to science popularization and non formal science education in India. It attracts over 3 lakh visitors annually, majority of whom are students. It is equipped with a large 15 M dome and a state of the art hybrid projection system installed and commissioned in 2017. The JNP organizes several interesting programmes aimed at school students and general public. These are: monthly star gazing, science club activities, science movies, Sky-theatre shows every day, viewing of astronomical events etc.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Jawaharlal%20Nehru%20Planetarium%2C%20Raj%20Bhavan%20Road%20Cycle%20Lane%2C%20Fair%20Field%20Layout%2C%20Vasanth%20Nagar%2C%20Bengaluru%2C%20Bangalore%20North%2C%20Bengaluru%20Urban%2C%20Karnataka%2C%20560001%2C%20India)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Jawaharlal%20Nehru%20Planetarium%2C%20Raj%20Bhavan%20Road%20Cycle%20Lane%2C%20Fair%20Field%20Layout%2C%20Vasanth%20Nagar%2C%20Bengaluru%2C%20Bangalore%20North%2C%20Bengaluru%20Urban%2C%20Karnataka%2C%20560001%2C%20India)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 574
**File:** `content/daytrip/as/in/jawaharlal-nehru-planetarium.md`

Please review this venue submission and edit the content as needed before merging.