### PR TITLE
New: Ravenglass Roman Bath House from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/ravenglass-roman-bath-house.md
+++ b/content/daytrip/eu/gb/ravenglass-roman-bath-house.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/ravenglass-roman-bath-house"
+date: "2025-06-22T18:06:21.969Z"
+poster: "AndiBing"
+lat: "54.350756"
+lng: "-3.404093"
+location: "Ravenglass Roman Bath House, Ravenglass, Cumbria, England, CA18 1SR, United Kingdom"
+title: "Ravenglass Roman Bath House"
+external_url: https://www.english-heritage.org.uk/visit/places/ravenglass-roman-bath-house/
+---
+Impressive remains of a 2000-year-old Roman Bath House.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Ravenglass Roman Bath House
**Location:** Ravenglass Roman Bath House, Ravenglass, Cumbria, England, CA18 1SR, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.english-heritage.org.uk/visit/places/ravenglass-roman-bath-house/

### Description
Impressive remains of a 2000-year-old Roman Bath House.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Ravenglass%20Roman%20Bath%20House%2C%20Ravenglass%2C%20Cumbria%2C%20England%2C%20CA18%201SR%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Ravenglass%20Roman%20Bath%20House%2C%20Ravenglass%2C%20Cumbria%2C%20England%2C%20CA18%201SR%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 581
**File:** `content/daytrip/eu/gb/ravenglass-roman-bath-house.md`

Please review this venue submission and edit the content as needed before merging.