### PR TITLE
New: Sycamore Gap from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/sycamore-gap.md
+++ b/content/daytrip/eu/gb/sycamore-gap.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/sycamore-gap"
+date: "2025-06-22T17:56:17.254Z"
+poster: "AndiBing"
+lat: "55.003675"
+lng: "-2.374008"
+location: "Sycamore Gap, Northumberland, England, NE47 7AL, United Kingdom"
+title: "Sycamore Gap"
+external_url: https://en.wikipedia.org/wiki/Sycamore_Gap_tree
+---
+The most famous and photographed tree in the World.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Sycamore Gap
**Location:** Sycamore Gap, Northumberland, England, NE47 7AL, United Kingdom
**Submitted by:** AndiBing
**Website:** https://en.wikipedia.org/wiki/Sycamore_Gap_tree

### Description
The most famous and photographed tree in the World.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Sycamore%20Gap%2C%20Northumberland%2C%20England%2C%20NE47%207AL%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Sycamore%20Gap%2C%20Northumberland%2C%20England%2C%20NE47%207AL%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 580
**File:** `content/daytrip/eu/gb/sycamore-gap.md`

Please review this venue submission and edit the content as needed before merging.