### PR TITLE
Fix semantic typo

### DIFF
--- a/themes/ndt2/layouts/partials/posts.html
+++ b/themes/ndt2/layouts/partials/posts.html
@@ -1,4 +1,4 @@
-<h3>Recent Blogs</h3>
+<h3>Recent Posts</h3>
 <ul id="posts">
 {{- range first 3 (where site.RegularPages "Section" "blog") }}
     <li class="post-item">


### PR DESCRIPTION
A blog is a website with multiple "articles" or "posts". Blogs plural would be multiple websites. This here should be posts (unless articles is wanted, but that is a longer word).