### PR TITLE
New: Early Television Museum from MikeP

### DIFF
--- a/content/daytrip/na/us/early-television-museum.md
+++ b/content/daytrip/na/us/early-television-museum.md
@@ -1,0 +1,11 @@
+---
+slug: "daytrip/na/us/early-television-museum"
+date: "2025-06-24T21:36:02.636Z"
+poster: "MikeP"
+lat: "40.034548"
+lng: "-83.161676"
+location: "Early Television Museum, Franklin Street, Hilliard, Franklin County, Ohio, 43026, United States"
+title: "Early Television Museum"
+external_url: https://www.earlytelevision.org/
+---
+The Early Television Foundation is dedicated to the preservation of the technology from the early days of television. Our mission is to preserve and make available to the public the history of early television, from the mechanical systems of the 1920s through the introduction of color television in the 1950s.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Early Television Museum
**Location:** Early Television Museum, Franklin Street, Hilliard, Franklin County, Ohio, 43026, United States
**Submitted by:** MikeP
**Website:** https://www.earlytelevision.org/

### Description
The Early Television Foundation is dedicated to the preservation of the technology from the early days of television. Our mission is to preserve and make available to the public the history of early television, from the mechanical systems of the 1920s through the introduction of color television in the 1950s.

### Review Checklist
- [x] Verify the venue information is accurate
- [x] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Early%20Television%20Museum%2C%20Franklin%20Street%2C%20Hilliard%2C%20Franklin%20County%2C%20Ohio%2C%2043026%2C%20United%20States)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Early%20Television%20Museum%2C%20Franklin%20Street%2C%20Hilliard%2C%20Franklin%20County%2C%20Ohio%2C%2043026%2C%20United%20States)
- [x] Ensure the description is appropriate and well-written
- [x] Confirm the external website link works
- [x] Review the generated slug and front matter

**Submission ID:** 618
**File:** `content/daytrip/na/us/early-television-museum.md`

Please review this venue submission and edit the content as needed before merging.