### PR TITLE
Cleanup 3/3: Add missing URLs

### DIFF
--- a/content/daytrip/na/us/blunk-space.md
+++ b/content/daytrip/na/us/blunk-space.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 38.066921
 lng: -122.804623
 location: 11101 CA-1, #105, Point Reyes Station, Marin County, California, 94956, United States
+external_url: https://www.blunkspace.com
 title: Blunk Space
 ---
 

--- a/content/daytrip/na/us/exploreum-science-center.md
+++ b/content/daytrip/na/us/exploreum-science-center.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 30.690040
 lng: -88.039868
 location: 65 Government St, Mobile, AL 36602, United States
+external_url: https://www.exploreum.com
 title: Exploreum Science Center
 ---
 

--- a/content/daytrip/na/us/goodsell-observatory.md
+++ b/content/daytrip/na/us/goodsell-observatory.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '44.461919452314326'
 lng: '-93.1523642931719'
 location: 1 North College Street, Northfield, Minnesota 55057, United States
+external_url: https://www.carleton.edu/goodsell/
 title: Goodsell Observatory
 ---
 

--- a/content/daytrip/na/us/juliette.md
+++ b/content/daytrip/na/us/juliette.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 33.106545
 lng: -83.798773
 location: Monroe County, Georgia, United States
+external_url: https://thewhistlestopcafe.com
 title: Juliette
 ---
 This town was the filming location for Fried Green Tomatoes at the Whistle Stop Cafe.

--- a/content/daytrip/na/us/lettuce-lake-park.md
+++ b/content/daytrip/na/us/lettuce-lake-park.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 28.07316
 lng: -82.37302
 location: 6920 East Fletcher Avenue, Tampa, FL 33637, United States
+external_url: https://hcfl.gov/locations/lettuce-lake-conservation-park
 title: Lettuce Lake Park
 ---
 

--- a/content/daytrip/na/us/merchant-square-antiques.md
+++ b/content/daytrip/na/us/merchant-square-antiques.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 33.331129
 lng: -111.840397
 location: 1509 N Arizona Ave, Chandler, Arizona 85225, United States
+external_url: https://merchantsquareantiques.com
 title: Merchant Square Antiques
 ---
 

--- a/content/daytrip/na/us/montgomery-county-historical-society.md
+++ b/content/daytrip/na/us/montgomery-county-historical-society.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 41.029853
 lng: -95.226606
 location: 2700 North 4th Street, Red Oak, Iowa 51566, United States
+external_url: https://hsmcpa.org
 title: Montgomery County Historical Society
 ---
 

--- a/content/daytrip/na/us/pearson-air-museum.md
+++ b/content/daytrip/na/us/pearson-air-museum.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '45.62408067478942'
 lng: '-122.65641969146423'
 location: 1115 East 5th Street, Vancouver, Washington 98661, United States
+external_url: https://www.nps.gov/fova/planyourvisit/pearsonairmuseum.htm
 title: Pearson Air Museum
 ---
 

--- a/content/daytrip/na/us/purgatory-chasm.md
+++ b/content/daytrip/na/us/purgatory-chasm.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 42.129310
 lng: -71.713826
 location: 198 Purgatory Rd., Sutton, Worcester County, Massachusetts 01590, United States
+external_url: https://www.mass.gov/locations/purgatory-chasm-state-reservation
 title: Purgatory Chasm
 ---
 

--- a/content/daytrip/na/us/ridgefield-wildlife-refuge-river-s-unit.md
+++ b/content/daytrip/na/us/ridgefield-wildlife-refuge-river-s-unit.md
@@ -6,7 +6,7 @@ poster: pberry2112
 date: '2012-05-01T06:19:00'
 lat: '45.807374101798764'
 lng: '-122.73382788123774'
-external_url: null
+external_url: https://www.fws.gov/refuge/ridgefield
 ---
 
 Portion of the refuge off limits to the public access except for a self-guided driving loop and seasonal trail.

--- a/content/daytrip/na/us/sedav-vaaki-museum.md
+++ b/content/daytrip/na/us/sedav-vaaki-museum.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: '33.4467510'
 lng: '-111.9847900'
 location: ​​4619 E. Washington St., Phoenix, Arizona 85034, United States
+external_url: https://www.phoenix.gov/administration/departments/sedav-vaaki.html
 title: S'edav Va'aki Museum
 ---
 

--- a/content/daytrip/na/us/smallest-park-in-the-world.md
+++ b/content/daytrip/na/us/smallest-park-in-the-world.md
@@ -6,7 +6,7 @@ poster: rainwriter
 date: '2012-09-01T06:37:00'
 lat: 45.516211
 lng: -122.673251
-external_url: null
+external_url: https://www.worldatlas.com/articles/mill-ends-park-the-mysterious-tale-of-the-smallest-park-in-the-world.html
 ---
 
 The Mill Ends Park has been designated the smallest park in the world by the Guinness Book of Records.  It is a tiny square, maintained by the city of Portland, Oregon, located in a median strip on Southwest Naito Parkway, near S.W. Taylor Street.  It was dedicated in 1948 and became an official park in 1976. Its total area is 452 square inches.

--- a/content/daytrip/na/us/stans-african-halls-permanent-taxidermy-exhibit-at-museum-of-york-county.md
+++ b/content/daytrip/na/us/stans-african-halls-permanent-taxidermy-exhibit-at-museum-of-york-county.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 35.010183
 lng: -81.062590
 location: 4621 Mt Gallant Rd, Rock Hill, SC 29732, USA
+external_url: https://chmuseums.org/myco/
 title: Stans African Halls (Permanent Taxidermy Exhibit at Museum of York County)
 ---
 

--- a/content/daytrip/na/us/the-west-virginia-state-capitol-building.md
+++ b/content/daytrip/na/us/the-west-virginia-state-capitol-building.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 38.336313
 lng: -81.612260
 location: 1900 Kanawha Blvd E, Charleston, WV 25305, United States
+external_url: https://www.wvlegislature.gov/Educational/citizens/guide.cfm
 title: The West Virginia State Capitol Building
 ---
 

--- a/content/daytrip/na/us/woodland-ferry.md
+++ b/content/daytrip/na/us/woodland-ferry.md
@@ -6,7 +6,7 @@ poster: Vagrarian
 date: '2012-05-07T01:00:00'
 lat: '38.59930642299575'
 lng: '-75.65620915113527'
-external_url: null
+external_url: https://deldot.gov/Programs/woodland_ferry/index.shtml
 ---
 
 Last free ferry operating in Delaware. Connects Bethel and Laurel with the hamlet of Woodland.

--- a/content/daytrip/sa/co/villa-de-leyva.md
+++ b/content/daytrip/sa/co/villa-de-leyva.md
@@ -4,6 +4,7 @@ date: '2001-01-30T04:37:00'
 lat: 5.63373
 lng: -73.52358
 location: "Ricaurte, Boyacá, 154001, Colombia"
+external_url: https://www.villadeleyva-boyaca.gov.co/Paginas/Inicio.aspx
 title: Villa de Leyva
 ---
 


### PR DESCRIPTION
We're now down to three entries that don't have a URL because I genuinely can't find a suitable web page(*), one mess that needs disentangling still (Libreria Acqua Alta, #400) and one outstanding (British Postal Museum Store) where I'm waiting for a reply from them about whether it's still open to the public (yes, I actually submitted query through their contact form).

(*) East Dundry Lane Viewpoint, Malahide Estuary Tidal Road, the Bear Cage at Pizzone.