### PR TITLE
New: Calleva Atrebatum from Hugo

### DIFF
--- a/content/daytrip/eu/gb/calleva-atrebatum.md
+++ b/content/daytrip/eu/gb/calleva-atrebatum.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/calleva-atrebatum"
+date: "2025-06-24T17:25:59.149Z"
+poster: "Hugo"
+lat: "51.357391"
+lng: "-1.0824"
+location: "Silchester, Hampshire, RG7 2HP"
+title: "Calleva Atrebatum"
+external_url: https://www.english-heritage.org.uk/visit/places/silchester-roman-city-walls-and-amphitheatre/
+---
+An Iron-age and Roman town, uninhabited since the seventh century CE. Little remains now, except for the (well-preserved) walls and the amphitheatre on the east side of the town.
+
+A decade-long series of excavations were recently made by the University of Reading Archaeology Department, and they have a website all about [the history of the town, and their findings](https://research.reading.ac.uk/silchester/)


### PR DESCRIPTION
## New Venue Submission

**Venue:** Calleva Atrebatum
**Location:** Silchester, Hampshire, RG7 2HP
**Submitted by:** Hugo
**Website:** https://www.english-heritage.org.uk/visit/places/silchester-roman-city-walls-and-amphitheatre/

### Description
An Iron-age and Roman town, uninhabited since the seventh century CE. Little remains now, except for the (well-preserved) walls and the amphitheatre on the east side of the town.

A decade-long series of excavations were recently made by the University of Reading Archaeology Department, and they have a website all about [the history of the town, and their findings](https://research.reading.ac.uk/silchester/)

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Silchester%2C%20Hampshire%2C%20RG7%202HP)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Silchester%2C%20Hampshire%2C%20RG7%202HP)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 614
**File:** `content/daytrip/eu/gb/calleva-atrebatum.md`

Please review this venue submission and edit the content as needed before merging.