### PR TITLE
New: Didcot Railway Centre from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/didcot-railway-centre.md
+++ b/content/daytrip/eu/gb/didcot-railway-centre.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/didcot-railway-centre"
+date: "2025-06-24T02:43:16.841Z"
+poster: "AndiBing"
+lat: "51.614349"
+lng: "-1.24519"
+location: "Didcot Railway Centre,  Didcot, Oxfordshire, England, OX11 7GF, United Kingdom"
+title: "Didcot Railway Centre"
+external_url: https://didcotrailwaycentre.org.uk/
+---
+Museum covering 200 years of railway history.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Didcot Railway Centre
**Location:** Didcot Railway Centre,  Didcot, Oxfordshire, England, OX11 7GF, United Kingdom
**Submitted by:** AndiBing
**Website:** https://didcotrailwaycentre.org.uk/

### Description
Museum covering 200 years of railway history.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Didcot%20Railway%20Centre%2C%20%20Didcot%2C%20Oxfordshire%2C%20England%2C%20OX11%207GF%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Didcot%20Railway%20Centre%2C%20%20Didcot%2C%20Oxfordshire%2C%20England%2C%20OX11%207GF%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 603
**File:** `content/daytrip/eu/gb/didcot-railway-centre.md`

Please review this venue submission and edit the content as needed before merging.