### PR TITLE
New: Wimbledon Windmill Museum from jamesgreenblue

### DIFF
--- a/content/daytrip/eu/gb/wimbledon-windmill.md
+++ b/content/daytrip/eu/gb/wimbledon-windmill.md
@@ -1,0 +1,13 @@
+---
+slug: "daytrip/eu/gb/wimbledon-windmill"
+date: "2025-08-17T12:03:45Z"
+poster: "jamesgreenblue"
+lat: "51.437654"
+lng: "-0.231619"
+location: "Wimbledon Windmill Museum, Windmill Road, Wimbledon Common, London, SW19 5NR"
+title: "Wimbledon Windmill Museum"
+external_url: https://www.wimbledonwindmill.org.uk/
+---
+Wimbledon Windmill is a Grade II* listed windmill situated on Wimbledon Common preserved as a museum. The museum has exhibits for both young and old, covering windmills and milling as well as local history. A supply of grain is provided so that you can try your hand at the saddle stone, mortar and hand quern.
+
+Access to the museum is free. Parking and tearooms are available nearby.


### PR DESCRIPTION
## New Venue Submission

**Venue:** Wimbledon Windmill Museum
**Location:** Wimbledon Windmill Museum, Windmill Road, Wimbledon Common, London, SW19 5NR
**Submitted by:** jamesgreenblue 
**Website:** https://www.wimbledonwindmill.org.uk/

### Description
Wimbledon Windmill is a Grade II* listed windmill situated on Wimbledon Common preserved as a museum. The museum has exhibits for both young and old, covering windmills and milling as well as local history. A supply of grain is provided so that you can try your hand at the saddle stone, mortar and hand quern.

Access to the museum is free. Parking and tearooms are available nearby.

**File:** `content/daytrip/eu/gb/wimbledon-windmill.md`