### PR TITLE
New: The Ruskin Museum from AndiBing

### DIFF
--- a/content/daytrip/eu/gb/the-ruskin-museum.md
+++ b/content/daytrip/eu/gb/the-ruskin-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/the-ruskin-museum"
+date: "2025-06-24T02:43:19.428Z"
+poster: "AndiBing"
+lat: "54.370256"
+lng: "-3.07615"
+location: "The Ruskin Museum, Coniston, Cumbria, England, LA21 8DU, United Kingdom"
+title: "The Ruskin Museum"
+external_url: https://ruskinmuseum.com/
+---
+The museum tells the story of Coniston over the last 100 years. Of particular interest is the story of Donald Campbell's speed records and Bluebird K7.


### PR DESCRIPTION
## New Venue Submission

**Venue:** The Ruskin Museum
**Location:** The Ruskin Museum, Coniston, Cumbria, England, LA21 8DU, United Kingdom
**Submitted by:** AndiBing
**Website:** https://ruskinmuseum.com/

### Description
The museum tells the story of Coniston over the last 100 years. Of particular interest is the story of Donald Campbell's speed records and Bluebird K7.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=The%20Ruskin%20Museum%2C%20Coniston%2C%20Cumbria%2C%20England%2C%20LA21%208DU%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=The%20Ruskin%20Museum%2C%20Coniston%2C%20Cumbria%2C%20England%2C%20LA21%208DU%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 604
**File:** `content/daytrip/eu/gb/the-ruskin-museum.md`

Please review this venue submission and edit the content as needed before merging.