### PR TITLE
New: rLab - Reading Hackspace from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/rlab-reading-hackspace.md
+++ b/content/daytrip/eu/gb/rlab-reading-hackspace.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/rlab-reading-hackspace"
+date: "2025-06-24T15:27:14.727Z"
+poster: "Stuart Ward"
+lat: "51.457685"
+lng: "-0.979932"
+location: "rLab - Reading Hackspace, Weldale Street, Coley, Reading, England, RG1 7PF, United Kingdom"
+title: "rLab - Reading Hackspace"
+external_url: https://rlab.org.uk
+---
+For makers, menders, re-purposers, creators, sharers and teachers. Come join our group workshop with amazing equipment and members to match.


### PR DESCRIPTION
## New Venue Submission

**Venue:** rLab - Reading Hackspace
**Location:** rLab - Reading Hackspace, Weldale Street, Coley, Reading, England, RG1 7PF, United Kingdom
**Submitted by:** Stuart Ward
**Website:** https://rlab.org.uk

### Description
For makers, menders, re-purposers, creators, sharers and teachers. Come join our group workshop with amazing equipment and members to match.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=rLab%20-%20Reading%20Hackspace%2C%20Weldale%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%207PF%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=rLab%20-%20Reading%20Hackspace%2C%20Weldale%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%207PF%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 608
**File:** `content/daytrip/eu/gb/rlab-reading-hackspace.md`

Please review this venue submission and edit the content as needed before merging.