### PR TITLE
New: The Dock Museum from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/the-dock-museum.md
+++ b/content/daytrip/eu/gb/the-dock-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/the-dock-museum"
+date: "2025-06-23T23:04:02.072Z"
+poster: "AndiBing"
+lat: "54.111981"
+lng: "-3.240066"
+location: "The Dock Museum, Barrow-in-Furness, Westmorland and Furness, England, LA14 2PW, United Kingdom"
+title: "The Dock Museum"
+external_url: https://dockmuseum.org.uk/
+---
+The museum contains galleries exploring the history of the people and industries of the Barrow-in-Furness area.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Dock Museum
**Location:** The Dock Museum, Barrow-in-Furness, Westmorland and Furness, England, LA14 2PW, United Kingdom
**Submitted by:** AndiBing
**Website:** https://dockmuseum.org.uk/

### Description
The museum contains galleries exploring the history of the people and industries of the Barrow-in-Furness area.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=The%20Dock%20Museum%2C%20Barrow-in-Furness%2C%20Westmorland%20and%20Furness%2C%20England%2C%20LA14%202PW%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=The%20Dock%20Museum%2C%20Barrow-in-Furness%2C%20Westmorland%20and%20Furness%2C%20England%2C%20LA14%202PW%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 600
**File:** `content/daytrip/eu/gb/the-dock-museum.md`

Please review this venue submission and edit the content as needed before merging.