### PR TITLE
New: Reading Hydro from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/reading-hydro.md
+++ b/content/daytrip/eu/gb/reading-hydro.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/reading-hydro"
+date: "2025-06-24T15:26:49.638Z"
+poster: "Stuart Ward"
+lat: "51.461584"
+lng: "-0.964603"
+location: "Caversham Weir, Reading"
+title: "Reading Hydro"
+external_url: https://readinghydro.org
+---
+Reading Hydro is a Archimedes Screw turbine, generating power from the Thames. It was built by the local community with crowdfunding and is now operated by volunteers. If you would like a tour please email visit@readinghydro.org


### PR DESCRIPTION
## New Venue Submission

**Venue:** Reading Hydro
**Location:** Caversham Weir, Reading
**Submitted by:** Stuart Ward
**Website:** https://readinghydro.org

### Description
Reading Hydro is a Archimedes Screw turbine, generating power from the Thames. It was built by the local community with crowdfunding and is now operated by volunteers. If you would like a tour please email visit@readinghydro.org

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Caversham%20Weir%2C%20Reading)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Caversham%20Weir%2C%20Reading)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 606
**File:** `content/daytrip/eu/gb/reading-hydro.md`

Please review this venue submission and edit the content as needed before merging.