### PR TITLE
New: Lakeside and Haverthwaite Railway from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/lakeside-and-haverthwaite-railway.md
+++ b/content/daytrip/eu/gb/lakeside-and-haverthwaite-railway.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/lakeside-and-haverthwaite-railway"
+date: "2025-06-23T23:04:04.673Z"
+poster: "AndiBing"
+lat: "54.24978"
+lng: "-2.999532"
+location: "Lakeside and Haverthwaite Railway, Haverthwaite, Cumbria, England, LA12 8AL, United Kingdom"
+title: "Lakeside and Haverthwaite Railway"
+external_url: https://www.lakesiderailway.co.uk/
+---
+Take a steam-hauled train from Haverthwaite to Lakeside.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Lakeside and Haverthwaite Railway
**Location:** Lakeside and Haverthwaite Railway, Haverthwaite, Cumbria, England, LA12 8AL, United Kingdom
**Submitted by:** AndiBing
**Website:** https://www.lakesiderailway.co.uk/

### Description
Take a steam-hauled train from Haverthwaite to Lakeside.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Lakeside%20and%20Haverthwaite%20Railway%2C%20Haverthwaite%2C%20Cumbria%2C%20England%2C%20LA12%208AL%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Lakeside%20and%20Haverthwaite%20Railway%2C%20Haverthwaite%2C%20Cumbria%2C%20England%2C%20LA12%208AL%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 601
**File:** `content/daytrip/eu/gb/lakeside-and-haverthwaite-railway.md`

Please review this venue submission and edit the content as needed before merging.