### PR TITLE
New: Broom Bridge from Hugo

### DIFF
--- a/content/daytrip/eu/ie/broom-bridge.md
+++ b/content/daytrip/eu/ie/broom-bridge.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/eu/ie/broom-bridge"
+date: "2025-06-23T18:30:30.618Z"
+poster: "Hugo"
+lat: "53.37303"
+lng: "-6.299948"
+location: "Broombridge Road, Dublin, Republic of Ireland"
+title: "Broom Bridge"
+external_url: https://www.buildingsofireland.ie/buildings-search/building/50060126/broome-bridge-royal-canal-broombridge-road-ballyboggan-south-dublin-7-dublin-city
+---
+In 1843, the mathematician Alexander Hamilton was working on extending complex numbers from two to four dimensions. Going on a walk along the Royal Canal to clear his head, he had the core inspiration of how to make them work.
+
+Not having any paper to hand, he scratched the equations onto the side of Broom Bridge.
+
+The original equations are gone, but there remains a plaque on the bridge to commemorate Hamilton's inscription.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Broom Bridge
**Location:** Broombridge Road, Dublin, Republic of Ireland
**Submitted by:** Hugo
**Website:** https://www.buildingsofireland.ie/buildings-search/building/50060126/broome-bridge-royal-canal-broombridge-road-ballyboggan-south-dublin-7-dublin-city

### Description
In 1843, the mathematician Alexander Hamilton was working on extending complex numbers from two to four dimensions. Going on a walk along the Royal Canal to clear his head, he had the core inspiration of how to make them work.

Not having any paper to hand, he scratched the equations onto the side of Broom Bridge.

The original equations are gone, but there remains a plaque on the bridge to commemorate Hamilton's inscription.


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Broombridge%20Road%2C%20Dublin%2C%20Republic%20of%20Ireland)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Broombridge%20Road%2C%20Dublin%2C%20Republic%20of%20Ireland)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 598
**File:** `content/daytrip/eu/ie/broom-bridge.md`

Please review this venue submission and edit the content as needed before merging.