### PR TITLE
New: Fire Services Museum from @joe@aus.social

### DIFF
--- a/content/daytrip/oc/au/fire-services-museum.md
+++ b/content/daytrip/oc/au/fire-services-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/oc/au/fire-services-museum"
+date: "2025-06-24T15:31:44.034Z"
+poster: "@joe@aus.social"
+lat: "-37.808597"
+lng: "144.975452"
+location: "Fire Services Museum, 39, Gisborne Street, East Melbourne, Melbourne, City of Melbourne, Victoria, 3002, Australia"
+title: "Fire Services Museum"
+external_url: https://www.fsmv.net.au/
+---
+The museum has a very extensive collection of firefighting memorabilia, equipment and appliances, and is housed in the original Melbourne Fire Brigade HQ.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Fire Services Museum
**Location:** Fire Services Museum, 39, Gisborne Street, East Melbourne, Melbourne, City of Melbourne, Victoria, 3002, Australia
**Submitted by:** @joe@aus.social
**Website:** https://www.fsmv.net.au/

### Description
The museum has a very extensive collection of firefighting memorabilia, equipment and appliances, and is housed in the original Melbourne Fire Brigade HQ.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Fire%20Services%20Museum%2C%2039%2C%20Gisborne%20Street%2C%20East%20Melbourne%2C%20Melbourne%2C%20City%20of%20Melbourne%2C%20Victoria%2C%203002%2C%20Australia)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Fire%20Services%20Museum%2C%2039%2C%20Gisborne%20Street%2C%20East%20Melbourne%2C%20Melbourne%2C%20City%20of%20Melbourne%2C%20Victoria%2C%203002%2C%20Australia)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 611
**File:** `content/daytrip/oc/au/fire-services-museum.md`

Please review this venue submission and edit the content as needed before merging.