### PR TITLE
add bounce to horizontal scroll

### DIFF
--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -91,7 +91,13 @@ async function loadMarkers(L, map) {
 }
 
 // initialize Leaflet
-var map = L.map('map').setView({lon: 0, lat: 0}, 2);
+var map = L.map('map', {
+    maxBounds: [
+        [-85, -180],
+        [85, 180]
+    ],
+    maxBoundsViscosity: 0.5 // Gentle bounce at the edge
+}).setView({lon: 0, lat: 0}, 2);
 
 // add the OpenStreetMap tiles
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
Fixes a bug where users with too much time on their hands can scroll off the side of the map and end up in purgatory.