### PR TITLE
New: Reading Bicycle Kitchen from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/reading-bicycle-kitchen.md
+++ b/content/daytrip/eu/gb/reading-bicycle-kitchen.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/reading-bicycle-kitchen"
+date: "2025-06-24T15:27:34.605Z"
+poster: "Stuart Ward"
+lat: "51.457497"
+lng: "-0.97965"
+location: "Reading Bicycle Kitchen, C10, Weldale Street, Coley, Reading, England, RG1 7PF, United Kingdom"
+title: "Reading Bicycle Kitchen"
+external_url: https://www.readingbicyclekitchen.org/
+---
+Reading Bike Kitchen is a not-for-profit community project run entirely by volunteers. Founded in 2014, our mission is to support the local community by ensuring that cycling is accessible to all. We achieve this by providing low-cost bike repairs, bike refurbishing & rehoming, bike donations to local causes and free bike maintenance courses. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Reading Bicycle Kitchen
**Location:** Reading Bicycle Kitchen, C10, Weldale Street, Coley, Reading, England, RG1 7PF, United Kingdom
**Submitted by:** Stuart Ward
**Website:** https://www.readingbicyclekitchen.org/

### Description
Reading Bike Kitchen is a not-for-profit community project run entirely by volunteers. Founded in 2014, our mission is to support the local community by ensuring that cycling is accessible to all. We achieve this by providing low-cost bike repairs, bike refurbishing & rehoming, bike donations to local causes and free bike maintenance courses. 


### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Reading%20Bicycle%20Kitchen%2C%20C10%2C%20Weldale%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%207PF%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Reading%20Bicycle%20Kitchen%2C%20C10%2C%20Weldale%20Street%2C%20Coley%2C%20Reading%2C%20England%2C%20RG1%207PF%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 609
**File:** `content/daytrip/eu/gb/reading-bicycle-kitchen.md`

Please review this venue submission and edit the content as needed before merging.