### PR TITLE
New: Vindolanda from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/vindolanda.md
+++ b/content/daytrip/eu/gb/vindolanda.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/vindolanda"
+date: "2025-06-22T17:56:14.770Z"
+poster: "AndiBing"
+lat: "54.990911"
+lng: "-2.361717"
+location: "Vindolanda, Northumberland, England, United Kingdom"
+title: "Vindolanda"
+external_url: https://www.vindolanda.com/
+---
+An archaeological site and museum of a Roman frontier fort along Hadrian's Wall.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Vindolanda
**Location:** Vindolanda, Northumberland, England, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.vindolanda.com/

### Description
An archaeological site and museum of a Roman frontier fort along Hadrian's Wall.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Vindolanda%2C%20Northumberland%2C%20England%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Vindolanda%2C%20Northumberland%2C%20England%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 579
**File:** `content/daytrip/eu/gb/vindolanda.md`

Please review this venue submission and edit the content as needed before merging.