### PR TITLE
New: ZigZag Steam and Rail Motor Railway from popey

### DIFF
--- a/content/daytrip/oc/au/zigzag-steam-and-rail-motor-railway.md
+++ b/content/daytrip/oc/au/zigzag-steam-and-rail-motor-railway.md
@@ -1,0 +1,15 @@
+---
+slug: "daytrip/oc/au/zigzag-steam-and-rail-motor-railway"
+date: "2025-06-24T22:03:09.490Z"
+poster: "popey"
+lat: "-33.477362"
+lng: "150.221397"
+location: "Chifley Road, Clarence, Lithgow City Council, New South Wales, 2790, Australia"
+title: "ZigZag Steam and Rail Motor Railway"
+external_url: https://zigzagrailway.com.au/
+---
+The Great Lithgow Zig Zag first opened in 1869 as part of the Western Railway line that linked Sydney with Western New South Wales. This railway line was used to transport people and produce from the western plains of NSW to and from Sydney.
+
+In 1910, a ten tunnel deviation was completed and the Great Lithgow Zig Zag closed and the original formation was declared as a reserve by the Crown. 60 something years later, Zig Zag Railway was born.
+
+Many will remember Zig Zag Railway from their childhood – riding the train in the 70s, 80s or 90s. Come and relive the magic of steam trains and admire how much it has changed (and hasn’t) since you last came aboard.


### PR DESCRIPTION
## New Venue Submission

**Venue:** ZigZag Steam and Rail Motor Railway
**Location:** Chifley Road, Clarence, Lithgow City Council, New South Wales, 2790, Australia
**Submitted by:** popey
**Website:** https://zigzagrailway.com.au/

### Description
The Great Lithgow Zig Zag first opened in 1869 as part of the Western Railway line that linked Sydney with Western New South Wales. This railway line was used to transport people and produce from the western plains of NSW to and from Sydney.

In 1910, a ten tunnel deviation was completed and the Great Lithgow Zig Zag closed and the original formation was declared as a reserve by the Crown. 60 something years later, Zig Zag Railway was born.

Many will remember Zig Zag Railway from their childhood – riding the train in the 70s, 80s or 90s. Come and relive the magic of steam trains and admire how much it has changed (and hasn’t) since you last came aboard.

### Review Checklist
- [ ] Verify the venue information is accurate
- [ ] Check that the location coordinates are correct
  - Google Maps link: [Search on Google Maps](https://www.google.com/maps/search/?api=1&query=Chifley%20Road%2C%20Clarence%2C%20Lithgow%20City%20Council%2C%20New%20South%20Wales%2C%202790%2C%20Australia)
  - OpenStreetMap link: [Search on OpenStreetMap](https://www.openstreetmap.org/search?query=Chifley%20Road%2C%20Clarence%2C%20Lithgow%20City%20Council%2C%20New%20South%20Wales%2C%202790%2C%20Australia)
- [ ] Ensure the description is appropriate and well-written
- [ ] Confirm the external website link works
- [ ] Review the generated slug and front matter

**Submission ID:** 619
**File:** `content/daytrip/oc/au/zigzag-steam-and-rail-motor-railway.md`

Please review this venue submission and edit the content as needed before merging.