### PR TITLE
New: The Museum Of Berkshire Aviation from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/the-museum-of-berkshire-aviation.md
+++ b/content/daytrip/eu/gb/the-museum-of-berkshire-aviation.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/the-museum-of-berkshire-aviation"
+date: "2025-06-23T01:39:53.877Z"
+poster: "AndiBing"
+lat: "51.450439"
+lng: "-0.882847"
+location: "The Museum Of Berkshire Aviation, Woodley, Berkshire, England, RG5 4UE, United Kingdom"
+title: "The Museum Of Berkshire Aviation"
+external_url: https://museumofberkshireaviation.co.uk/
+---
+The museum shows Berkshire's contribution to aviation history.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Museum Of Berkshire Aviation
**Location:** The Museum Of Berkshire Aviation, Woodley, Berkshire, England, RG5 4UE, United Kingdom
**Submitted by:** AndiBing
**Website:** https://museumofberkshireaviation.co.uk/

### Description
The museum shows Berkshire's contribution to aviation history.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=The%20Museum%20Of%20Berkshire%20Aviation%2C%20Woodley%2C%20Berkshire%2C%20England%2C%20RG5%204UE%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=The%20Museum%20Of%20Berkshire%20Aviation%2C%20Woodley%2C%20Berkshire%2C%20England%2C%20RG5%204UE%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 586
**File:** `content/daytrip/eu/gb/the-museum-of-berkshire-aviation.md`

Please review this venue submission and edit the content as needed before merging.