### PR TITLE
New: Region 6 War Room from Stuart Ward

### DIFF
--- a/content/daytrip/eu/gb/region-6-war-room.md
+++ b/content/daytrip/eu/gb/region-6-war-room.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/eu/gb/region-6-war-room"
+date: "2025-06-24T15:28:42.017Z"
+poster: "Stuart Ward"
+lat: "51.438981"
+lng: "-0.934515"
+location: "Region 6 War Room, Earley Gate, Lower Earley, Earley, Borough of Wokingham, England, RG6 6BU, United Kingdom"
+title: "Region 6 War Room"
+external_url: https://en.wikipedia.org/wiki/Region_6_War_Room
+---
+WW2 Era bunker. Now disused, but protected as a grade II listed building. It would have been used by the Regional Commissioner and staff in the event of nuclear attack. 


### PR DESCRIPTION
## New Venue Submission

**Venue:** Region 6 War Room
**Location:** Region 6 War Room, Earley Gate, Lower Earley, Earley, Borough of Wokingham, England, RG6 6BU, United Kingdom
**Submitted by:** Stuart Ward
**Website:** https://en.wikipedia.org/wiki/Region_6_War_Room

### Description
WW2 Era bunker. Now disused, but protected as a grade II listed building. It would have been used by the Regional Commissioner and staff in the event of nuclear attack. 

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Region%206%20War%20Room%2C%20Earley%20Gate%2C%20Lower%20Earley%2C%20Earley%2C%20Borough%20of%20Wokingham%2C%20England%2C%20RG6%206BU%2C%20United%20Kingdom)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Region%206%20War%20Room%2C%20Earley%20Gate%2C%20Lower%20Earley%2C%20Earley%2C%20Borough%20of%20Wokingham%2C%20England%2C%20RG6%206BU%2C%20United%20Kingdom)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 610
**File:** `content/daytrip/eu/gb/region-6-war-room.md`

Please review this venue submission and edit the content as needed before merging.