### PR TITLE
Fix bluesky opengraph loading

### DIFF
--- a/themes/ndt2/layouts/partials/opengraph.html
+++ b/themes/ndt2/layouts/partials/opengraph.html
@@ -54,7 +54,7 @@
 
       {{ $processedImg := $img.Process (printf "png %s" $imageName) }}
       {{/* warnf "Processed image: %s for %s" $processedImg.Permalink $truncatedTitle */}}
-      <meta property="og:image" content="{{ $processedImg.Permalink | relURL }}" />
+      <meta property="og:image" content="{{ $processedImg.Permalink | absURL }}" />
       <meta property="og:image:width" content="{{ $processedImg.Width }}" />
       <meta property="og:image:height" content="{{ $processedImg.Height }}" />
       


### PR DESCRIPTION
The bluesky opengraph scraper appears to require absolute urls rather than relative ones.