### PR TITLE
New: Manifold Valley Visitor Centre from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/manifold-valley-visitor-centre.md
+++ b/content/daytrip/eu/gb/manifold-valley-visitor-centre.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/manifold-valley-visitor-centre"
+date: "2025-06-23T03:20:00.957Z"
+poster: "AndiBing"
+lat: "53.131015"
+lng: "-1.846972"
+location: "Manifold Valley Visitor Centre, Hulme End, Staffordshire, England, SK17 0EZ, United Kingdom"
+title: "Manifold Valley Visitor Centre"
+external_url: https://www.peakdistrict.gov.uk/visiting/places-to-visit/trails/manifold
+---
+Visitor centre at one end of the Manifold Way.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Manifold Valley Visitor Centre
**Location:** Manifold Valley Visitor Centre, Hulme End, Staffordshire, England, SK17 0EZ, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.peakdistrict.gov.uk/visiting/places-to-visit/trails/manifold

### Description
Visitor centre at one end of the Manifold Way.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Manifold%20Valley%20Visitor%20Centre%2C%20Hulme%20End%2C%20Staffordshire%2C%20England%2C%20SK17%200EZ%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Manifold%20Valley%20Visitor%20Centre%2C%20Hulme%20End%2C%20Staffordshire%2C%20England%2C%20SK17%200EZ%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 588
**File:** `content/daytrip/eu/gb/manifold-valley-visitor-centre.md`

Please review this venue submission and edit the content as needed before merging.