### PR TITLE
New: Fleet Air Arm Museum from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/fleet-air-arm-museum.md
+++ b/content/daytrip/eu/gb/fleet-air-arm-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/fleet-air-arm-museum"
+date: "2025-06-23T01:39:46.359Z"
+poster: "AndiBing"
+lat: "51.014916"
+lng: "-2.636504"
+location: "Fleet Air Arm Museum, RNAS Yeovilton, Somerset, England, BA22 8HT, United Kingdom"
+title: "Fleet Air Arm Museum"
+external_url: https://www.nmrn.org.uk/visit-us/fleet-air-arm-museum
+---
+Europe's largest naval aviation museum, showing the evolution of the Fleet Air Arm from inception to modern day.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fleet Air Arm Museum
**Location:** Fleet Air Arm Museum, RNAS Yeovilton, Somerset, England, BA22 8HT, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.nmrn.org.uk/visit-us/fleet-air-arm-museum

### Description
Europe's largest naval aviation museum, showing the evolution of the Fleet Air Arm from inception to modern day.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Fleet%20Air%20Arm%20Museum%2C%20RNAS%20Yeovilton%2C%20Somerset%2C%20England%2C%20BA22%208HT%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Fleet%20Air%20Arm%20Museum%2C%20RNAS%20Yeovilton%2C%20Somerset%2C%20England%2C%20BA22%208HT%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 583
**File:** `content/daytrip/eu/gb/fleet-air-arm-museum.md`

Please review this venue submission and edit the content as needed before merging.