### PR TITLE
New: Reading Museum from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/reading-museum.md
+++ b/content/daytrip/eu/gb/reading-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/reading-museum"
+date: "2025-06-24T15:26:35.837Z"
+poster: "Stuart Ward"
+lat: "51.457147"
+lng: "-0.969827"
+location: "Reading Museum, Valpy Street, Coley, Reading, England, RG1 1QH, United Kingdom"
+title: "Reading Museum"
+external_url: https://www.readingmuseum.org.uk/digital60
+---
+Reading Museum is celebrating 60 years since Digital Equipment Corporation (DEC) established it's European headquarters in Reading. The Digital Revolution charts the role of Reading in the development of Technology.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Reading Museum
**Location:** Reading Museum, Valpy Street, Coley, Reading, England, RG1 1QH, United Kingdom
**Submitted by:** Stuart Ward
**Website:** https://www.readingmuseum.org.uk/digital60

### Description
Reading Museum is celebrating 60 years since Digital Equipment Corporation (DEC) established it's European headquarters in Reading. The Digital Revolution charts the role of Reading in the development of Technology.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Reading%20Museum%2C%20Valpy%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%201QH%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Reading%20Museum%2C%20Valpy%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%201QH%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 605
**File:** `content/daytrip/eu/gb/reading-museum.md`

Please review this venue submission and edit the content as needed before merging.