### PR TITLE
New: Bourne Wood from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/bourne-wood.md
+++ b/content/daytrip/eu/gb/bourne-wood.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/bourne-wood"
+date: "2025-06-23T03:20:03.568Z"
+poster: "AndiBing"
+lat: "51.187416"
+lng: "-0.772042"
+location: "Bourne Wood, Frensham, Surrey, England, GU10 3BU, United Kingdom"
+title: "Bourne Wood"
+external_url: https://www.forestryengland.uk/bourne-wood-farnham
+---
+Beautiful location for a walk in this ancient woodland. If the surroundings look familiar, it is because Bourne Wood has starred in many films and television programmes.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Bourne Wood
**Location:** Bourne Wood, Frensham, Surrey, England, GU10 3BU, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.forestryengland.uk/bourne-wood-farnham

### Description
Beautiful location for a walk in this ancient woodland. If the surroundings look familiar, it is because Bourne Wood has starred in many films and television programmes.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Bourne%20Wood%2C%20Frensham%2C%20Surrey%2C%20England%2C%20GU10%203BU%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Bourne%20Wood%2C%20Frensham%2C%20Surrey%2C%20England%2C%20GU10%203BU%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 589
**File:** `content/daytrip/eu/gb/bourne-wood.md`

Please review this venue submission and edit the content as needed before merging.