### PR TITLE
Tidy up entries where title duplicated in location

### DIFF
--- a/content/daytrip/eu/de/carl-zeiss-planetarium.md
+++ b/content/daytrip/eu/de/carl-zeiss-planetarium.md
@@ -4,7 +4,7 @@ date: '2025-06-11T15:37:00'
 lat: '48.783319999999996'
 lng: '9.18688'
 poster: "sebastian-xyz"
-location: "Carl-Zeiss-Planetarium, Willy-Brandt-Straße 25, Stuttgart, Baden-Württemberg, 70173, Deutschland"
+location: "Willy-Brandt-Straße 25, Stuttgart, Baden-Württemberg, 70173, Deutschland"
 title: Carl-Zeiss-Planetarium
 external_url: https://www.planetarium-stuttgart.de/site/Stuttgart-Planetarium/node/11933363/index.html
 ---

--- a/content/daytrip/eu/de/urwelt-hauff-museum.md
+++ b/content/daytrip/eu/de/urwelt-hauff-museum.md
@@ -4,7 +4,7 @@ date: '2025-06-12T10:37:00'
 lat: '48.63540'
 lng: '9.52812'
 poster: "sebastian-xyz"
-location: "Urwelt-Hauff Museum, Aichelberger Straße 90, Holzmaden, Baden-Württemberg, 73271, Deutschland"
+location: "Aichelberger Straße 90, Holzmaden, Baden-Württemberg, 73271, Deutschland"
 title: Urwelt-Hauff Museum
 external_url: https://www.urweltmuseum.de/english
 ---

--- a/content/daytrip/eu/dk/naturbornholm.md
+++ b/content/daytrip/eu/dk/naturbornholm.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/dk/naturbornholm"
 date: '2001-01-30T04:37:00'
 lat: '55.063979246566156'
 lng: '14.917272108154293'
-location: "NaturBornholm, Grønningen 30, 3720 Aakirkeby, Danmark"
+location: "Grønningen 30, 3720 Aakirkeby, Danmark"
 title: NaturBornholm
 external_url: https://naturbornholm.dk/da/
 ---

--- a/content/daytrip/eu/fi/suomenlinna.md
+++ b/content/daytrip/eu/fi/suomenlinna.md
@@ -3,8 +3,8 @@ slug: "daytrip/eu/fi/suomenlinna"
 date: '2001-01-30T04:37:00'
 lat: '60.14493247488122'
 lng: '24.98318142111816'
-location: "Suomenlinnan linnoitus, Suomenlinnan huoltotunneli, Suomenlinna, Eteläinen suurpiiri, Helsinki, Helsingin seutukunta, Uusimaa, Manner-Suomi, 00140, Suomi / Finland"
-title: Suomenlinna
+location: "Suomenlinnan huoltotunneli, Suomenlinna, Eteläinen suurpiiri, Helsinki, Helsingin seutukunta, Uusimaa, Manner-Suomi, 00140, Suomi / Finland"
+title: Suomenlinna Linnoitus (Fortress)
 external_url: https://suomenlinna.fi/en/
 ---
 

--- a/content/daytrip/eu/gb/dale-abbey.md
+++ b/content/daytrip/eu/gb/dale-abbey.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/dale-abbey"
 date: '2001-01-30T04:37:00'
 lat: '52.944280'
 lng: '-1.350412'
-location: "Dale Abbey, Erewash, Derbyshire, East Midlands, England, DE7 4PN, United Kingdom"
+location: "Erewash, Derbyshire, East Midlands, England, DE7 4PN, United Kingdom"
 external_url: https://www.daleabbey.org.uk/index.html
 title: Dale Abbey
 ---

--- a/content/daytrip/eu/gb/kisimul-castle.md
+++ b/content/daytrip/eu/gb/kisimul-castle.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/kisimul-castle"
 date: '2001-01-30T04:37:00'
 lat: 56.952102
 lng: -7.487365
