### PR TITLE
New: Orkney Wireless Museum from JohnH

### DIFF
--- a/content/daytrip/eu/gb/orkney-wireless-museum.md
+++ b/content/daytrip/eu/gb/orkney-wireless-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/orkney-wireless-museum"
+date: "2025-06-23T09:42:27.759Z"
+poster: "JohnH"
+lat: "58.984454"
+lng: "-2.960201"
+location: "Orkney Wireless Museum, 1, Junction Road, Kirkwall, Orkney Islands, Scotland, KW15 1LB, UK"
+title: "Orkney Wireless Museum"
+external_url: https://www.visitscotland.com/info/see-do/orkney-wireless-museum-p251621
+---
+spot your first radio set ...


### PR DESCRIPTION
## New Venue Submission

**Venue:** Orkney Wireless Museum
**Location:** Orkney Wireless Museum, 1, Junction Road, Kirkwall, Orkney Islands, Scotland, KW15 1LB, UK
**Submitted by:** JohnH
**Website:** https://www.visitscotland.com/info/see-do/orkney-wireless-museum-p251621

### Description
spot your first radio set ...

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Orkney%20Wireless%20Museum%2C%201%2C%20Junction%20Road%2C%20Kirkwall%2C%20Orkney%20Islands%2C%20Scotland%2C%20KW15%201LB%2C%20UK)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Orkney%20Wireless%20Museum%2C%201%2C%20Junction%20Road%2C%20Kirkwall%2C%20Orkney%20Islands%2C%20Scotland%2C%20KW15%201LB%2C%20UK)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 591
**File:** `content/daytrip/eu/gb/orkney-wireless-museum.md`

Please review this venue submission and edit the content as needed before merging.