### PR TITLE
Improve venue and 'you are here' popups

### DIFF
--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -474,8 +474,8 @@ html, body {
 
 #map .leaflet-popup-content { 
   color: #222; 
-  width: 400px;
-  height: 200px;
+  width: auto;
+  height: auto;
   line-height: 1.4;
   font-weight: normal;
   font-size: 1em; 
@@ -495,6 +495,13 @@ html, body {
 
 #map .leaflet-popup-content .popup-poster { 
   font-size: 1.8em; 
+  font-weight: normal;
+  color: #000000;
+  font-style: italic;
+}
+
+#map .leaflet-popup-content .you-header { 
+  font-size: 3.0em; 
   font-weight: normal;
   color: #000000;
   font-style: italic;
@@ -730,6 +737,7 @@ main#content:has(> article) {
 }
 
 .user-location-icon {
+  font-size: 5em;
   background: none;
   border: none;
   display: flex;

--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -739,6 +739,7 @@ main#content:has(> article) {
 }
 
 .user-location-icon {
+  font-size: 5em;
   background: none;
   border: none;
   display: flex;

--- a/themes/ndt2/assets/css/main.css
+++ b/themes/ndt2/assets/css/main.css
@@ -476,6 +476,8 @@ html, body {
   color: #222; 
   width: auto;
   height: auto;
+  max-width: 90vw; /* Prevent overly wide popups */
+  max-height: 80vh; /* Prevent overly tall popups */
   line-height: 1.4;
   font-weight: normal;
   font-size: 1em; 
@@ -487,7 +489,7 @@ html, body {
   color: #02b1ec;
 }
 
-#map .leaflet-popup-content .popup-location { 
+#map .leaflet-popup-content .popup-description { 
   font-size: 2em; 
   font-weight: normal;
   color: #000000;
@@ -737,7 +739,6 @@ main#content:has(> article) {
 }
 
 .user-location-icon {
-  font-size: 5em;
   background: none;
   border: none;
   display: flex;

--- a/themes/ndt2/layouts/_default/item.json.json
+++ b/themes/ndt2/layouts/_default/item.json.json
@@ -1,10 +1,10 @@
 {
     "name": "{{ .Title | htmlEscape }}",
-    "permalink": "{{ .RelPermalink }}",
-    "lat": "{{ .Params.lat }}",
-    "lng": "{{ .Params.lng }}"{{ if .Params.poster }},
-    "poster": "{{ .Params.poster }}"{{ end }}{{ if .Params.location }},
-    "location": "{{ .Params.location }}"{{ end }}{{ if .Params.external_url }},
-    "external_url": "{{ .Params.external_url }}"{{ end }}{{ if .Content }},
-    "description": {{ .Content | plainify | truncate 200 | replaceRE "\n" " " | chomp | jsonify }}{{ end }}
+    "permalink": {{ .RelPermalink | jsonify}},
+    "lat": {{ .Params.lat | jsonify}},
+    "lng": {{ .Params.lng | jsonify}},
+    "poster": {{ if .Params.poster }}{{ .Params.poster | jsonify }}{{ else}}""{{ end }},
+    "location": {{ if .Params.location }}{{ .Params.location | jsonify }}{{ else}}""{{ end }},
+    "external_url": {{ if .Params.external_url }}{{ .Params.external_url | jsonify }}{{ else}}""{{ end }},
+    "description": {{ if .Content }}{{ .Content | plainify | truncate 200 | replaceRE "\n" " " | chomp | jsonify }}{{ else}}""{{ end }}
 }

--- a/themes/ndt2/layouts/_default/item.json.json
+++ b/themes/ndt2/layouts/_default/item.json.json
@@ -6,5 +6,5 @@
     "poster": "{{ .Params.poster }}"{{ end }}{{ if .Params.location }},
     "location": "{{ .Params.location }}"{{ end }}{{ if .Params.external_url }},
     "external_url": "{{ .Params.external_url }}"{{ end }}{{ if .Content }},
-    "description": "{{ .Content | plainify | truncate 200 | replaceRE "\n" " " | chomp }}"{{ end }}
+    "description": {{ .Content | plainify | truncate 200 | replaceRE "\n" " " | chomp | jsonify }}{{ end }}
 }

--- a/themes/ndt2/layouts/_default/item.json.json
+++ b/themes/ndt2/layouts/_default/item.json.json
@@ -5,5 +5,6 @@
     "lng": "{{ .Params.lng }}"{{ if .Params.poster }},
     "poster": "{{ .Params.poster }}"{{ end }}{{ if .Params.location }},
     "location": "{{ .Params.location }}"{{ end }}{{ if .Params.external_url }},
-    "external_url": "{{ .Params.external_url }}"{{ end }}
+    "external_url": "{{ .Params.external_url }}"{{ end }}{{ if .Content }},
+    "description": "{{ .Content | plainify | truncate 200 | replaceRE "\n" " " | chomp }}"{{ end }}
 }

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -69,8 +69,12 @@ async function loadMarkers(L, map) {
                     popupText += `&nbsp;&nbsp;<a href="${v.external_url}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>`;
                 }
                 // If the venue has a location, append it to the popup text
