### PR TITLE
Fix: jumptoslug broke - encoding issues

### DIFF
--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -82,7 +82,7 @@ async function loadMarkers(L, map) {
                 allMarkers.push(marker); // Store marker reference
                 
                 //console.log({jumpToSlug, p: v.permalink, eq: jumpToSlug == v.permalink})
-                if (jumpToSlug && jumpToSlug == v.permalink) {
+                if (jumpToSlug && decodeURIComponent(v.permalink) == jumpToSlug) {
                     //console.log("Fly, my pretties")
                     map.flyTo([v.lat, v.lng], 19);
                 }


### PR DESCRIPTION
I think this fixes the "show on map" that venue pages have.