### PR TITLE
New: Samuel Cody Statue from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/samuel-cody-statue.md
+++ b/content/daytrip/eu/gb/samuel-cody-statue.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/samuel-cody-statue"
+date: "2025-06-23T22:25:47.436Z"
+poster: "AndiBing"
+lat: "51.282755"
+lng: "-0.753098"
+location: "Samuel Cody Statue, RAE Road, Farnborough, Hampshire, England, GU14 6TF, United Kingdom"
+title: "Samuel Cody Statue"
+external_url: https://www.bbc.co.uk/news/uk-england-hampshire-23591409
+---
+Statue to [Samuel Franklin Cody](https://en.wikipedia.org/wiki/Samuel_Franklin_Cody), who was the first person in the UK to pilot a powered, controlled and sustained flight. His flight was in October 1908 and lasted 30 seconds.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Samuel Cody Statue
**Location:** Samuel Cody Statue, RAE Road, Farnborough, Hampshire, England, GU14 6TF, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.bbc.co.uk/news/uk-england-hampshire-23591409

### Description
Statue to [Samuel Franklin Cody](https://en.wikipedia.org/wiki/Samuel_Franklin_Cody), who was the first person in the UK to pilot a powered, controlled and sustained flight. His flight was in October 1908 and lasted 30 seconds.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Samuel%20Cody%20Statue%2C%20RAE%20Road%2C%20Farnborough%2C%20Hampshire%2C%20England%2C%20GU14%206TF%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Samuel%20Cody%20Statue%2C%20RAE%20Road%2C%20Farnborough%2C%20Hampshire%2C%20England%2C%20GU14%206TF%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 599
**File:** `content/daytrip/eu/gb/samuel-cody-statue.md`

Please review this venue submission and edit the content as needed before merging.