-                if (v.location) {
-                    popupText += `<br><div class="popup-location">${v.location}</div>`;
+                // if (v.location) {
+                //     popupText += `<br><div class="popup-location">${v.location}</div>`;
+                // }
+                // If the venue has a description, append it to the popup text
+                if (v.description) {
+                    popupText += `<br><div class="popup-location">${v.description}</div>`;
                 }
                 // If the venue has a poster, add it to the popup
                 if (v.poster) {
@@ -219,7 +223,7 @@ map.on('locationfound', function(e) {
         map.removeLayer(window._userLocationMarker);
     }
     window._userLocationMarker = L.marker(e.latlng, {icon: userLocationIcon}).addTo(map)
-        .bindPopup('You are here!').openPopup();
+        .bindPopup('<div class="you-header">You are here!</div>').openPopup();
     // Auto-close the popup after 3 seconds
     setTimeout(function() {
         if (window._userLocationMarker) {

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -211,7 +211,7 @@ map.on('locationfound', function(e) {
         className: 'user-location-icon',
         iconSize: [64, 64],
         iconAnchor: [20, 40],
-        popupAnchor: [0, -40]
+        popupAnchor: [10, -20]
     });
     
     // Add a marker at the user's location with the custom pin icon

--- a/themes/ndt2/layouts/index.html
+++ b/themes/ndt2/layouts/index.html
@@ -68,13 +68,9 @@ async function loadMarkers(L, map) {
                 if (v.external_url) {
                     popupText += `&nbsp;&nbsp;<a href="${v.external_url}" target="_blank" class="external-link" title="Website"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>`;
                 }
-                // If the venue has a location, append it to the popup text
-                // if (v.location) {
-                //     popupText += `<br><div class="popup-location">${v.location}</div>`;
-                // }
                 // If the venue has a description, append it to the popup text
                 if (v.description) {
-                    popupText += `<br><div class="popup-location">${v.description}</div>`;
+                    popupText += `<br><div class="popup-description">${v.description}</div>`;
                 }
                 // If the venue has a poster, add it to the popup
                 if (v.poster) {
@@ -213,7 +209,7 @@ map.on('locationfound', function(e) {
     const userLocationIcon = L.divIcon({
         html: '📍',
         className: 'user-location-icon',
-        iconSize: [40, 40],
+        iconSize: [64, 64],
         iconAnchor: [20, 40],
         popupAnchor: [0, -40]
     });


### PR DESCRIPTION
This PR:

* Auto-sizes poups to the content
* Removes the location (address) from the venue popup
* Adds first 200 chars of the venue description to the popup
* Makes the "you are here" location pin larger
* Makes the "You are here!" text in the popup larger

<img width="388" alt="Screenshot 2025-06-29 at 15 40 30" src="https://github.com/user-attachments/assets/f3c849f7-84e3-4bc8-8d02-87b5ca2963d3" />
<img width="388" alt="Screenshot 2025-06-29 at 15 41 27" src="https://github.com/user-attachments/assets/fd227735-acc7-4164-a8e8-4d0452845803" />
<img width="388" alt="Screenshot 2025-06-29 at 15 40 56" src="https://github.com/user-attachments/assets/ff9135aa-dc0a-4b4c-bb27-5db149045ee8" />

(I pressed the copilot review button by accident, but it's actually quite neat)