-location: "Kisimul Castle, Castlebay, Isle of Barra, HS9 5UZ, United Kingdom"
+location: "Castlebay, Isle of Barra, HS9 5UZ, United Kingdom"
 external_url: https://www.historicenvironment.scot/visit-a-place/places/kisimul-castle/
 title: Kisimul Castle
 ---

--- a/content/daytrip/eu/gb/navan-centre-and-fort.md
+++ b/content/daytrip/eu/gb/navan-centre-and-fort.md
@@ -3,7 +3,7 @@ slug: "daytrip/eu/gb/navan-centre-and-fort"
 date: '2001-01-30T04:37:00'
 lat: '54.34403624985255'
 lng: '-6.701418382568363'
-location: "Navan Centre and Fort, A28, Armagh, County Armagh, Northern Ireland / Tuaisceart\
+location: "A28, Armagh, County Armagh, Northern Ireland / Tuaisceart\
   \ Éireann, BT60 3PD, United Kingdom"
 external_url: https://visitarmagh.com/places-to-explore/navan-centre-fort/
 title: Navan Centre and Fort

--- a/content/daytrip/eu/ie/derrynane-house.md
+++ b/content/daytrip/eu/ie/derrynane-house.md
@@ -3,10 +3,10 @@ slug: "daytrip/eu/ie/derrynane-house"
 date: '2001-01-30T04:37:00'
 lat: '51.76235379073393'
 lng: '-10.130654794616703'
-location: "Derrynane House / Teach Dhoire Fhionáin, Derrynane Beach Track, Darrynane\
+location: "Derrynane Beach Track, Darrynane\
   \ ED, Kenmare Municipal District, County Kerry, Munster, V93 DD83, Éire / Ireland"
 external_url: https://heritageireland.ie/places-to-visit/daniel-oconnell-house-derrynane-house/
-title: Derrynane House
+title: Derrynane House / Teach Dhoire Fhionáin
 ---
 
 

--- a/content/daytrip/na/ca/st-lawrence-market.md
+++ b/content/daytrip/na/ca/st-lawrence-market.md
@@ -3,10 +3,10 @@ slug: "daytrip/na/ca/st-lawrence-market"
 date: '2001-01-30T04:37:00'
 lat: '43.648759896563746'
 lng: '-79.3716820306015'
-location: "St. Lawrence Market South, 93-95, Front Street East, St Lawrence-East Bayfront-The\
+location: "93-95, Front Street East, St Lawrence-East Bayfront-The\
   \ Islands, Spadina—Fort York, Toronto, Golden Horseshoe, Ontario, M5E 1C3,\
   \ Canada"
-title: St. Lawrence Market
+title: St. Lawrence Market South
 ---
 
 

--- a/content/daytrip/na/mx/san-dionisio.md
+++ b/content/daytrip/na/mx/san-dionisio.md
@@ -3,7 +3,7 @@ slug: daytrip/na/mx/san-dionisio
 date: '2001-01-30T04:37:00'
 lat: 23.55867
 lng: -109.86533
-location: "San Dionisio, Municipio de Los Cabos, Baja California Sur, México"
+location: "Municipio de Los Cabos, Baja California Sur, México"
 external_url: https://www.escapadah.com/destinos/2023/9/25/san-dionisio-el-paraiso-natural-de-baja-california-sur-que-muy-pocos-conocen-13977.html
 title: San Dionisio
 ---

--- a/content/daytrip/sa/co/villa-de-leyva.md
+++ b/content/daytrip/sa/co/villa-de-leyva.md
@@ -3,7 +3,7 @@ slug: "daytrip/sa/co/villa-de-leyva"
 date: '2001-01-30T04:37:00'
 lat: 5.63373
 lng: -73.52358
-location: "Villa de Leyva, Ricaurte, Boyacá, 154001, Colombia"
+location: "Ricaurte, Boyacá, 154001, Colombia"
 title: Villa de Leyva
 ---
 


### PR DESCRIPTION
I found a bunch of entries where the `title` was also in the `location` field, which I think we decided is superfluous. So I cleaned them up.

