### PR TITLE
New: Green Park Wind Turbine from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/green-park-wind-turbine.md
+++ b/content/daytrip/eu/gb/green-park-wind-turbine.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/green-park-wind-turbine"
+date: "2025-06-24T15:27:04.669Z"
+poster: "Stuart Ward"
+lat: "51.418687"
+lng: "-0.985594"
+location: "South Oak Way, Green Park, Reading"
+title: "Green Park Wind Turbine"
+external_url: https://www.ecotricity.co.uk/our-green-energy/green-electricity
+---
+Visible to anyone passing through Reading on the M4, the town’s first windmill was built in 2005 under our Merchant Wind Power scheme to provide energy for the office buildings at Green Park. Bringing wind power into urban areas people can witness for themselves how clean, quiet and efficient it is.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Green Park Wind Turbine
**Location:** South Oak Way, Green Park, Reading
**Submitted by:** Stuart Ward
**Website:** https://www.ecotricity.co.uk/our-green-energy/green-electricity

### Description
Visible to anyone passing through Reading on the M4, the town’s first windmill was built in 2005 under our Merchant Wind Power scheme to provide energy for the office buildings at Green Park. Bringing wind power into urban areas people can witness for themselves how clean, quiet and efficient it is.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=South%20Oak%20Way%2C%20Green%20Park%2C%20Reading)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=South%20Oak%20Way%2C%20Green%20Park%2C%20Reading)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 607
**File:** `content/daytrip/eu/gb/green-park-wind-turbine.md`

Please review this venue submission and edit the content as needed before merging.