### PR TITLE
[Feature] add a share button to each venue page

### DIFF
--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -1,17 +1,7 @@
 {{ define "main" }}
 <article>
     <header id="post-header">
-        <h1>{{ if .Params.lat }}
-                    &nbsp;
-                    <a href="/#{{ .Params.slug }}" title="Show {{ .Title }} on the map"><i class="fa-solid fa-map-location-dot"></i></a>{{ end }}&nbsp;{{ .Title }}
-            {{ if .Params.external_url }}
-                &nbsp;
-                <a href="{{ .Params.external_url }}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
-            {{ end }}
-            &nbsp;
-                <a href="javascript:void(0);" onclick="copyToClipboard(window.location.href)" class="external-link" title="Copy link to clipboard"><i class="fa-solid fa-share-nodes"></i></a>
-                <span id="copy-notification" class="copy-notification">Link copied<br>to clipboard!</span>
-        </h1>
+        <h1>{{ .Title }}</h1>
             <div>
                 <!-- Created Date -->
                 <span class="post-info-pubdate"></span>
@@ -36,9 +26,16 @@
                     {{- end }}
                     </span>
                 {{- end }}
-
-                </span>
-            </div>
+                </div><hr><center>
+                {{ if .Params.lat }}
+                    <a class="external-link" href="/#{{ .Params.slug }}" title="Show {{ .Title }} on the main map"><i class="fa-solid fa-map-location-dot">&nbsp;</i>Show on map</a>{{ end }}&nbsp;
+                    {{ if .Params.external_url }}
+                &nbsp;
+                <a href="{{ .Params.external_url }}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square">&nbsp;</i>Visit website</a>
+            {{ end }}&nbsp;
+                <a href="javascript:void(0);" onclick="copyToClipboard(window.location.href)" class="external-link" title="Copy link to clipboard"><i class="fa-solid fa-share-nodes">&nbsp;</i>Share page</a>
+                <span id="copy-notification" class="copy-notification">Link copied<br>to clipboard!</span>
+                </span></center>
     </header>
     <hr>
     {{- if and .Params.lat .Params.lng }}
@@ -87,14 +84,14 @@
     {{- end }}
     {{- .Content -}}
 </article>
-<hr>
+<hr><center>
 {{ if .Params.lat }}
-    <a href="https://www.google.com/maps?ll={{ .Params.lat }},{{ .Params.lng }}&q={{ .Params.lat }},{{ .Params.lng }}&hl=en&t=m&z=15" target="_blank" class="external-link" title="Google Maps"><i class="fa-solid fa-map"></i> Open in Google Maps</a>
-    <br>
-    <a href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe"></i> Open in OpenStreetMap</a>
-{{ end }}
-{{ partial "repository-link.html" (dict "action" "edit" "page" .) }}
+    <a class="external-link" href="https://www.google.com/maps?ll={{ .Params.lat }},{{ .Params.lng }}&q={{ .Params.lat }},{{ .Params.lng }}&hl=en&t=m&z=15" target="_blank" class="external-link" title="Google Maps"><i class="fa-solid fa-map">&nbsp;</i>Google&nbsp;Maps</a>&nbsp;
+    <a class="external-link" href="https://www.openstreetmap.org/?mlat={{ .Params.lat }}&mlon={{ .Params.lng }}#map=19/{{ .Params.lat }}/{{ .Params.lng }}" target="_blank" class="external-link" title="OpenStreetMap"><i class="fa-solid fa-globe">&nbsp;</i>OpenStreetMap</a>
+{{ end }}&nbsp;
+{{ partial "repository-link.html" (dict "action" "edit" "page" .) }}&nbsp;
 {{ partial "repository-link.html" (dict "action" "view" "page" .) }}
+</center><hr>
 
 <style>
 .copy-notification {

--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -8,6 +8,9 @@
                 &nbsp;
                 <a href="{{ .Params.external_url }}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
             {{ end }}
+            &nbsp;
+                <a href="javascript:void(0);" onclick="copyToClipboard(window.location.href)" class="external-link" title="Copy link to clipboard"><i class="fa-solid fa-share-nodes"></i></a>
+                <span id="copy-notification" class="copy-notification">Link copied<br>to clipboard!</span>
         </h1>
             <div>
                 <!-- Created Date -->
@@ -93,4 +96,40 @@
 {{ end }}
 {{ partial "repository-link.html" (dict "action" "edit" "page" .) }}
 {{ partial "repository-link.html" (dict "action" "view" "page" .) }}
+
+<style>
+.copy-notification {
+    display: none;
+    position: absolute;
+    background-color: #333;
+    color: white;
+    padding: 5px 10px;
+    border-radius: 4px;
+    font-size: 14px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    margin-left: 10px;
+}
+.copy-notification.show {
+    display: inline;
+    opacity: 1;
+}
+</style>
+
+<script>
+function copyToClipboard(text) {
+    navigator.clipboard.writeText(text).then(function() {
+        // Show notification
+        const notification = document.getElementById('copy-notification');
+        notification.classList.add('show');
+        
+        // Hide notification after 3 seconds
+        setTimeout(function() {
+            notification.classList.remove('show');
+        }, 3000);
+    }).catch(function(err) {
+        console.error('Failed to copy: ', err);
+    });
+}
+</script>
 {{ end }}

--- a/themes/ndt2/layouts/_default/single.html
+++ b/themes/ndt2/layouts/_default/single.html
@@ -28,8 +28,7 @@
                         {{- if ne $lastmod $created }}
                                 (Updated: 
                                 <time datetime="{{ .Lastmod }}" title="{{ .Lastmod }}">
-                                    {{ $lastmod }}
-                                </time>)
+                                    {{ $lastmod }}</time>)
                         {{- end }}
                     {{- end }}
                     {{- if .Params.poster }}

--- a/themes/ndt2/layouts/partials/repository-link.html
+++ b/themes/ndt2/layouts/partials/repository-link.html
@@ -6,15 +6,13 @@
     {{- $icon := "" }}
     {{- if eq $.action "edit" }}
       {{- $href = printf .urlPatternEdit .owner .repo .branch $path | urls.JoinPath }}
-      {{- $text = printf "Edit this page on %s" .service }}
+      {{- $text = printf "Edit on %s" .service }}
       {{- $icon = "fa-solid fa-pen-to-square" }}
     {{- else if eq $.action "view" }}
       {{- $href = printf .urlPatternView .owner .repo .branch $path | urls.JoinPath }}
-      {{- $text = printf "View this page on %s" .service }}
+      {{- $text = printf "View on %s" .service }}
       {{- $icon = "fa-solid fa-eye" }}
     {{- end }}
-    <div class="repository-link">
-      <a href="{{ $href }}" rel="external"><i class='{{ $icon }}'></i>&nbsp{{ $text }}</a>
-    </div>
+   <a href="{{ $href }}" rel="external"><i class='{{ $icon }}'>&nbsp;</i>{{ $text }}</a>
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
An attempt to fix #827 

Every venue page now has a share button at the top. Press it, and the url (should/will) be copied to your clipboard.

I'm not adding text like "I went to this venue" or "I added this venue" because I always delete that stuff. Just the url, and people can post it anywhere. 